### PR TITLE
bring back short aliases

### DIFF
--- a/addons/emojis-for-godot/EmojiPanel/EmojiPanel.tscn
+++ b/addons/emojis-for-godot/EmojiPanel/EmojiPanel.tscn
@@ -79,6 +79,7 @@ theme_override_fonts/normal_font = ExtResource("2_66r43")
 theme_override_font_sizes/normal_font_size = 32
 bbcode_enabled = true
 fit_content = true
+scroll_active = false
 autowrap_mode = 0
 meta_underlined = false
 threaded = true

--- a/addons/emojis-for-godot/emojis/emojis.gd
+++ b/addons/emojis-for-godot/emojis/emojis.gd
@@ -39,7 +39,9 @@ func init_emoji_dictionaries(dict:Dictionary):
 	emojis = {}
 
 	for emoji in dict:
-		emojis[dict[emoji]] = emoji
+		var keys = dict[emoji]
+		for key in keys:
+			emojis[key] = emoji
 		
 		# prints(dict[emoji], emoji)
 

--- a/addons/emojis-for-godot/emojis/emojis.json
+++ b/addons/emojis-for-godot/emojis/emojis.json
@@ -1,5036 +1,16485 @@
 {
-  "#\u20e3": "keycap_#",
-  "#\ufe0f\u20e3": "keycap_#",
-  "*\u20e3": "keycap_*",
-  "*\ufe0f\u20e3": "keycap_*",
-  "0\u20e3": "keycap_0",
-  "0\ufe0f\u20e3": "keycap_0",
-  "1\u20e3": "keycap_1",
-  "1\ufe0f\u20e3": "keycap_1",
-  "2\u20e3": "keycap_2",
-  "2\ufe0f\u20e3": "keycap_2",
-  "3\u20e3": "keycap_3",
-  "3\ufe0f\u20e3": "keycap_3",
-  "4\u20e3": "keycap_4",
-  "4\ufe0f\u20e3": "keycap_4",
-  "5\u20e3": "keycap_5",
-  "5\ufe0f\u20e3": "keycap_5",
-  "6\u20e3": "keycap_6",
-  "6\ufe0f\u20e3": "keycap_6",
-  "7\u20e3": "keycap_7",
-  "7\ufe0f\u20e3": "keycap_7",
-  "8\u20e3": "keycap_8",
-  "8\ufe0f\u20e3": "keycap_8",
-  "9\u20e3": "keycap_9",
-  "9\ufe0f\u20e3": "keycap_9",
-  "\u00a9": "copyright",
-  "\u00a9\ufe0f": "copyright",
-  "\u00ae": "registered",
-  "\u00ae\ufe0f": "registered",
-  "\u203c": "double_exclamation_mark",
-  "\u203c\ufe0f": "double_exclamation_mark",
-  "\u2049": "exclamation_question_mark",
-  "\u2049\ufe0f": "exclamation_question_mark",
-  "\u2122": "trade_mark",
-  "\u2122\ufe0f": "trade_mark",
-  "\u2139": "information",
-  "\u2139\ufe0f": "information",
-  "\u2194": "left-right_arrow",
-  "\u2194\ufe0f": "left-right_arrow",
-  "\u2195": "up-down_arrow",
-  "\u2195\ufe0f": "up-down_arrow",
-  "\u2196": "up-left_arrow",
-  "\u2196\ufe0f": "up-left_arrow",
-  "\u2197": "up-right_arrow",
-  "\u2197\ufe0f": "up-right_arrow",
-  "\u2198": "down-right_arrow",
-  "\u2198\ufe0f": "down-right_arrow",
-  "\u2199": "down-left_arrow",
-  "\u2199\ufe0f": "down-left_arrow",
-  "\u21a9": "right_arrow_curving_left",
-  "\u21a9\ufe0f": "right_arrow_curving_left",
-  "\u21aa": "left_arrow_curving_right",
-  "\u21aa\ufe0f": "left_arrow_curving_right",
-  "\u231a": "watch",
-  "\u231b": "hourglass_done",
-  "\u2328": "keyboard",
-  "\u2328\ufe0f": "keyboard",
-  "\u23cf": "eject_button",
-  "\u23cf\ufe0f": "eject_button",
-  "\u23e9": "fast-forward_button",
-  "\u23ea": "fast_reverse_button",
-  "\u23eb": "fast_up_button",
-  "\u23ec": "fast_down_button",
-  "\u23ed": "next_track_button",
-  "\u23ed\ufe0f": "next_track_button",
-  "\u23ee": "last_track_button",
-  "\u23ee\ufe0f": "last_track_button",
-  "\u23ef": "play_or_pause_button",
-  "\u23ef\ufe0f": "play_or_pause_button",
-  "\u23f0": "alarm_clock",
-  "\u23f1": "stopwatch",
-  "\u23f1\ufe0f": "stopwatch",
-  "\u23f2": "timer_clock",
-  "\u23f2\ufe0f": "timer_clock",
-  "\u23f3": "hourglass_not_done",
-  "\u23f8": "pause_button",
-  "\u23f8\ufe0f": "pause_button",
-  "\u23f9": "stop_button",
-  "\u23f9\ufe0f": "stop_button",
-  "\u23fa": "record_button",
-  "\u23fa\ufe0f": "record_button",
-  "\u24c2": "circled_m",
-  "\u24c2\ufe0f": "circled_m",
-  "\u25aa": "black_small_square",
-  "\u25aa\ufe0f": "black_small_square",
-  "\u25ab": "white_small_square",
-  "\u25ab\ufe0f": "white_small_square",
-  "\u25b6": "play_button",
-  "\u25b6\ufe0f": "play_button",
-  "\u25c0": "reverse_button",
-  "\u25c0\ufe0f": "reverse_button",
-  "\u25fb": "white_medium_square",
-  "\u25fb\ufe0f": "white_medium_square",
-  "\u25fc": "black_medium_square",
-  "\u25fc\ufe0f": "black_medium_square",
-  "\u25fd": "white_medium-small_square",
-  "\u25fe": "black_medium-small_square",
-  "\u2600": "sun",
-  "\u2600\ufe0f": "sun",
-  "\u2601": "cloud",
-  "\u2601\ufe0f": "cloud",
-  "\u2602": "umbrella",
-  "\u2602\ufe0f": "umbrella",
-  "\u2603": "snowman",
-  "\u2603\ufe0f": "snowman",
-  "\u2604": "comet",
-  "\u2604\ufe0f": "comet",
-  "\u260e": "telephone",
-  "\u260e\ufe0f": "telephone",
-  "\u2611": "check_box_with_check",
-  "\u2611\ufe0f": "check_box_with_check",
-  "\u2614": "umbrella_with_rain_drops",
-  "\u2615": "hot_beverage",
-  "\u2618": "shamrock",
-  "\u2618\ufe0f": "shamrock",
-  "\u261d": "index_pointing_up",
-  "\u261d\ufe0f": "index_pointing_up",
-  "\u261d\ud83c\udffb": "index_pointing_up_light_skin_tone",
-  "\u261d\ud83c\udffc": "index_pointing_up_medium-light_skin_tone",
-  "\u261d\ud83c\udffd": "index_pointing_up_medium_skin_tone",
-  "\u261d\ud83c\udffe": "index_pointing_up_medium-dark_skin_tone",
-  "\u261d\ud83c\udfff": "index_pointing_up_dark_skin_tone",
-  "\u2620": "skull_and_crossbones",
-  "\u2620\ufe0f": "skull_and_crossbones",
-  "\u2622": "radioactive",
-  "\u2622\ufe0f": "radioactive",
-  "\u2623": "biohazard",
-  "\u2623\ufe0f": "biohazard",
-  "\u2626": "orthodox_cross",
-  "\u2626\ufe0f": "orthodox_cross",
-  "\u262a": "star_and_crescent",
-  "\u262a\ufe0f": "star_and_crescent",
-  "\u262e": "peace_symbol",
-  "\u262e\ufe0f": "peace_symbol",
-  "\u262f": "yin_yang",
-  "\u262f\ufe0f": "yin_yang",
-  "\u2638": "wheel_of_dharma",
-  "\u2638\ufe0f": "wheel_of_dharma",
-  "\u2639": "frowning_face",
-  "\u2639\ufe0f": "frowning_face",
-  "\u263a": "smiling_face",
-  "\u263a\ufe0f": "smiling_face",
-  "\u2640": "female_sign",
-  "\u2640\ufe0f": "female_sign",
-  "\u2642": "male_sign",
-  "\u2642\ufe0f": "male_sign",
-  "\u2648": "aries",
-  "\u2649": "taurus",
-  "\u264a": "gemini",
-  "\u264b": "cancer",
-  "\u264c": "leo",
-  "\u264d": "virgo",
-  "\u264e": "libra",
-  "\u264f": "scorpio",
-  "\u2650": "sagittarius",
-  "\u2651": "capricorn",
-  "\u2652": "aquarius",
-  "\u2653": "pisces",
-  "\u265f": "chess_pawn",
-  "\u265f\ufe0f": "chess_pawn",
-  "\u2660": "spade_suit",
-  "\u2660\ufe0f": "spade_suit",
-  "\u2663": "club_suit",
-  "\u2663\ufe0f": "club_suit",
-  "\u2665": "heart_suit",
-  "\u2665\ufe0f": "heart_suit",
-  "\u2666": "diamond_suit",
-  "\u2666\ufe0f": "diamond_suit",
-  "\u2668": "hot_springs",
-  "\u2668\ufe0f": "hot_springs",
-  "\u267b": "recycling_symbol",
-  "\u267b\ufe0f": "recycling_symbol",
-  "\u267e": "infinity",
-  "\u267e\ufe0f": "infinity",
-  "\u267f": "wheelchair_symbol",
-  "\u2692": "hammer_and_pick",
-  "\u2692\ufe0f": "hammer_and_pick",
-  "\u2693": "anchor",
-  "\u2694": "crossed_swords",
-  "\u2694\ufe0f": "crossed_swords",
-  "\u2695": "medical_symbol",
-  "\u2695\ufe0f": "medical_symbol",
-  "\u2696": "balance_scale",
-  "\u2696\ufe0f": "balance_scale",
-  "\u2697": "alembic",
-  "\u2697\ufe0f": "alembic",
-  "\u2699": "gear",
-  "\u2699\ufe0f": "gear",
-  "\u269b": "atom_symbol",
-  "\u269b\ufe0f": "atom_symbol",
-  "\u269c": "fleur-de-lis",
-  "\u269c\ufe0f": "fleur-de-lis",
-  "\u26a0": "warning",
-  "\u26a0\ufe0f": "warning",
-  "\u26a1": "high_voltage",
-  "\u26a7": "transgender_symbol",
-  "\u26a7\ufe0f": "transgender_symbol",
-  "\u26aa": "white_circle",
-  "\u26ab": "black_circle",
-  "\u26b0": "coffin",
-  "\u26b0\ufe0f": "coffin",
-  "\u26b1": "funeral_urn",
-  "\u26b1\ufe0f": "funeral_urn",
-  "\u26bd": "soccer_ball",
-  "\u26be": "baseball",
-  "\u26c4": "snowman_without_snow",
-  "\u26c5": "sun_behind_cloud",
-  "\u26c8": "cloud_with_lightning_and_rain",
-  "\u26c8\ufe0f": "cloud_with_lightning_and_rain",
-  "\u26ce": "ophiuchus",
-  "\u26cf": "pick",
-  "\u26cf\ufe0f": "pick",
-  "\u26d1": "rescue_worker\u2019s_helmet",
-  "\u26d1\ufe0f": "rescue_worker\u2019s_helmet",
-  "\u26d3": "chains",
-  "\u26d3\u200d\ud83d\udca5": "broken_chain",
-  "\u26d3\ufe0f": "chains",
-  "\u26d3\ufe0f\u200d\ud83d\udca5": "broken_chain",
-  "\u26d4": "no_entry",
-  "\u26e9": "shinto_shrine",
-  "\u26e9\ufe0f": "shinto_shrine",
-  "\u26ea": "church",
-  "\u26f0": "mountain",
-  "\u26f0\ufe0f": "mountain",
-  "\u26f1": "umbrella_on_ground",
-  "\u26f1\ufe0f": "umbrella_on_ground",
-  "\u26f2": "fountain",
-  "\u26f3": "flag_in_hole",
-  "\u26f4": "ferry",
-  "\u26f4\ufe0f": "ferry",
-  "\u26f5": "sailboat",
-  "\u26f7": "skier",
-  "\u26f7\ufe0f": "skier",
-  "\u26f8": "ice_skate",
-  "\u26f8\ufe0f": "ice_skate",
-  "\u26f9": "person_bouncing_ball",
-  "\u26f9\u200d\u2640": "woman_bouncing_ball",
-  "\u26f9\u200d\u2640\ufe0f": "woman_bouncing_ball",
-  "\u26f9\u200d\u2642": "man_bouncing_ball",
-  "\u26f9\u200d\u2642\ufe0f": "man_bouncing_ball",
-  "\u26f9\ufe0f": "person_bouncing_ball",
-  "\u26f9\ufe0f\u200d\u2640": "woman_bouncing_ball",
-  "\u26f9\ufe0f\u200d\u2640\ufe0f": "woman_bouncing_ball",
-  "\u26f9\ufe0f\u200d\u2642": "man_bouncing_ball",
-  "\u26f9\ufe0f\u200d\u2642\ufe0f": "man_bouncing_ball",
-  "\u26f9\ud83c\udffb": "person_bouncing_ball_light_skin_tone",
-  "\u26f9\ud83c\udffb\u200d\u2640": "woman_bouncing_ball_light_skin_tone",
-  "\u26f9\ud83c\udffb\u200d\u2640\ufe0f": "woman_bouncing_ball_light_skin_tone",
-  "\u26f9\ud83c\udffb\u200d\u2642": "man_bouncing_ball_light_skin_tone",
-  "\u26f9\ud83c\udffb\u200d\u2642\ufe0f": "man_bouncing_ball_light_skin_tone",
-  "\u26f9\ud83c\udffc": "person_bouncing_ball_medium-light_skin_tone",
-  "\u26f9\ud83c\udffc\u200d\u2640": "woman_bouncing_ball_medium-light_skin_tone",
-  "\u26f9\ud83c\udffc\u200d\u2640\ufe0f": "woman_bouncing_ball_medium-light_skin_tone",
-  "\u26f9\ud83c\udffc\u200d\u2642": "man_bouncing_ball_medium-light_skin_tone",
-  "\u26f9\ud83c\udffc\u200d\u2642\ufe0f": "man_bouncing_ball_medium-light_skin_tone",
-  "\u26f9\ud83c\udffd": "person_bouncing_ball_medium_skin_tone",
-  "\u26f9\ud83c\udffd\u200d\u2640": "woman_bouncing_ball_medium_skin_tone",
-  "\u26f9\ud83c\udffd\u200d\u2640\ufe0f": "woman_bouncing_ball_medium_skin_tone",
-  "\u26f9\ud83c\udffd\u200d\u2642": "man_bouncing_ball_medium_skin_tone",
-  "\u26f9\ud83c\udffd\u200d\u2642\ufe0f": "man_bouncing_ball_medium_skin_tone",
-  "\u26f9\ud83c\udffe": "person_bouncing_ball_medium-dark_skin_tone",
-  "\u26f9\ud83c\udffe\u200d\u2640": "woman_bouncing_ball_medium-dark_skin_tone",
-  "\u26f9\ud83c\udffe\u200d\u2640\ufe0f": "woman_bouncing_ball_medium-dark_skin_tone",
-  "\u26f9\ud83c\udffe\u200d\u2642": "man_bouncing_ball_medium-dark_skin_tone",
-  "\u26f9\ud83c\udffe\u200d\u2642\ufe0f": "man_bouncing_ball_medium-dark_skin_tone",
-  "\u26f9\ud83c\udfff": "person_bouncing_ball_dark_skin_tone",
-  "\u26f9\ud83c\udfff\u200d\u2640": "woman_bouncing_ball_dark_skin_tone",
-  "\u26f9\ud83c\udfff\u200d\u2640\ufe0f": "woman_bouncing_ball_dark_skin_tone",
-  "\u26f9\ud83c\udfff\u200d\u2642": "man_bouncing_ball_dark_skin_tone",
-  "\u26f9\ud83c\udfff\u200d\u2642\ufe0f": "man_bouncing_ball_dark_skin_tone",
-  "\u26fa": "tent",
-  "\u26fd": "fuel_pump",
-  "\u2702": "scissors",
-  "\u2702\ufe0f": "scissors",
-  "\u2705": "check_mark_button",
-  "\u2708": "airplane",
-  "\u2708\ufe0f": "airplane",
-  "\u2709": "envelope",
-  "\u2709\ufe0f": "envelope",
-  "\u270a": "raised_fist",
-  "\u270a\ud83c\udffb": "raised_fist_light_skin_tone",
-  "\u270a\ud83c\udffc": "raised_fist_medium-light_skin_tone",
-  "\u270a\ud83c\udffd": "raised_fist_medium_skin_tone",
-  "\u270a\ud83c\udffe": "raised_fist_medium-dark_skin_tone",
-  "\u270a\ud83c\udfff": "raised_fist_dark_skin_tone",
-  "\u270b": "raised_hand",
-  "\u270b\ud83c\udffb": "raised_hand_light_skin_tone",
-  "\u270b\ud83c\udffc": "raised_hand_medium-light_skin_tone",
-  "\u270b\ud83c\udffd": "raised_hand_medium_skin_tone",
-  "\u270b\ud83c\udffe": "raised_hand_medium-dark_skin_tone",
-  "\u270b\ud83c\udfff": "raised_hand_dark_skin_tone",
-  "\u270c": "victory_hand",
-  "\u270c\ufe0f": "victory_hand",
-  "\u270c\ud83c\udffb": "victory_hand_light_skin_tone",
-  "\u270c\ud83c\udffc": "victory_hand_medium-light_skin_tone",
-  "\u270c\ud83c\udffd": "victory_hand_medium_skin_tone",
-  "\u270c\ud83c\udffe": "victory_hand_medium-dark_skin_tone",
-  "\u270c\ud83c\udfff": "victory_hand_dark_skin_tone",
-  "\u270d": "writing_hand",
-  "\u270d\ufe0f": "writing_hand",
-  "\u270d\ud83c\udffb": "writing_hand_light_skin_tone",
-  "\u270d\ud83c\udffc": "writing_hand_medium-light_skin_tone",
-  "\u270d\ud83c\udffd": "writing_hand_medium_skin_tone",
-  "\u270d\ud83c\udffe": "writing_hand_medium-dark_skin_tone",
-  "\u270d\ud83c\udfff": "writing_hand_dark_skin_tone",
-  "\u270f": "pencil",
-  "\u270f\ufe0f": "pencil",
-  "\u2712": "black_nib",
-  "\u2712\ufe0f": "black_nib",
-  "\u2714": "check_mark",
-  "\u2714\ufe0f": "check_mark",
-  "\u2716": "multiply",
-  "\u2716\ufe0f": "multiply",
-  "\u271d": "latin_cross",
-  "\u271d\ufe0f": "latin_cross",
-  "\u2721": "star_of_david",
-  "\u2721\ufe0f": "star_of_david",
-  "\u2728": "sparkles",
-  "\u2733": "eight-spoked_asterisk",
-  "\u2733\ufe0f": "eight-spoked_asterisk",
-  "\u2734": "eight-pointed_star",
-  "\u2734\ufe0f": "eight-pointed_star",
-  "\u2744": "snowflake",
-  "\u2744\ufe0f": "snowflake",
-  "\u2747": "sparkle",
-  "\u2747\ufe0f": "sparkle",
-  "\u274c": "cross_mark",
-  "\u274e": "cross_mark_button",
-  "\u2753": "red_question_mark",
-  "\u2754": "white_question_mark",
-  "\u2755": "white_exclamation_mark",
-  "\u2757": "red_exclamation_mark",
-  "\u2763": "heart_exclamation",
-  "\u2763\ufe0f": "heart_exclamation",
-  "\u2764": "red_heart",
-  "\u2764\u200d\ud83d\udd25": "heart_on_fire",
-  "\u2764\u200d\ud83e\ude79": "mending_heart",
-  "\u2764\ufe0f": "red_heart",
-  "\u2764\ufe0f\u200d\ud83d\udd25": "heart_on_fire",
-  "\u2764\ufe0f\u200d\ud83e\ude79": "mending_heart",
-  "\u2795": "plus",
-  "\u2796": "minus",
-  "\u2797": "divide",
-  "\u27a1": "right_arrow",
-  "\u27a1\ufe0f": "right_arrow",
-  "\u27b0": "curly_loop",
-  "\u27bf": "double_curly_loop",
-  "\u2934": "right_arrow_curving_up",
-  "\u2934\ufe0f": "right_arrow_curving_up",
-  "\u2935": "right_arrow_curving_down",
-  "\u2935\ufe0f": "right_arrow_curving_down",
-  "\u2b05": "left_arrow",
-  "\u2b05\ufe0f": "left_arrow",
-  "\u2b06": "up_arrow",
-  "\u2b06\ufe0f": "up_arrow",
-  "\u2b07": "down_arrow",
-  "\u2b07\ufe0f": "down_arrow",
-  "\u2b1b": "black_large_square",
-  "\u2b1c": "white_large_square",
-  "\u2b50": "star",
-  "\u2b55": "hollow_red_circle",
-  "\u3030": "wavy_dash",
-  "\u3030\ufe0f": "wavy_dash",
-  "\u303d": "part_alternation_mark",
-  "\u303d\ufe0f": "part_alternation_mark",
-  "\u3297": "japanese_congratulations_button",
-  "\u3297\ufe0f": "japanese_congratulations_button",
-  "\u3299": "japanese_secret_button",
-  "\u3299\ufe0f": "japanese_secret_button",
-  "\ud83c\udc04": "mahjong_red_dragon",
-  "\ud83c\udccf": "joker",
-  "\ud83c\udd70": "a_button_(blood_type)",
-  "\ud83c\udd70\ufe0f": "a_button_(blood_type)",
-  "\ud83c\udd71": "b_button_(blood_type)",
-  "\ud83c\udd71\ufe0f": "b_button_(blood_type)",
-  "\ud83c\udd7e": "o_button_(blood_type)",
-  "\ud83c\udd7e\ufe0f": "o_button_(blood_type)",
-  "\ud83c\udd7f": "p_button",
-  "\ud83c\udd7f\ufe0f": "p_button",
-  "\ud83c\udd8e": "ab_button_(blood_type)",
-  "\ud83c\udd91": "cl_button",
-  "\ud83c\udd92": "cool_button",
-  "\ud83c\udd93": "free_button",
-  "\ud83c\udd94": "id_button",
-  "\ud83c\udd95": "new_button",
-  "\ud83c\udd96": "ng_button",
-  "\ud83c\udd97": "ok_button",
-  "\ud83c\udd98": "sos_button",
-  "\ud83c\udd99": "up!_button",
-  "\ud83c\udd9a": "vs_button",
-  "\ud83c\udde6\ud83c\udde8": "ascension_island",
-  "\ud83c\udde6\ud83c\udde9": "andorra",
-  "\ud83c\udde6\ud83c\uddea": "united_arab_emirates",
-  "\ud83c\udde6\ud83c\uddeb": "afghanistan",
-  "\ud83c\udde6\ud83c\uddec": "antigua_&_barbuda",
-  "\ud83c\udde6\ud83c\uddee": "anguilla",
-  "\ud83c\udde6\ud83c\uddf1": "albania",
-  "\ud83c\udde6\ud83c\uddf2": "armenia",
-  "\ud83c\udde6\ud83c\uddf4": "angola",
-  "\ud83c\udde6\ud83c\uddf6": "antarctica",
-  "\ud83c\udde6\ud83c\uddf7": "argentina",
-  "\ud83c\udde6\ud83c\uddf8": "american_samoa",
-  "\ud83c\udde6\ud83c\uddf9": "austria",
-  "\ud83c\udde6\ud83c\uddfa": "australia",
-  "\ud83c\udde6\ud83c\uddfc": "aruba",
-  "\ud83c\udde6\ud83c\uddfd": "\u00e5land_islands",
-  "\ud83c\udde6\ud83c\uddff": "azerbaijan",
-  "\ud83c\udde7\ud83c\udde6": "bosnia_&_herzegovina",
-  "\ud83c\udde7\ud83c\udde7": "barbados",
-  "\ud83c\udde7\ud83c\udde9": "bangladesh",
-  "\ud83c\udde7\ud83c\uddea": "belgium",
-  "\ud83c\udde7\ud83c\uddeb": "burkina_faso",
-  "\ud83c\udde7\ud83c\uddec": "bulgaria",
-  "\ud83c\udde7\ud83c\udded": "bahrain",
-  "\ud83c\udde7\ud83c\uddee": "burundi",
-  "\ud83c\udde7\ud83c\uddef": "benin",
-  "\ud83c\udde7\ud83c\uddf1": "st._barth\u00e9lemy",
-  "\ud83c\udde7\ud83c\uddf2": "bermuda",
-  "\ud83c\udde7\ud83c\uddf3": "brunei",
-  "\ud83c\udde7\ud83c\uddf4": "bolivia",
-  "\ud83c\udde7\ud83c\uddf6": "caribbean_netherlands",
-  "\ud83c\udde7\ud83c\uddf7": "brazil",
-  "\ud83c\udde7\ud83c\uddf8": "bahamas",
-  "\ud83c\udde7\ud83c\uddf9": "bhutan",
-  "\ud83c\udde7\ud83c\uddfb": "bouvet_island",
-  "\ud83c\udde7\ud83c\uddfc": "botswana",
-  "\ud83c\udde7\ud83c\uddfe": "belarus",
-  "\ud83c\udde7\ud83c\uddff": "belize",
-  "\ud83c\udde8\ud83c\udde6": "canada",
-  "\ud83c\udde8\ud83c\udde8": "cocos_(keeling)_islands",
-  "\ud83c\udde8\ud83c\udde9": "congo-kinshasa",
-  "\ud83c\udde8\ud83c\uddeb": "central_african_republic",
-  "\ud83c\udde8\ud83c\uddec": "congo-brazzaville",
-  "\ud83c\udde8\ud83c\udded": "switzerland",
-  "\ud83c\udde8\ud83c\uddee": "c\u00f4te_d\u2019ivoire",
-  "\ud83c\udde8\ud83c\uddf0": "cook_islands",
-  "\ud83c\udde8\ud83c\uddf1": "chile",
-  "\ud83c\udde8\ud83c\uddf2": "cameroon",
-  "\ud83c\udde8\ud83c\uddf3": "china",
-  "\ud83c\udde8\ud83c\uddf4": "colombia",
-  "\ud83c\udde8\ud83c\uddf5": "clipperton_island",
-  "\ud83c\udde8\ud83c\uddf7": "costa_rica",
-  "\ud83c\udde8\ud83c\uddfa": "cuba",
-  "\ud83c\udde8\ud83c\uddfb": "cape_verde",
-  "\ud83c\udde8\ud83c\uddfc": "cura\u00e7ao",
-  "\ud83c\udde8\ud83c\uddfd": "christmas_island",
-  "\ud83c\udde8\ud83c\uddfe": "cyprus",
-  "\ud83c\udde8\ud83c\uddff": "czechia",
-  "\ud83c\udde9\ud83c\uddea": "germany",
-  "\ud83c\udde9\ud83c\uddec": "diego_garcia",
-  "\ud83c\udde9\ud83c\uddef": "djibouti",
-  "\ud83c\udde9\ud83c\uddf0": "denmark",
-  "\ud83c\udde9\ud83c\uddf2": "dominica",
-  "\ud83c\udde9\ud83c\uddf4": "dominican_republic",
-  "\ud83c\udde9\ud83c\uddff": "algeria",
-  "\ud83c\uddea\ud83c\udde6": "ceuta_&_melilla",
-  "\ud83c\uddea\ud83c\udde8": "ecuador",
-  "\ud83c\uddea\ud83c\uddea": "estonia",
-  "\ud83c\uddea\ud83c\uddec": "egypt",
-  "\ud83c\uddea\ud83c\udded": "western_sahara",
-  "\ud83c\uddea\ud83c\uddf7": "eritrea",
-  "\ud83c\uddea\ud83c\uddf8": "spain",
-  "\ud83c\uddea\ud83c\uddf9": "ethiopia",
-  "\ud83c\uddea\ud83c\uddfa": "european_union",
-  "\ud83c\uddeb\ud83c\uddee": "finland",
-  "\ud83c\uddeb\ud83c\uddef": "fiji",
-  "\ud83c\uddeb\ud83c\uddf0": "falkland_islands",
-  "\ud83c\uddeb\ud83c\uddf2": "micronesia",
-  "\ud83c\uddeb\ud83c\uddf4": "faroe_islands",
-  "\ud83c\uddeb\ud83c\uddf7": "france",
-  "\ud83c\uddec\ud83c\udde6": "gabon",
-  "\ud83c\uddec\ud83c\udde7": "united_kingdom",
-  "\ud83c\uddec\ud83c\udde9": "grenada",
-  "\ud83c\uddec\ud83c\uddea": "georgia",
-  "\ud83c\uddec\ud83c\uddeb": "french_guiana",
-  "\ud83c\uddec\ud83c\uddec": "guernsey",
-  "\ud83c\uddec\ud83c\udded": "ghana",
-  "\ud83c\uddec\ud83c\uddee": "gibraltar",
-  "\ud83c\uddec\ud83c\uddf1": "greenland",
-  "\ud83c\uddec\ud83c\uddf2": "gambia",
-  "\ud83c\uddec\ud83c\uddf3": "guinea",
-  "\ud83c\uddec\ud83c\uddf5": "guadeloupe",
-  "\ud83c\uddec\ud83c\uddf6": "equatorial_guinea",
-  "\ud83c\uddec\ud83c\uddf7": "greece",
-  "\ud83c\uddec\ud83c\uddf8": "south_georgia_&_south_sandwich_islands",
-  "\ud83c\uddec\ud83c\uddf9": "guatemala",
-  "\ud83c\uddec\ud83c\uddfa": "guam",
-  "\ud83c\uddec\ud83c\uddfc": "guinea-bissau",
-  "\ud83c\uddec\ud83c\uddfe": "guyana",
-  "\ud83c\udded\ud83c\uddf0": "hong_kong_sar_china",
-  "\ud83c\udded\ud83c\uddf2": "heard_&_mcdonald_islands",
-  "\ud83c\udded\ud83c\uddf3": "honduras",
-  "\ud83c\udded\ud83c\uddf7": "croatia",
-  "\ud83c\udded\ud83c\uddf9": "haiti",
-  "\ud83c\udded\ud83c\uddfa": "hungary",
-  "\ud83c\uddee\ud83c\udde8": "canary_islands",
-  "\ud83c\uddee\ud83c\udde9": "indonesia",
-  "\ud83c\uddee\ud83c\uddea": "ireland",
-  "\ud83c\uddee\ud83c\uddf1": "israel",
-  "\ud83c\uddee\ud83c\uddf2": "isle_of_man",
-  "\ud83c\uddee\ud83c\uddf3": "india",
-  "\ud83c\uddee\ud83c\uddf4": "british_indian_ocean_territory",
-  "\ud83c\uddee\ud83c\uddf6": "iraq",
-  "\ud83c\uddee\ud83c\uddf7": "iran",
-  "\ud83c\uddee\ud83c\uddf8": "iceland",
-  "\ud83c\uddee\ud83c\uddf9": "italy",
-  "\ud83c\uddef\ud83c\uddea": "jersey",
-  "\ud83c\uddef\ud83c\uddf2": "jamaica",
-  "\ud83c\uddef\ud83c\uddf4": "jordan",
-  "\ud83c\uddef\ud83c\uddf5": "japan",
-  "\ud83c\uddf0\ud83c\uddea": "kenya",
-  "\ud83c\uddf0\ud83c\uddec": "kyrgyzstan",
-  "\ud83c\uddf0\ud83c\udded": "cambodia",
-  "\ud83c\uddf0\ud83c\uddee": "kiribati",
-  "\ud83c\uddf0\ud83c\uddf2": "comoros",
-  "\ud83c\uddf0\ud83c\uddf3": "st._kitts_&_nevis",
-  "\ud83c\uddf0\ud83c\uddf5": "north_korea",
-  "\ud83c\uddf0\ud83c\uddf7": "south_korea",
-  "\ud83c\uddf0\ud83c\uddfc": "kuwait",
-  "\ud83c\uddf0\ud83c\uddfe": "cayman_islands",
-  "\ud83c\uddf0\ud83c\uddff": "kazakhstan",
-  "\ud83c\uddf1\ud83c\udde6": "laos",
-  "\ud83c\uddf1\ud83c\udde7": "lebanon",
-  "\ud83c\uddf1\ud83c\udde8": "st._lucia",
-  "\ud83c\uddf1\ud83c\uddee": "liechtenstein",
-  "\ud83c\uddf1\ud83c\uddf0": "sri_lanka",
-  "\ud83c\uddf1\ud83c\uddf7": "liberia",
-  "\ud83c\uddf1\ud83c\uddf8": "lesotho",
-  "\ud83c\uddf1\ud83c\uddf9": "lithuania",
-  "\ud83c\uddf1\ud83c\uddfa": "luxembourg",
-  "\ud83c\uddf1\ud83c\uddfb": "latvia",
-  "\ud83c\uddf1\ud83c\uddfe": "libya",
-  "\ud83c\uddf2\ud83c\udde6": "morocco",
-  "\ud83c\uddf2\ud83c\udde8": "monaco",
-  "\ud83c\uddf2\ud83c\udde9": "moldova",
-  "\ud83c\uddf2\ud83c\uddea": "montenegro",
-  "\ud83c\uddf2\ud83c\uddeb": "st._martin",
-  "\ud83c\uddf2\ud83c\uddec": "madagascar",
-  "\ud83c\uddf2\ud83c\udded": "marshall_islands",
-  "\ud83c\uddf2\ud83c\uddf0": "north_macedonia",
-  "\ud83c\uddf2\ud83c\uddf1": "mali",
-  "\ud83c\uddf2\ud83c\uddf2": "myanmar_(burma)",
-  "\ud83c\uddf2\ud83c\uddf3": "mongolia",
-  "\ud83c\uddf2\ud83c\uddf4": "macao_sar_china",
-  "\ud83c\uddf2\ud83c\uddf5": "northern_mariana_islands",
-  "\ud83c\uddf2\ud83c\uddf6": "martinique",
-  "\ud83c\uddf2\ud83c\uddf7": "mauritania",
-  "\ud83c\uddf2\ud83c\uddf8": "montserrat",
-  "\ud83c\uddf2\ud83c\uddf9": "malta",
-  "\ud83c\uddf2\ud83c\uddfa": "mauritius",
-  "\ud83c\uddf2\ud83c\uddfb": "maldives",
-  "\ud83c\uddf2\ud83c\uddfc": "malawi",
-  "\ud83c\uddf2\ud83c\uddfd": "mexico",
-  "\ud83c\uddf2\ud83c\uddfe": "malaysia",
-  "\ud83c\uddf2\ud83c\uddff": "mozambique",
-  "\ud83c\uddf3\ud83c\udde6": "namibia",
-  "\ud83c\uddf3\ud83c\udde8": "new_caledonia",
-  "\ud83c\uddf3\ud83c\uddea": "niger",
-  "\ud83c\uddf3\ud83c\uddeb": "norfolk_island",
-  "\ud83c\uddf3\ud83c\uddec": "nigeria",
-  "\ud83c\uddf3\ud83c\uddee": "nicaragua",
-  "\ud83c\uddf3\ud83c\uddf1": "netherlands",
-  "\ud83c\uddf3\ud83c\uddf4": "norway",
-  "\ud83c\uddf3\ud83c\uddf5": "nepal",
-  "\ud83c\uddf3\ud83c\uddf7": "nauru",
-  "\ud83c\uddf3\ud83c\uddfa": "niue",
-  "\ud83c\uddf3\ud83c\uddff": "new_zealand",
-  "\ud83c\uddf4\ud83c\uddf2": "oman",
-  "\ud83c\uddf5\ud83c\udde6": "panama",
-  "\ud83c\uddf5\ud83c\uddea": "peru",
-  "\ud83c\uddf5\ud83c\uddeb": "french_polynesia",
-  "\ud83c\uddf5\ud83c\uddec": "papua_new_guinea",
-  "\ud83c\uddf5\ud83c\udded": "philippines",
-  "\ud83c\uddf5\ud83c\uddf0": "pakistan",
-  "\ud83c\uddf5\ud83c\uddf1": "poland",
-  "\ud83c\uddf5\ud83c\uddf2": "st._pierre_&_miquelon",
-  "\ud83c\uddf5\ud83c\uddf3": "pitcairn_islands",
-  "\ud83c\uddf5\ud83c\uddf7": "puerto_rico",
-  "\ud83c\uddf5\ud83c\uddf8": "palestinian_territories",
-  "\ud83c\uddf5\ud83c\uddf9": "portugal",
-  "\ud83c\uddf5\ud83c\uddfc": "palau",
-  "\ud83c\uddf5\ud83c\uddfe": "paraguay",
-  "\ud83c\uddf6\ud83c\udde6": "qatar",
-  "\ud83c\uddf7\ud83c\uddea": "r\u00e9union",
-  "\ud83c\uddf7\ud83c\uddf4": "romania",
-  "\ud83c\uddf7\ud83c\uddf8": "serbia",
-  "\ud83c\uddf7\ud83c\uddfa": "russia",
-  "\ud83c\uddf7\ud83c\uddfc": "rwanda",
-  "\ud83c\uddf8\ud83c\udde6": "saudi_arabia",
-  "\ud83c\uddf8\ud83c\udde7": "solomon_islands",
-  "\ud83c\uddf8\ud83c\udde8": "seychelles",
-  "\ud83c\uddf8\ud83c\udde9": "sudan",
-  "\ud83c\uddf8\ud83c\uddea": "sweden",
-  "\ud83c\uddf8\ud83c\uddec": "singapore",
-  "\ud83c\uddf8\ud83c\udded": "st._helena",
-  "\ud83c\uddf8\ud83c\uddee": "slovenia",
-  "\ud83c\uddf8\ud83c\uddef": "svalbard_&_jan_mayen",
-  "\ud83c\uddf8\ud83c\uddf0": "slovakia",
-  "\ud83c\uddf8\ud83c\uddf1": "sierra_leone",
-  "\ud83c\uddf8\ud83c\uddf2": "san_marino",
-  "\ud83c\uddf8\ud83c\uddf3": "senegal",
-  "\ud83c\uddf8\ud83c\uddf4": "somalia",
-  "\ud83c\uddf8\ud83c\uddf7": "suriname",
-  "\ud83c\uddf8\ud83c\uddf8": "south_sudan",
-  "\ud83c\uddf8\ud83c\uddf9": "s\u00e3o_tom\u00e9_&_pr\u00edncipe",
-  "\ud83c\uddf8\ud83c\uddfb": "el_salvador",
-  "\ud83c\uddf8\ud83c\uddfd": "sint_maarten",
-  "\ud83c\uddf8\ud83c\uddfe": "syria",
-  "\ud83c\uddf8\ud83c\uddff": "eswatini",
-  "\ud83c\uddf9\ud83c\udde6": "tristan_da_cunha",
-  "\ud83c\uddf9\ud83c\udde8": "turks_&_caicos_islands",
-  "\ud83c\uddf9\ud83c\udde9": "chad",
-  "\ud83c\uddf9\ud83c\uddeb": "french_southern_territories",
-  "\ud83c\uddf9\ud83c\uddec": "togo",
-  "\ud83c\uddf9\ud83c\udded": "thailand",
-  "\ud83c\uddf9\ud83c\uddef": "tajikistan",
-  "\ud83c\uddf9\ud83c\uddf0": "tokelau",
-  "\ud83c\uddf9\ud83c\uddf1": "timor-leste",
-  "\ud83c\uddf9\ud83c\uddf2": "turkmenistan",
-  "\ud83c\uddf9\ud83c\uddf3": "tunisia",
-  "\ud83c\uddf9\ud83c\uddf4": "tonga",
-  "\ud83c\uddf9\ud83c\uddf7": "t\u00fcrkiye",
-  "\ud83c\uddf9\ud83c\uddf9": "trinidad_&_tobago",
-  "\ud83c\uddf9\ud83c\uddfb": "tuvalu",
-  "\ud83c\uddf9\ud83c\uddfc": "taiwan",
-  "\ud83c\uddf9\ud83c\uddff": "tanzania",
-  "\ud83c\uddfa\ud83c\udde6": "ukraine",
-  "\ud83c\uddfa\ud83c\uddec": "uganda",
-  "\ud83c\uddfa\ud83c\uddf2": "u.s._outlying_islands",
-  "\ud83c\uddfa\ud83c\uddf3": "united_nations",
-  "\ud83c\uddfa\ud83c\uddf8": "united_states",
-  "\ud83c\uddfa\ud83c\uddfe": "uruguay",
-  "\ud83c\uddfa\ud83c\uddff": "uzbekistan",
-  "\ud83c\uddfb\ud83c\udde6": "vatican_city",
-  "\ud83c\uddfb\ud83c\udde8": "st._vincent_&_grenadines",
-  "\ud83c\uddfb\ud83c\uddea": "venezuela",
-  "\ud83c\uddfb\ud83c\uddec": "british_virgin_islands",
-  "\ud83c\uddfb\ud83c\uddee": "u.s._virgin_islands",
-  "\ud83c\uddfb\ud83c\uddf3": "vietnam",
-  "\ud83c\uddfb\ud83c\uddfa": "vanuatu",
-  "\ud83c\uddfc\ud83c\uddeb": "wallis_&_futuna",
-  "\ud83c\uddfc\ud83c\uddf8": "samoa",
-  "\ud83c\uddfd\ud83c\uddf0": "kosovo",
-  "\ud83c\uddfe\ud83c\uddea": "yemen",
-  "\ud83c\uddfe\ud83c\uddf9": "mayotte",
-  "\ud83c\uddff\ud83c\udde6": "south_africa",
-  "\ud83c\uddff\ud83c\uddf2": "zambia",
-  "\ud83c\uddff\ud83c\uddfc": "zimbabwe",
-  "\ud83c\ude01": "japanese_here_button",
-  "\ud83c\ude02": "japanese_service_charge_button",
-  "\ud83c\ude02\ufe0f": "japanese_service_charge_button",
-  "\ud83c\ude1a": "japanese_free_of_charge_button",
-  "\ud83c\ude2f": "japanese_reserved_button",
-  "\ud83c\ude32": "japanese_prohibited_button",
-  "\ud83c\ude33": "japanese_vacancy_button",
-  "\ud83c\ude34": "japanese_passing_grade_button",
-  "\ud83c\ude35": "japanese_no_vacancy_button",
-  "\ud83c\ude36": "japanese_not_free_of_charge_button",
-  "\ud83c\ude37": "japanese_monthly_amount_button",
-  "\ud83c\ude37\ufe0f": "japanese_monthly_amount_button",
-  "\ud83c\ude38": "japanese_application_button",
-  "\ud83c\ude39": "japanese_discount_button",
-  "\ud83c\ude3a": "japanese_open_for_business_button",
-  "\ud83c\ude50": "japanese_bargain_button",
-  "\ud83c\ude51": "japanese_acceptable_button",
-  "\ud83c\udf00": "cyclone",
-  "\ud83c\udf01": "foggy",
-  "\ud83c\udf02": "closed_umbrella",
-  "\ud83c\udf03": "night_with_stars",
-  "\ud83c\udf04": "sunrise_over_mountains",
-  "\ud83c\udf05": "sunrise",
-  "\ud83c\udf06": "cityscape_at_dusk",
-  "\ud83c\udf07": "sunset",
-  "\ud83c\udf08": "rainbow",
-  "\ud83c\udf09": "bridge_at_night",
-  "\ud83c\udf0a": "water_wave",
-  "\ud83c\udf0b": "volcano",
-  "\ud83c\udf0c": "milky_way",
-  "\ud83c\udf0d": "globe_showing_europe-africa",
-  "\ud83c\udf0e": "globe_showing_americas",
-  "\ud83c\udf0f": "globe_showing_asia-australia",
-  "\ud83c\udf10": "globe_with_meridians",
-  "\ud83c\udf11": "new_moon",
-  "\ud83c\udf12": "waxing_crescent_moon",
-  "\ud83c\udf13": "first_quarter_moon",
-  "\ud83c\udf14": "waxing_gibbous_moon",
-  "\ud83c\udf15": "full_moon",
-  "\ud83c\udf16": "waning_gibbous_moon",
-  "\ud83c\udf17": "last_quarter_moon",
-  "\ud83c\udf18": "waning_crescent_moon",
-  "\ud83c\udf19": "crescent_moon",
-  "\ud83c\udf1a": "new_moon_face",
-  "\ud83c\udf1b": "first_quarter_moon_face",
-  "\ud83c\udf1c": "last_quarter_moon_face",
-  "\ud83c\udf1d": "full_moon_face",
-  "\ud83c\udf1e": "sun_with_face",
-  "\ud83c\udf1f": "glowing_star",
-  "\ud83c\udf20": "shooting_star",
-  "\ud83c\udf21": "thermometer",
-  "\ud83c\udf21\ufe0f": "thermometer",
-  "\ud83c\udf24": "sun_behind_small_cloud",
-  "\ud83c\udf24\ufe0f": "sun_behind_small_cloud",
-  "\ud83c\udf25": "sun_behind_large_cloud",
-  "\ud83c\udf25\ufe0f": "sun_behind_large_cloud",
-  "\ud83c\udf26": "sun_behind_rain_cloud",
-  "\ud83c\udf26\ufe0f": "sun_behind_rain_cloud",
-  "\ud83c\udf27": "cloud_with_rain",
-  "\ud83c\udf27\ufe0f": "cloud_with_rain",
-  "\ud83c\udf28": "cloud_with_snow",
-  "\ud83c\udf28\ufe0f": "cloud_with_snow",
-  "\ud83c\udf29": "cloud_with_lightning",
-  "\ud83c\udf29\ufe0f": "cloud_with_lightning",
-  "\ud83c\udf2a": "tornado",
-  "\ud83c\udf2a\ufe0f": "tornado",
-  "\ud83c\udf2b": "fog",
-  "\ud83c\udf2b\ufe0f": "fog",
-  "\ud83c\udf2c": "wind_face",
-  "\ud83c\udf2c\ufe0f": "wind_face",
-  "\ud83c\udf2d": "hot_dog",
-  "\ud83c\udf2e": "taco",
-  "\ud83c\udf2f": "burrito",
-  "\ud83c\udf30": "chestnut",
-  "\ud83c\udf31": "seedling",
-  "\ud83c\udf32": "evergreen_tree",
-  "\ud83c\udf33": "deciduous_tree",
-  "\ud83c\udf34": "palm_tree",
-  "\ud83c\udf35": "cactus",
-  "\ud83c\udf36": "hot_pepper",
-  "\ud83c\udf36\ufe0f": "hot_pepper",
-  "\ud83c\udf37": "tulip",
-  "\ud83c\udf38": "cherry_blossom",
-  "\ud83c\udf39": "rose",
-  "\ud83c\udf3a": "hibiscus",
-  "\ud83c\udf3b": "sunflower",
-  "\ud83c\udf3c": "blossom",
-  "\ud83c\udf3d": "ear_of_corn",
-  "\ud83c\udf3e": "sheaf_of_rice",
-  "\ud83c\udf3f": "herb",
-  "\ud83c\udf40": "four_leaf_clover",
-  "\ud83c\udf41": "maple_leaf",
-  "\ud83c\udf42": "fallen_leaf",
-  "\ud83c\udf43": "leaf_fluttering_in_wind",
-  "\ud83c\udf44": "mushroom",
-  "\ud83c\udf44\u200d\ud83d\udfeb": "brown_mushroom",
-  "\ud83c\udf45": "tomato",
-  "\ud83c\udf46": "eggplant",
-  "\ud83c\udf47": "grapes",
-  "\ud83c\udf48": "melon",
-  "\ud83c\udf49": "watermelon",
-  "\ud83c\udf4a": "tangerine",
-  "\ud83c\udf4b": "lemon",
-  "\ud83c\udf4b\u200d\ud83d\udfe9": "lime",
-  "\ud83c\udf4c": "banana",
-  "\ud83c\udf4d": "pineapple",
-  "\ud83c\udf4e": "red_apple",
-  "\ud83c\udf4f": "green_apple",
-  "\ud83c\udf50": "pear",
-  "\ud83c\udf51": "peach",
-  "\ud83c\udf52": "cherries",
-  "\ud83c\udf53": "strawberry",
-  "\ud83c\udf54": "hamburger",
-  "\ud83c\udf55": "pizza",
-  "\ud83c\udf56": "meat_on_bone",
-  "\ud83c\udf57": "poultry_leg",
-  "\ud83c\udf58": "rice_cracker",
-  "\ud83c\udf59": "rice_ball",
-  "\ud83c\udf5a": "cooked_rice",
-  "\ud83c\udf5b": "curry_rice",
-  "\ud83c\udf5c": "steaming_bowl",
-  "\ud83c\udf5d": "spaghetti",
-  "\ud83c\udf5e": "bread",
-  "\ud83c\udf5f": "french_fries",
-  "\ud83c\udf60": "roasted_sweet_potato",
-  "\ud83c\udf61": "dango",
-  "\ud83c\udf62": "oden",
-  "\ud83c\udf63": "sushi",
-  "\ud83c\udf64": "fried_shrimp",
-  "\ud83c\udf65": "fish_cake_with_swirl",
-  "\ud83c\udf66": "soft_ice_cream",
-  "\ud83c\udf67": "shaved_ice",
-  "\ud83c\udf68": "ice_cream",
-  "\ud83c\udf69": "doughnut",
-  "\ud83c\udf6a": "cookie",
-  "\ud83c\udf6b": "chocolate_bar",
-  "\ud83c\udf6c": "candy",
-  "\ud83c\udf6d": "lollipop",
-  "\ud83c\udf6e": "custard",
-  "\ud83c\udf6f": "honey_pot",
-  "\ud83c\udf70": "shortcake",
-  "\ud83c\udf71": "bento_box",
-  "\ud83c\udf72": "pot_of_food",
-  "\ud83c\udf73": "cooking",
-  "\ud83c\udf74": "fork_and_knife",
-  "\ud83c\udf75": "teacup_without_handle",
-  "\ud83c\udf76": "sake",
-  "\ud83c\udf77": "wine_glass",
-  "\ud83c\udf78": "cocktail_glass",
-  "\ud83c\udf79": "tropical_drink",
-  "\ud83c\udf7a": "beer_mug",
-  "\ud83c\udf7b": "clinking_beer_mugs",
-  "\ud83c\udf7c": "baby_bottle",
-  "\ud83c\udf7d": "fork_and_knife_with_plate",
-  "\ud83c\udf7d\ufe0f": "fork_and_knife_with_plate",
-  "\ud83c\udf7e": "bottle_with_popping_cork",
-  "\ud83c\udf7f": "popcorn",
-  "\ud83c\udf80": "ribbon",
-  "\ud83c\udf81": "wrapped_gift",
-  "\ud83c\udf82": "birthday_cake",
-  "\ud83c\udf83": "jack-o-lantern",
-  "\ud83c\udf84": "christmas_tree",
-  "\ud83c\udf85": "santa_claus",
-  "\ud83c\udf85\ud83c\udffb": "santa_claus_light_skin_tone",
-  "\ud83c\udf85\ud83c\udffc": "santa_claus_medium-light_skin_tone",
-  "\ud83c\udf85\ud83c\udffd": "santa_claus_medium_skin_tone",
-  "\ud83c\udf85\ud83c\udffe": "santa_claus_medium-dark_skin_tone",
-  "\ud83c\udf85\ud83c\udfff": "santa_claus_dark_skin_tone",
-  "\ud83c\udf86": "fireworks",
-  "\ud83c\udf87": "sparkler",
-  "\ud83c\udf88": "balloon",
-  "\ud83c\udf89": "party_popper",
-  "\ud83c\udf8a": "confetti_ball",
-  "\ud83c\udf8b": "tanabata_tree",
-  "\ud83c\udf8c": "crossed_flags",
-  "\ud83c\udf8d": "pine_decoration",
-  "\ud83c\udf8e": "japanese_dolls",
-  "\ud83c\udf8f": "carp_streamer",
-  "\ud83c\udf90": "wind_chime",
-  "\ud83c\udf91": "moon_viewing_ceremony",
-  "\ud83c\udf92": "backpack",
-  "\ud83c\udf93": "graduation_cap",
-  "\ud83c\udf96": "military_medal",
-  "\ud83c\udf96\ufe0f": "military_medal",
-  "\ud83c\udf97": "reminder_ribbon",
-  "\ud83c\udf97\ufe0f": "reminder_ribbon",
-  "\ud83c\udf99": "studio_microphone",
-  "\ud83c\udf99\ufe0f": "studio_microphone",
-  "\ud83c\udf9a": "level_slider",
-  "\ud83c\udf9a\ufe0f": "level_slider",
-  "\ud83c\udf9b": "control_knobs",
-  "\ud83c\udf9b\ufe0f": "control_knobs",
-  "\ud83c\udf9e": "film_frames",
-  "\ud83c\udf9e\ufe0f": "film_frames",
-  "\ud83c\udf9f": "admission_tickets",
-  "\ud83c\udf9f\ufe0f": "admission_tickets",
-  "\ud83c\udfa0": "carousel_horse",
-  "\ud83c\udfa1": "ferris_wheel",
-  "\ud83c\udfa2": "roller_coaster",
-  "\ud83c\udfa3": "fishing_pole",
-  "\ud83c\udfa4": "microphone",
-  "\ud83c\udfa5": "movie_camera",
-  "\ud83c\udfa6": "cinema",
-  "\ud83c\udfa7": "headphone",
-  "\ud83c\udfa8": "artist_palette",
-  "\ud83c\udfa9": "top_hat",
-  "\ud83c\udfaa": "circus_tent",
-  "\ud83c\udfab": "ticket",
-  "\ud83c\udfac": "clapper_board",
-  "\ud83c\udfad": "performing_arts",
-  "\ud83c\udfae": "video_game",
-  "\ud83c\udfaf": "bullseye",
-  "\ud83c\udfb0": "slot_machine",
-  "\ud83c\udfb1": "pool_8_ball",
-  "\ud83c\udfb2": "game_die",
-  "\ud83c\udfb3": "bowling",
-  "\ud83c\udfb4": "flower_playing_cards",
-  "\ud83c\udfb5": "musical_note",
-  "\ud83c\udfb6": "musical_notes",
-  "\ud83c\udfb7": "saxophone",
-  "\ud83c\udfb8": "guitar",
-  "\ud83c\udfb9": "musical_keyboard",
-  "\ud83c\udfba": "trumpet",
-  "\ud83c\udfbb": "violin",
-  "\ud83c\udfbc": "musical_score",
-  "\ud83c\udfbd": "running_shirt",
-  "\ud83c\udfbe": "tennis",
-  "\ud83c\udfbf": "skis",
-  "\ud83c\udfc0": "basketball",
-  "\ud83c\udfc1": "chequered_flag",
-  "\ud83c\udfc2": "snowboarder",
-  "\ud83c\udfc2\ud83c\udffb": "snowboarder_light_skin_tone",
-  "\ud83c\udfc2\ud83c\udffc": "snowboarder_medium-light_skin_tone",
-  "\ud83c\udfc2\ud83c\udffd": "snowboarder_medium_skin_tone",
-  "\ud83c\udfc2\ud83c\udffe": "snowboarder_medium-dark_skin_tone",
-  "\ud83c\udfc2\ud83c\udfff": "snowboarder_dark_skin_tone",
-  "\ud83c\udfc3": "person_running",
-  "\ud83c\udfc3\u200d\u2640": "woman_running",
-  "\ud83c\udfc3\u200d\u2640\u200d\u27a1": "woman_running_facing_right",
-  "\ud83c\udfc3\u200d\u2640\u200d\u27a1\ufe0f": "woman_running_facing_right",
-  "\ud83c\udfc3\u200d\u2640\ufe0f": "woman_running",
-  "\ud83c\udfc3\u200d\u2640\ufe0f\u200d\u27a1": "woman_running_facing_right",
-  "\ud83c\udfc3\u200d\u2640\ufe0f\u200d\u27a1\ufe0f": "woman_running_facing_right",
-  "\ud83c\udfc3\u200d\u2642": "man_running",
-  "\ud83c\udfc3\u200d\u2642\u200d\u27a1": "man_running_facing_right",
-  "\ud83c\udfc3\u200d\u2642\u200d\u27a1\ufe0f": "man_running_facing_right",
-  "\ud83c\udfc3\u200d\u2642\ufe0f": "man_running",
-  "\ud83c\udfc3\u200d\u2642\ufe0f\u200d\u27a1": "man_running_facing_right",
-  "\ud83c\udfc3\u200d\u2642\ufe0f\u200d\u27a1\ufe0f": "man_running_facing_right",
-  "\ud83c\udfc3\u200d\u27a1": "person_running_facing_right",
-  "\ud83c\udfc3\u200d\u27a1\ufe0f": "person_running_facing_right",
-  "\ud83c\udfc3\ud83c\udffb": "person_running_light_skin_tone",
-  "\ud83c\udfc3\ud83c\udffb\u200d\u2640": "woman_running_light_skin_tone",
-  "\ud83c\udfc3\ud83c\udffb\u200d\u2640\u200d\u27a1": "woman_running_facing_right_light_skin_tone",
-  "\ud83c\udfc3\ud83c\udffb\u200d\u2640\u200d\u27a1\ufe0f": "woman_running_facing_right_light_skin_tone",
-  "\ud83c\udfc3\ud83c\udffb\u200d\u2640\ufe0f": "woman_running_light_skin_tone",
-  "\ud83c\udfc3\ud83c\udffb\u200d\u2640\ufe0f\u200d\u27a1": "woman_running_facing_right_light_skin_tone",
-  "\ud83c\udfc3\ud83c\udffb\u200d\u2640\ufe0f\u200d\u27a1\ufe0f": "woman_running_facing_right_light_skin_tone",
-  "\ud83c\udfc3\ud83c\udffb\u200d\u2642": "man_running_light_skin_tone",
-  "\ud83c\udfc3\ud83c\udffb\u200d\u2642\u200d\u27a1": "man_running_facing_right_light_skin_tone",
-  "\ud83c\udfc3\ud83c\udffb\u200d\u2642\u200d\u27a1\ufe0f": "man_running_facing_right_light_skin_tone",
-  "\ud83c\udfc3\ud83c\udffb\u200d\u2642\ufe0f": "man_running_light_skin_tone",
-  "\ud83c\udfc3\ud83c\udffb\u200d\u2642\ufe0f\u200d\u27a1": "man_running_facing_right_light_skin_tone",
-  "\ud83c\udfc3\ud83c\udffb\u200d\u2642\ufe0f\u200d\u27a1\ufe0f": "man_running_facing_right_light_skin_tone",
-  "\ud83c\udfc3\ud83c\udffb\u200d\u27a1": "person_running_facing_right_light_skin_tone",
-  "\ud83c\udfc3\ud83c\udffb\u200d\u27a1\ufe0f": "person_running_facing_right_light_skin_tone",
-  "\ud83c\udfc3\ud83c\udffc": "person_running_medium-light_skin_tone",
-  "\ud83c\udfc3\ud83c\udffc\u200d\u2640": "woman_running_medium-light_skin_tone",
-  "\ud83c\udfc3\ud83c\udffc\u200d\u2640\u200d\u27a1": "woman_running_facing_right_medium-light_skin_tone",
-  "\ud83c\udfc3\ud83c\udffc\u200d\u2640\u200d\u27a1\ufe0f": "woman_running_facing_right_medium-light_skin_tone",
-  "\ud83c\udfc3\ud83c\udffc\u200d\u2640\ufe0f": "woman_running_medium-light_skin_tone",
-  "\ud83c\udfc3\ud83c\udffc\u200d\u2640\ufe0f\u200d\u27a1": "woman_running_facing_right_medium-light_skin_tone",
-  "\ud83c\udfc3\ud83c\udffc\u200d\u2640\ufe0f\u200d\u27a1\ufe0f": "woman_running_facing_right_medium-light_skin_tone",
-  "\ud83c\udfc3\ud83c\udffc\u200d\u2642": "man_running_medium-light_skin_tone",
-  "\ud83c\udfc3\ud83c\udffc\u200d\u2642\u200d\u27a1": "man_running_facing_right_medium-light_skin_tone",
-  "\ud83c\udfc3\ud83c\udffc\u200d\u2642\u200d\u27a1\ufe0f": "man_running_facing_right_medium-light_skin_tone",
-  "\ud83c\udfc3\ud83c\udffc\u200d\u2642\ufe0f": "man_running_medium-light_skin_tone",
-  "\ud83c\udfc3\ud83c\udffc\u200d\u2642\ufe0f\u200d\u27a1": "man_running_facing_right_medium-light_skin_tone",
-  "\ud83c\udfc3\ud83c\udffc\u200d\u2642\ufe0f\u200d\u27a1\ufe0f": "man_running_facing_right_medium-light_skin_tone",
-  "\ud83c\udfc3\ud83c\udffc\u200d\u27a1": "person_running_facing_right_medium-light_skin_tone",
-  "\ud83c\udfc3\ud83c\udffc\u200d\u27a1\ufe0f": "person_running_facing_right_medium-light_skin_tone",
-  "\ud83c\udfc3\ud83c\udffd": "person_running_medium_skin_tone",
-  "\ud83c\udfc3\ud83c\udffd\u200d\u2640": "woman_running_medium_skin_tone",
-  "\ud83c\udfc3\ud83c\udffd\u200d\u2640\u200d\u27a1": "woman_running_facing_right_medium_skin_tone",
-  "\ud83c\udfc3\ud83c\udffd\u200d\u2640\u200d\u27a1\ufe0f": "woman_running_facing_right_medium_skin_tone",
-  "\ud83c\udfc3\ud83c\udffd\u200d\u2640\ufe0f": "woman_running_medium_skin_tone",
-  "\ud83c\udfc3\ud83c\udffd\u200d\u2640\ufe0f\u200d\u27a1": "woman_running_facing_right_medium_skin_tone",
-  "\ud83c\udfc3\ud83c\udffd\u200d\u2640\ufe0f\u200d\u27a1\ufe0f": "woman_running_facing_right_medium_skin_tone",
-  "\ud83c\udfc3\ud83c\udffd\u200d\u2642": "man_running_medium_skin_tone",
-  "\ud83c\udfc3\ud83c\udffd\u200d\u2642\u200d\u27a1": "man_running_facing_right_medium_skin_tone",
-  "\ud83c\udfc3\ud83c\udffd\u200d\u2642\u200d\u27a1\ufe0f": "man_running_facing_right_medium_skin_tone",
-  "\ud83c\udfc3\ud83c\udffd\u200d\u2642\ufe0f": "man_running_medium_skin_tone",
-  "\ud83c\udfc3\ud83c\udffd\u200d\u2642\ufe0f\u200d\u27a1": "man_running_facing_right_medium_skin_tone",
-  "\ud83c\udfc3\ud83c\udffd\u200d\u2642\ufe0f\u200d\u27a1\ufe0f": "man_running_facing_right_medium_skin_tone",
-  "\ud83c\udfc3\ud83c\udffd\u200d\u27a1": "person_running_facing_right_medium_skin_tone",
-  "\ud83c\udfc3\ud83c\udffd\u200d\u27a1\ufe0f": "person_running_facing_right_medium_skin_tone",
-  "\ud83c\udfc3\ud83c\udffe": "person_running_medium-dark_skin_tone",
-  "\ud83c\udfc3\ud83c\udffe\u200d\u2640": "woman_running_medium-dark_skin_tone",
-  "\ud83c\udfc3\ud83c\udffe\u200d\u2640\u200d\u27a1": "woman_running_facing_right_medium-dark_skin_tone",
-  "\ud83c\udfc3\ud83c\udffe\u200d\u2640\u200d\u27a1\ufe0f": "woman_running_facing_right_medium-dark_skin_tone",
-  "\ud83c\udfc3\ud83c\udffe\u200d\u2640\ufe0f": "woman_running_medium-dark_skin_tone",
-  "\ud83c\udfc3\ud83c\udffe\u200d\u2640\ufe0f\u200d\u27a1": "woman_running_facing_right_medium-dark_skin_tone",
-  "\ud83c\udfc3\ud83c\udffe\u200d\u2640\ufe0f\u200d\u27a1\ufe0f": "woman_running_facing_right_medium-dark_skin_tone",
-  "\ud83c\udfc3\ud83c\udffe\u200d\u2642": "man_running_medium-dark_skin_tone",
-  "\ud83c\udfc3\ud83c\udffe\u200d\u2642\u200d\u27a1": "man_running_facing_right_medium-dark_skin_tone",
-  "\ud83c\udfc3\ud83c\udffe\u200d\u2642\u200d\u27a1\ufe0f": "man_running_facing_right_medium-dark_skin_tone",
-  "\ud83c\udfc3\ud83c\udffe\u200d\u2642\ufe0f": "man_running_medium-dark_skin_tone",
-  "\ud83c\udfc3\ud83c\udffe\u200d\u2642\ufe0f\u200d\u27a1": "man_running_facing_right_medium-dark_skin_tone",
-  "\ud83c\udfc3\ud83c\udffe\u200d\u2642\ufe0f\u200d\u27a1\ufe0f": "man_running_facing_right_medium-dark_skin_tone",
-  "\ud83c\udfc3\ud83c\udffe\u200d\u27a1": "person_running_facing_right_medium-dark_skin_tone",
-  "\ud83c\udfc3\ud83c\udffe\u200d\u27a1\ufe0f": "person_running_facing_right_medium-dark_skin_tone",
-  "\ud83c\udfc3\ud83c\udfff": "person_running_dark_skin_tone",
-  "\ud83c\udfc3\ud83c\udfff\u200d\u2640": "woman_running_dark_skin_tone",
-  "\ud83c\udfc3\ud83c\udfff\u200d\u2640\u200d\u27a1": "woman_running_facing_right_dark_skin_tone",
-  "\ud83c\udfc3\ud83c\udfff\u200d\u2640\u200d\u27a1\ufe0f": "woman_running_facing_right_dark_skin_tone",
-  "\ud83c\udfc3\ud83c\udfff\u200d\u2640\ufe0f": "woman_running_dark_skin_tone",
-  "\ud83c\udfc3\ud83c\udfff\u200d\u2640\ufe0f\u200d\u27a1": "woman_running_facing_right_dark_skin_tone",
-  "\ud83c\udfc3\ud83c\udfff\u200d\u2640\ufe0f\u200d\u27a1\ufe0f": "woman_running_facing_right_dark_skin_tone",
-  "\ud83c\udfc3\ud83c\udfff\u200d\u2642": "man_running_dark_skin_tone",
-  "\ud83c\udfc3\ud83c\udfff\u200d\u2642\u200d\u27a1": "man_running_facing_right_dark_skin_tone",
-  "\ud83c\udfc3\ud83c\udfff\u200d\u2642\u200d\u27a1\ufe0f": "man_running_facing_right_dark_skin_tone",
-  "\ud83c\udfc3\ud83c\udfff\u200d\u2642\ufe0f": "man_running_dark_skin_tone",
-  "\ud83c\udfc3\ud83c\udfff\u200d\u2642\ufe0f\u200d\u27a1": "man_running_facing_right_dark_skin_tone",
-  "\ud83c\udfc3\ud83c\udfff\u200d\u2642\ufe0f\u200d\u27a1\ufe0f": "man_running_facing_right_dark_skin_tone",
-  "\ud83c\udfc3\ud83c\udfff\u200d\u27a1": "person_running_facing_right_dark_skin_tone",
-  "\ud83c\udfc3\ud83c\udfff\u200d\u27a1\ufe0f": "person_running_facing_right_dark_skin_tone",
-  "\ud83c\udfc4": "person_surfing",
-  "\ud83c\udfc4\u200d\u2640": "woman_surfing",
-  "\ud83c\udfc4\u200d\u2640\ufe0f": "woman_surfing",
-  "\ud83c\udfc4\u200d\u2642": "man_surfing",
-  "\ud83c\udfc4\u200d\u2642\ufe0f": "man_surfing",
-  "\ud83c\udfc4\ud83c\udffb": "person_surfing_light_skin_tone",
-  "\ud83c\udfc4\ud83c\udffb\u200d\u2640": "woman_surfing_light_skin_tone",
-  "\ud83c\udfc4\ud83c\udffb\u200d\u2640\ufe0f": "woman_surfing_light_skin_tone",
-  "\ud83c\udfc4\ud83c\udffb\u200d\u2642": "man_surfing_light_skin_tone",
-  "\ud83c\udfc4\ud83c\udffb\u200d\u2642\ufe0f": "man_surfing_light_skin_tone",
-  "\ud83c\udfc4\ud83c\udffc": "person_surfing_medium-light_skin_tone",
-  "\ud83c\udfc4\ud83c\udffc\u200d\u2640": "woman_surfing_medium-light_skin_tone",
-  "\ud83c\udfc4\ud83c\udffc\u200d\u2640\ufe0f": "woman_surfing_medium-light_skin_tone",
-  "\ud83c\udfc4\ud83c\udffc\u200d\u2642": "man_surfing_medium-light_skin_tone",
-  "\ud83c\udfc4\ud83c\udffc\u200d\u2642\ufe0f": "man_surfing_medium-light_skin_tone",
-  "\ud83c\udfc4\ud83c\udffd": "person_surfing_medium_skin_tone",
-  "\ud83c\udfc4\ud83c\udffd\u200d\u2640": "woman_surfing_medium_skin_tone",
-  "\ud83c\udfc4\ud83c\udffd\u200d\u2640\ufe0f": "woman_surfing_medium_skin_tone",
-  "\ud83c\udfc4\ud83c\udffd\u200d\u2642": "man_surfing_medium_skin_tone",
-  "\ud83c\udfc4\ud83c\udffd\u200d\u2642\ufe0f": "man_surfing_medium_skin_tone",
-  "\ud83c\udfc4\ud83c\udffe": "person_surfing_medium-dark_skin_tone",
-  "\ud83c\udfc4\ud83c\udffe\u200d\u2640": "woman_surfing_medium-dark_skin_tone",
-  "\ud83c\udfc4\ud83c\udffe\u200d\u2640\ufe0f": "woman_surfing_medium-dark_skin_tone",
-  "\ud83c\udfc4\ud83c\udffe\u200d\u2642": "man_surfing_medium-dark_skin_tone",
-  "\ud83c\udfc4\ud83c\udffe\u200d\u2642\ufe0f": "man_surfing_medium-dark_skin_tone",
-  "\ud83c\udfc4\ud83c\udfff": "person_surfing_dark_skin_tone",
-  "\ud83c\udfc4\ud83c\udfff\u200d\u2640": "woman_surfing_dark_skin_tone",
-  "\ud83c\udfc4\ud83c\udfff\u200d\u2640\ufe0f": "woman_surfing_dark_skin_tone",
-  "\ud83c\udfc4\ud83c\udfff\u200d\u2642": "man_surfing_dark_skin_tone",
-  "\ud83c\udfc4\ud83c\udfff\u200d\u2642\ufe0f": "man_surfing_dark_skin_tone",
-  "\ud83c\udfc5": "sports_medal",
-  "\ud83c\udfc6": "trophy",
-  "\ud83c\udfc7": "horse_racing",
-  "\ud83c\udfc7\ud83c\udffb": "horse_racing_light_skin_tone",
-  "\ud83c\udfc7\ud83c\udffc": "horse_racing_medium-light_skin_tone",
-  "\ud83c\udfc7\ud83c\udffd": "horse_racing_medium_skin_tone",
-  "\ud83c\udfc7\ud83c\udffe": "horse_racing_medium-dark_skin_tone",
-  "\ud83c\udfc7\ud83c\udfff": "horse_racing_dark_skin_tone",
-  "\ud83c\udfc8": "american_football",
-  "\ud83c\udfc9": "rugby_football",
-  "\ud83c\udfca": "person_swimming",
-  "\ud83c\udfca\u200d\u2640": "woman_swimming",
-  "\ud83c\udfca\u200d\u2640\ufe0f": "woman_swimming",
-  "\ud83c\udfca\u200d\u2642": "man_swimming",
-  "\ud83c\udfca\u200d\u2642\ufe0f": "man_swimming",
-  "\ud83c\udfca\ud83c\udffb": "person_swimming_light_skin_tone",
-  "\ud83c\udfca\ud83c\udffb\u200d\u2640": "woman_swimming_light_skin_tone",
-  "\ud83c\udfca\ud83c\udffb\u200d\u2640\ufe0f": "woman_swimming_light_skin_tone",
-  "\ud83c\udfca\ud83c\udffb\u200d\u2642": "man_swimming_light_skin_tone",
-  "\ud83c\udfca\ud83c\udffb\u200d\u2642\ufe0f": "man_swimming_light_skin_tone",
-  "\ud83c\udfca\ud83c\udffc": "person_swimming_medium-light_skin_tone",
-  "\ud83c\udfca\ud83c\udffc\u200d\u2640": "woman_swimming_medium-light_skin_tone",
-  "\ud83c\udfca\ud83c\udffc\u200d\u2640\ufe0f": "woman_swimming_medium-light_skin_tone",
-  "\ud83c\udfca\ud83c\udffc\u200d\u2642": "man_swimming_medium-light_skin_tone",
-  "\ud83c\udfca\ud83c\udffc\u200d\u2642\ufe0f": "man_swimming_medium-light_skin_tone",
-  "\ud83c\udfca\ud83c\udffd": "person_swimming_medium_skin_tone",
-  "\ud83c\udfca\ud83c\udffd\u200d\u2640": "woman_swimming_medium_skin_tone",
-  "\ud83c\udfca\ud83c\udffd\u200d\u2640\ufe0f": "woman_swimming_medium_skin_tone",
-  "\ud83c\udfca\ud83c\udffd\u200d\u2642": "man_swimming_medium_skin_tone",
-  "\ud83c\udfca\ud83c\udffd\u200d\u2642\ufe0f": "man_swimming_medium_skin_tone",
-  "\ud83c\udfca\ud83c\udffe": "person_swimming_medium-dark_skin_tone",
-  "\ud83c\udfca\ud83c\udffe\u200d\u2640": "woman_swimming_medium-dark_skin_tone",
-  "\ud83c\udfca\ud83c\udffe\u200d\u2640\ufe0f": "woman_swimming_medium-dark_skin_tone",
-  "\ud83c\udfca\ud83c\udffe\u200d\u2642": "man_swimming_medium-dark_skin_tone",
-  "\ud83c\udfca\ud83c\udffe\u200d\u2642\ufe0f": "man_swimming_medium-dark_skin_tone",
-  "\ud83c\udfca\ud83c\udfff": "person_swimming_dark_skin_tone",
-  "\ud83c\udfca\ud83c\udfff\u200d\u2640": "woman_swimming_dark_skin_tone",
-  "\ud83c\udfca\ud83c\udfff\u200d\u2640\ufe0f": "woman_swimming_dark_skin_tone",
-  "\ud83c\udfca\ud83c\udfff\u200d\u2642": "man_swimming_dark_skin_tone",
-  "\ud83c\udfca\ud83c\udfff\u200d\u2642\ufe0f": "man_swimming_dark_skin_tone",
-  "\ud83c\udfcb": "person_lifting_weights",
-  "\ud83c\udfcb\u200d\u2640": "woman_lifting_weights",
-  "\ud83c\udfcb\u200d\u2640\ufe0f": "woman_lifting_weights",
-  "\ud83c\udfcb\u200d\u2642": "man_lifting_weights",
-  "\ud83c\udfcb\u200d\u2642\ufe0f": "man_lifting_weights",
-  "\ud83c\udfcb\ufe0f": "person_lifting_weights",
-  "\ud83c\udfcb\ufe0f\u200d\u2640": "woman_lifting_weights",
-  "\ud83c\udfcb\ufe0f\u200d\u2640\ufe0f": "woman_lifting_weights",
-  "\ud83c\udfcb\ufe0f\u200d\u2642": "man_lifting_weights",
-  "\ud83c\udfcb\ufe0f\u200d\u2642\ufe0f": "man_lifting_weights",
-  "\ud83c\udfcb\ud83c\udffb": "person_lifting_weights_light_skin_tone",
-  "\ud83c\udfcb\ud83c\udffb\u200d\u2640": "woman_lifting_weights_light_skin_tone",
-  "\ud83c\udfcb\ud83c\udffb\u200d\u2640\ufe0f": "woman_lifting_weights_light_skin_tone",
-  "\ud83c\udfcb\ud83c\udffb\u200d\u2642": "man_lifting_weights_light_skin_tone",
-  "\ud83c\udfcb\ud83c\udffb\u200d\u2642\ufe0f": "man_lifting_weights_light_skin_tone",
-  "\ud83c\udfcb\ud83c\udffc": "person_lifting_weights_medium-light_skin_tone",
-  "\ud83c\udfcb\ud83c\udffc\u200d\u2640": "woman_lifting_weights_medium-light_skin_tone",
-  "\ud83c\udfcb\ud83c\udffc\u200d\u2640\ufe0f": "woman_lifting_weights_medium-light_skin_tone",
-  "\ud83c\udfcb\ud83c\udffc\u200d\u2642": "man_lifting_weights_medium-light_skin_tone",
-  "\ud83c\udfcb\ud83c\udffc\u200d\u2642\ufe0f": "man_lifting_weights_medium-light_skin_tone",
-  "\ud83c\udfcb\ud83c\udffd": "person_lifting_weights_medium_skin_tone",
-  "\ud83c\udfcb\ud83c\udffd\u200d\u2640": "woman_lifting_weights_medium_skin_tone",
-  "\ud83c\udfcb\ud83c\udffd\u200d\u2640\ufe0f": "woman_lifting_weights_medium_skin_tone",
-  "\ud83c\udfcb\ud83c\udffd\u200d\u2642": "man_lifting_weights_medium_skin_tone",
-  "\ud83c\udfcb\ud83c\udffd\u200d\u2642\ufe0f": "man_lifting_weights_medium_skin_tone",
-  "\ud83c\udfcb\ud83c\udffe": "person_lifting_weights_medium-dark_skin_tone",
-  "\ud83c\udfcb\ud83c\udffe\u200d\u2640": "woman_lifting_weights_medium-dark_skin_tone",
-  "\ud83c\udfcb\ud83c\udffe\u200d\u2640\ufe0f": "woman_lifting_weights_medium-dark_skin_tone",
-  "\ud83c\udfcb\ud83c\udffe\u200d\u2642": "man_lifting_weights_medium-dark_skin_tone",
-  "\ud83c\udfcb\ud83c\udffe\u200d\u2642\ufe0f": "man_lifting_weights_medium-dark_skin_tone",
-  "\ud83c\udfcb\ud83c\udfff": "person_lifting_weights_dark_skin_tone",
-  "\ud83c\udfcb\ud83c\udfff\u200d\u2640": "woman_lifting_weights_dark_skin_tone",
-  "\ud83c\udfcb\ud83c\udfff\u200d\u2640\ufe0f": "woman_lifting_weights_dark_skin_tone",
-  "\ud83c\udfcb\ud83c\udfff\u200d\u2642": "man_lifting_weights_dark_skin_tone",
-  "\ud83c\udfcb\ud83c\udfff\u200d\u2642\ufe0f": "man_lifting_weights_dark_skin_tone",
-  "\ud83c\udfcc": "person_golfing",
-  "\ud83c\udfcc\u200d\u2640": "woman_golfing",
-  "\ud83c\udfcc\u200d\u2640\ufe0f": "woman_golfing",
-  "\ud83c\udfcc\u200d\u2642": "man_golfing",
-  "\ud83c\udfcc\u200d\u2642\ufe0f": "man_golfing",
-  "\ud83c\udfcc\ufe0f": "person_golfing",
-  "\ud83c\udfcc\ufe0f\u200d\u2640": "woman_golfing",
-  "\ud83c\udfcc\ufe0f\u200d\u2640\ufe0f": "woman_golfing",
-  "\ud83c\udfcc\ufe0f\u200d\u2642": "man_golfing",
-  "\ud83c\udfcc\ufe0f\u200d\u2642\ufe0f": "man_golfing",
-  "\ud83c\udfcc\ud83c\udffb": "person_golfing_light_skin_tone",
-  "\ud83c\udfcc\ud83c\udffb\u200d\u2640": "woman_golfing_light_skin_tone",
-  "\ud83c\udfcc\ud83c\udffb\u200d\u2640\ufe0f": "woman_golfing_light_skin_tone",
-  "\ud83c\udfcc\ud83c\udffb\u200d\u2642": "man_golfing_light_skin_tone",
-  "\ud83c\udfcc\ud83c\udffb\u200d\u2642\ufe0f": "man_golfing_light_skin_tone",
-  "\ud83c\udfcc\ud83c\udffc": "person_golfing_medium-light_skin_tone",
-  "\ud83c\udfcc\ud83c\udffc\u200d\u2640": "woman_golfing_medium-light_skin_tone",
-  "\ud83c\udfcc\ud83c\udffc\u200d\u2640\ufe0f": "woman_golfing_medium-light_skin_tone",
-  "\ud83c\udfcc\ud83c\udffc\u200d\u2642": "man_golfing_medium-light_skin_tone",
-  "\ud83c\udfcc\ud83c\udffc\u200d\u2642\ufe0f": "man_golfing_medium-light_skin_tone",
-  "\ud83c\udfcc\ud83c\udffd": "person_golfing_medium_skin_tone",
-  "\ud83c\udfcc\ud83c\udffd\u200d\u2640": "woman_golfing_medium_skin_tone",
-  "\ud83c\udfcc\ud83c\udffd\u200d\u2640\ufe0f": "woman_golfing_medium_skin_tone",
-  "\ud83c\udfcc\ud83c\udffd\u200d\u2642": "man_golfing_medium_skin_tone",
-  "\ud83c\udfcc\ud83c\udffd\u200d\u2642\ufe0f": "man_golfing_medium_skin_tone",
-  "\ud83c\udfcc\ud83c\udffe": "person_golfing_medium-dark_skin_tone",
-  "\ud83c\udfcc\ud83c\udffe\u200d\u2640": "woman_golfing_medium-dark_skin_tone",
-  "\ud83c\udfcc\ud83c\udffe\u200d\u2640\ufe0f": "woman_golfing_medium-dark_skin_tone",
-  "\ud83c\udfcc\ud83c\udffe\u200d\u2642": "man_golfing_medium-dark_skin_tone",
-  "\ud83c\udfcc\ud83c\udffe\u200d\u2642\ufe0f": "man_golfing_medium-dark_skin_tone",
-  "\ud83c\udfcc\ud83c\udfff": "person_golfing_dark_skin_tone",
-  "\ud83c\udfcc\ud83c\udfff\u200d\u2640": "woman_golfing_dark_skin_tone",
-  "\ud83c\udfcc\ud83c\udfff\u200d\u2640\ufe0f": "woman_golfing_dark_skin_tone",
-  "\ud83c\udfcc\ud83c\udfff\u200d\u2642": "man_golfing_dark_skin_tone",
-  "\ud83c\udfcc\ud83c\udfff\u200d\u2642\ufe0f": "man_golfing_dark_skin_tone",
-  "\ud83c\udfcd": "motorcycle",
-  "\ud83c\udfcd\ufe0f": "motorcycle",
-  "\ud83c\udfce": "racing_car",
-  "\ud83c\udfce\ufe0f": "racing_car",
-  "\ud83c\udfcf": "cricket_game",
-  "\ud83c\udfd0": "volleyball",
-  "\ud83c\udfd1": "field_hockey",
-  "\ud83c\udfd2": "ice_hockey",
-  "\ud83c\udfd3": "ping_pong",
-  "\ud83c\udfd4": "snow-capped_mountain",
-  "\ud83c\udfd4\ufe0f": "snow-capped_mountain",
-  "\ud83c\udfd5": "camping",
-  "\ud83c\udfd5\ufe0f": "camping",
-  "\ud83c\udfd6": "beach_with_umbrella",
-  "\ud83c\udfd6\ufe0f": "beach_with_umbrella",
-  "\ud83c\udfd7": "building_construction",
-  "\ud83c\udfd7\ufe0f": "building_construction",
-  "\ud83c\udfd8": "houses",
-  "\ud83c\udfd8\ufe0f": "houses",
-  "\ud83c\udfd9": "cityscape",
-  "\ud83c\udfd9\ufe0f": "cityscape",
-  "\ud83c\udfda": "derelict_house",
-  "\ud83c\udfda\ufe0f": "derelict_house",
-  "\ud83c\udfdb": "classical_building",
-  "\ud83c\udfdb\ufe0f": "classical_building",
-  "\ud83c\udfdc": "desert",
-  "\ud83c\udfdc\ufe0f": "desert",
-  "\ud83c\udfdd": "desert_island",
-  "\ud83c\udfdd\ufe0f": "desert_island",
-  "\ud83c\udfde": "national_park",
-  "\ud83c\udfde\ufe0f": "national_park",
-  "\ud83c\udfdf": "stadium",
-  "\ud83c\udfdf\ufe0f": "stadium",
-  "\ud83c\udfe0": "house",
-  "\ud83c\udfe1": "house_with_garden",
-  "\ud83c\udfe2": "office_building",
-  "\ud83c\udfe3": "japanese_post_office",
-  "\ud83c\udfe4": "post_office",
-  "\ud83c\udfe5": "hospital",
-  "\ud83c\udfe6": "bank",
-  "\ud83c\udfe7": "atm_sign",
-  "\ud83c\udfe8": "hotel",
-  "\ud83c\udfe9": "love_hotel",
-  "\ud83c\udfea": "convenience_store",
-  "\ud83c\udfeb": "school",
-  "\ud83c\udfec": "department_store",
-  "\ud83c\udfed": "factory",
-  "\ud83c\udfee": "red_paper_lantern",
-  "\ud83c\udfef": "japanese_castle",
-  "\ud83c\udff0": "castle",
-  "\ud83c\udff3": "white_flag",
-  "\ud83c\udff3\u200d\u26a7": "transgender_flag",
-  "\ud83c\udff3\u200d\u26a7\ufe0f": "transgender_flag",
-  "\ud83c\udff3\u200d\ud83c\udf08": "rainbow_flag",
-  "\ud83c\udff3\ufe0f": "white_flag",
-  "\ud83c\udff3\ufe0f\u200d\u26a7": "transgender_flag",
-  "\ud83c\udff3\ufe0f\u200d\u26a7\ufe0f": "transgender_flag",
-  "\ud83c\udff3\ufe0f\u200d\ud83c\udf08": "rainbow_flag",
-  "\ud83c\udff4": "black_flag",
-  "\ud83c\udff4\u200d\u2620": "pirate_flag",
-  "\ud83c\udff4\u200d\u2620\ufe0f": "pirate_flag",
-  "\ud83c\udff4\udb40\udc67\udb40\udc62\udb40\udc65\udb40\udc6e\udb40\udc67\udb40\udc7f": "england",
-  "\ud83c\udff4\udb40\udc67\udb40\udc62\udb40\udc73\udb40\udc63\udb40\udc74\udb40\udc7f": "scotland",
-  "\ud83c\udff4\udb40\udc67\udb40\udc62\udb40\udc77\udb40\udc6c\udb40\udc73\udb40\udc7f": "wales",
-  "\ud83c\udff5": "rosette",
-  "\ud83c\udff5\ufe0f": "rosette",
-  "\ud83c\udff7": "label",
-  "\ud83c\udff7\ufe0f": "label",
-  "\ud83c\udff8": "badminton",
-  "\ud83c\udff9": "bow_and_arrow",
-  "\ud83c\udffa": "amphora",
-  "\ud83c\udffb": "light_skin_tone",
-  "\ud83c\udffc": "medium-light_skin_tone",
-  "\ud83c\udffd": "medium_skin_tone",
-  "\ud83c\udffe": "medium-dark_skin_tone",
-  "\ud83c\udfff": "dark_skin_tone",
-  "\ud83d\udc00": "rat",
-  "\ud83d\udc01": "mouse",
-  "\ud83d\udc02": "ox",
-  "\ud83d\udc03": "water_buffalo",
-  "\ud83d\udc04": "cow",
-  "\ud83d\udc05": "tiger",
-  "\ud83d\udc06": "leopard",
-  "\ud83d\udc07": "rabbit",
-  "\ud83d\udc08": "cat",
-  "\ud83d\udc08\u200d\u2b1b": "black_cat",
-  "\ud83d\udc09": "dragon",
-  "\ud83d\udc0a": "crocodile",
-  "\ud83d\udc0b": "whale",
-  "\ud83d\udc0c": "snail",
-  "\ud83d\udc0d": "snake",
-  "\ud83d\udc0e": "horse",
-  "\ud83d\udc0f": "ram",
-  "\ud83d\udc10": "goat",
-  "\ud83d\udc11": "ewe",
-  "\ud83d\udc12": "monkey",
-  "\ud83d\udc13": "rooster",
-  "\ud83d\udc14": "chicken",
-  "\ud83d\udc15": "dog",
-  "\ud83d\udc15\u200d\ud83e\uddba": "service_dog",
-  "\ud83d\udc16": "pig",
-  "\ud83d\udc17": "boar",
-  "\ud83d\udc18": "elephant",
-  "\ud83d\udc19": "octopus",
-  "\ud83d\udc1a": "spiral_shell",
-  "\ud83d\udc1b": "bug",
-  "\ud83d\udc1c": "ant",
-  "\ud83d\udc1d": "honeybee",
-  "\ud83d\udc1e": "lady_beetle",
-  "\ud83d\udc1f": "fish",
-  "\ud83d\udc20": "tropical_fish",
-  "\ud83d\udc21": "blowfish",
-  "\ud83d\udc22": "turtle",
-  "\ud83d\udc23": "hatching_chick",
-  "\ud83d\udc24": "baby_chick",
-  "\ud83d\udc25": "front-facing_baby_chick",
-  "\ud83d\udc26": "bird",
-  "\ud83d\udc26\u200d\u2b1b": "black_bird",
-  "\ud83d\udc26\u200d\ud83d\udd25": "phoenix",
-  "\ud83d\udc27": "penguin",
-  "\ud83d\udc28": "koala",
-  "\ud83d\udc29": "poodle",
-  "\ud83d\udc2a": "camel",
-  "\ud83d\udc2b": "two-hump_camel",
-  "\ud83d\udc2c": "dolphin",
-  "\ud83d\udc2d": "mouse_face",
-  "\ud83d\udc2e": "cow_face",
-  "\ud83d\udc2f": "tiger_face",
-  "\ud83d\udc30": "rabbit_face",
-  "\ud83d\udc31": "cat_face",
-  "\ud83d\udc32": "dragon_face",
-  "\ud83d\udc33": "spouting_whale",
-  "\ud83d\udc34": "horse_face",
-  "\ud83d\udc35": "monkey_face",
-  "\ud83d\udc36": "dog_face",
-  "\ud83d\udc37": "pig_face",
-  "\ud83d\udc38": "frog",
-  "\ud83d\udc39": "hamster",
-  "\ud83d\udc3a": "wolf",
-  "\ud83d\udc3b": "bear",
-  "\ud83d\udc3b\u200d\u2744": "polar_bear",
-  "\ud83d\udc3b\u200d\u2744\ufe0f": "polar_bear",
-  "\ud83d\udc3c": "panda",
-  "\ud83d\udc3d": "pig_nose",
-  "\ud83d\udc3e": "paw_prints",
-  "\ud83d\udc3f": "chipmunk",
-  "\ud83d\udc3f\ufe0f": "chipmunk",
-  "\ud83d\udc40": "eyes",
-  "\ud83d\udc41": "eye",
-  "\ud83d\udc41\u200d\ud83d\udde8": "eye_in_speech_bubble",
-  "\ud83d\udc41\u200d\ud83d\udde8\ufe0f": "eye_in_speech_bubble",
-  "\ud83d\udc41\ufe0f": "eye",
-  "\ud83d\udc41\ufe0f\u200d\ud83d\udde8": "eye_in_speech_bubble",
-  "\ud83d\udc41\ufe0f\u200d\ud83d\udde8\ufe0f": "eye_in_speech_bubble",
-  "\ud83d\udc42": "ear",
-  "\ud83d\udc42\ud83c\udffb": "ear_light_skin_tone",
-  "\ud83d\udc42\ud83c\udffc": "ear_medium-light_skin_tone",
-  "\ud83d\udc42\ud83c\udffd": "ear_medium_skin_tone",
-  "\ud83d\udc42\ud83c\udffe": "ear_medium-dark_skin_tone",
-  "\ud83d\udc42\ud83c\udfff": "ear_dark_skin_tone",
-  "\ud83d\udc43": "nose",
-  "\ud83d\udc43\ud83c\udffb": "nose_light_skin_tone",
-  "\ud83d\udc43\ud83c\udffc": "nose_medium-light_skin_tone",
-  "\ud83d\udc43\ud83c\udffd": "nose_medium_skin_tone",
-  "\ud83d\udc43\ud83c\udffe": "nose_medium-dark_skin_tone",
-  "\ud83d\udc43\ud83c\udfff": "nose_dark_skin_tone",
-  "\ud83d\udc44": "mouth",
-  "\ud83d\udc45": "tongue",
-  "\ud83d\udc46": "backhand_index_pointing_up",
-  "\ud83d\udc46\ud83c\udffb": "backhand_index_pointing_up_light_skin_tone",
-  "\ud83d\udc46\ud83c\udffc": "backhand_index_pointing_up_medium-light_skin_tone",
-  "\ud83d\udc46\ud83c\udffd": "backhand_index_pointing_up_medium_skin_tone",
-  "\ud83d\udc46\ud83c\udffe": "backhand_index_pointing_up_medium-dark_skin_tone",
-  "\ud83d\udc46\ud83c\udfff": "backhand_index_pointing_up_dark_skin_tone",
-  "\ud83d\udc47": "backhand_index_pointing_down",
-  "\ud83d\udc47\ud83c\udffb": "backhand_index_pointing_down_light_skin_tone",
-  "\ud83d\udc47\ud83c\udffc": "backhand_index_pointing_down_medium-light_skin_tone",
-  "\ud83d\udc47\ud83c\udffd": "backhand_index_pointing_down_medium_skin_tone",
-  "\ud83d\udc47\ud83c\udffe": "backhand_index_pointing_down_medium-dark_skin_tone",
-  "\ud83d\udc47\ud83c\udfff": "backhand_index_pointing_down_dark_skin_tone",
-  "\ud83d\udc48": "backhand_index_pointing_left",
-  "\ud83d\udc48\ud83c\udffb": "backhand_index_pointing_left_light_skin_tone",
-  "\ud83d\udc48\ud83c\udffc": "backhand_index_pointing_left_medium-light_skin_tone",
-  "\ud83d\udc48\ud83c\udffd": "backhand_index_pointing_left_medium_skin_tone",
-  "\ud83d\udc48\ud83c\udffe": "backhand_index_pointing_left_medium-dark_skin_tone",
-  "\ud83d\udc48\ud83c\udfff": "backhand_index_pointing_left_dark_skin_tone",
-  "\ud83d\udc49": "backhand_index_pointing_right",
-  "\ud83d\udc49\ud83c\udffb": "backhand_index_pointing_right_light_skin_tone",
-  "\ud83d\udc49\ud83c\udffc": "backhand_index_pointing_right_medium-light_skin_tone",
-  "\ud83d\udc49\ud83c\udffd": "backhand_index_pointing_right_medium_skin_tone",
-  "\ud83d\udc49\ud83c\udffe": "backhand_index_pointing_right_medium-dark_skin_tone",
-  "\ud83d\udc49\ud83c\udfff": "backhand_index_pointing_right_dark_skin_tone",
-  "\ud83d\udc4a": "oncoming_fist",
-  "\ud83d\udc4a\ud83c\udffb": "oncoming_fist_light_skin_tone",
-  "\ud83d\udc4a\ud83c\udffc": "oncoming_fist_medium-light_skin_tone",
-  "\ud83d\udc4a\ud83c\udffd": "oncoming_fist_medium_skin_tone",
-  "\ud83d\udc4a\ud83c\udffe": "oncoming_fist_medium-dark_skin_tone",
-  "\ud83d\udc4a\ud83c\udfff": "oncoming_fist_dark_skin_tone",
-  "\ud83d\udc4b": "waving_hand",
-  "\ud83d\udc4b\ud83c\udffb": "waving_hand_light_skin_tone",
-  "\ud83d\udc4b\ud83c\udffc": "waving_hand_medium-light_skin_tone",
-  "\ud83d\udc4b\ud83c\udffd": "waving_hand_medium_skin_tone",
-  "\ud83d\udc4b\ud83c\udffe": "waving_hand_medium-dark_skin_tone",
-  "\ud83d\udc4b\ud83c\udfff": "waving_hand_dark_skin_tone",
-  "\ud83d\udc4c": "ok_hand",
-  "\ud83d\udc4c\ud83c\udffb": "ok_hand_light_skin_tone",
-  "\ud83d\udc4c\ud83c\udffc": "ok_hand_medium-light_skin_tone",
-  "\ud83d\udc4c\ud83c\udffd": "ok_hand_medium_skin_tone",
-  "\ud83d\udc4c\ud83c\udffe": "ok_hand_medium-dark_skin_tone",
-  "\ud83d\udc4c\ud83c\udfff": "ok_hand_dark_skin_tone",
-  "\ud83d\udc4d": "thumbs_up",
-  "\ud83d\udc4d\ud83c\udffb": "thumbs_up_light_skin_tone",
-  "\ud83d\udc4d\ud83c\udffc": "thumbs_up_medium-light_skin_tone",
-  "\ud83d\udc4d\ud83c\udffd": "thumbs_up_medium_skin_tone",
-  "\ud83d\udc4d\ud83c\udffe": "thumbs_up_medium-dark_skin_tone",
-  "\ud83d\udc4d\ud83c\udfff": "thumbs_up_dark_skin_tone",
-  "\ud83d\udc4e": "thumbs_down",
-  "\ud83d\udc4e\ud83c\udffb": "thumbs_down_light_skin_tone",
-  "\ud83d\udc4e\ud83c\udffc": "thumbs_down_medium-light_skin_tone",
-  "\ud83d\udc4e\ud83c\udffd": "thumbs_down_medium_skin_tone",
-  "\ud83d\udc4e\ud83c\udffe": "thumbs_down_medium-dark_skin_tone",
-  "\ud83d\udc4e\ud83c\udfff": "thumbs_down_dark_skin_tone",
-  "\ud83d\udc4f": "clapping_hands",
-  "\ud83d\udc4f\ud83c\udffb": "clapping_hands_light_skin_tone",
-  "\ud83d\udc4f\ud83c\udffc": "clapping_hands_medium-light_skin_tone",
-  "\ud83d\udc4f\ud83c\udffd": "clapping_hands_medium_skin_tone",
-  "\ud83d\udc4f\ud83c\udffe": "clapping_hands_medium-dark_skin_tone",
-  "\ud83d\udc4f\ud83c\udfff": "clapping_hands_dark_skin_tone",
-  "\ud83d\udc50": "open_hands",
-  "\ud83d\udc50\ud83c\udffb": "open_hands_light_skin_tone",
-  "\ud83d\udc50\ud83c\udffc": "open_hands_medium-light_skin_tone",
-  "\ud83d\udc50\ud83c\udffd": "open_hands_medium_skin_tone",
-  "\ud83d\udc50\ud83c\udffe": "open_hands_medium-dark_skin_tone",
-  "\ud83d\udc50\ud83c\udfff": "open_hands_dark_skin_tone",
-  "\ud83d\udc51": "crown",
-  "\ud83d\udc52": "woman\u2019s_hat",
-  "\ud83d\udc53": "glasses",
-  "\ud83d\udc54": "necktie",
-  "\ud83d\udc55": "t-shirt",
-  "\ud83d\udc56": "jeans",
-  "\ud83d\udc57": "dress",
-  "\ud83d\udc58": "kimono",
-  "\ud83d\udc59": "bikini",
-  "\ud83d\udc5a": "woman\u2019s_clothes",
-  "\ud83d\udc5b": "purse",
-  "\ud83d\udc5c": "handbag",
-  "\ud83d\udc5d": "clutch_bag",
-  "\ud83d\udc5e": "man\u2019s_shoe",
-  "\ud83d\udc5f": "running_shoe",
-  "\ud83d\udc60": "high-heeled_shoe",
-  "\ud83d\udc61": "woman\u2019s_sandal",
-  "\ud83d\udc62": "woman\u2019s_boot",
-  "\ud83d\udc63": "footprints",
-  "\ud83d\udc64": "bust_in_silhouette",
-  "\ud83d\udc65": "busts_in_silhouette",
-  "\ud83d\udc66": "boy",
-  "\ud83d\udc66\ud83c\udffb": "boy_light_skin_tone",
-  "\ud83d\udc66\ud83c\udffc": "boy_medium-light_skin_tone",
-  "\ud83d\udc66\ud83c\udffd": "boy_medium_skin_tone",
-  "\ud83d\udc66\ud83c\udffe": "boy_medium-dark_skin_tone",
-  "\ud83d\udc66\ud83c\udfff": "boy_dark_skin_tone",
-  "\ud83d\udc67": "girl",
-  "\ud83d\udc67\ud83c\udffb": "girl_light_skin_tone",
-  "\ud83d\udc67\ud83c\udffc": "girl_medium-light_skin_tone",
-  "\ud83d\udc67\ud83c\udffd": "girl_medium_skin_tone",
-  "\ud83d\udc67\ud83c\udffe": "girl_medium-dark_skin_tone",
-  "\ud83d\udc67\ud83c\udfff": "girl_dark_skin_tone",
-  "\ud83d\udc68": "man",
-  "\ud83d\udc68\u200d\u2695": "man_health_worker",
-  "\ud83d\udc68\u200d\u2695\ufe0f": "man_health_worker",
-  "\ud83d\udc68\u200d\u2696": "man_judge",
-  "\ud83d\udc68\u200d\u2696\ufe0f": "man_judge",
-  "\ud83d\udc68\u200d\u2708": "man_pilot",
-  "\ud83d\udc68\u200d\u2708\ufe0f": "man_pilot",
-  "\ud83d\udc68\u200d\u2764\u200d\ud83d\udc68": "couple_with_heart_man_man",
-  "\ud83d\udc68\u200d\u2764\u200d\ud83d\udc8b\u200d\ud83d\udc68": "kiss_man_man",
-  "\ud83d\udc68\u200d\u2764\ufe0f\u200d\ud83d\udc68": "couple_with_heart_man_man",
-  "\ud83d\udc68\u200d\u2764\ufe0f\u200d\ud83d\udc8b\u200d\ud83d\udc68": "kiss_man_man",
-  "\ud83d\udc68\u200d\ud83c\udf3e": "man_farmer",
-  "\ud83d\udc68\u200d\ud83c\udf73": "man_cook",
-  "\ud83d\udc68\u200d\ud83c\udf7c": "man_feeding_baby",
-  "\ud83d\udc68\u200d\ud83c\udf93": "man_student",
-  "\ud83d\udc68\u200d\ud83c\udfa4": "man_singer",
-  "\ud83d\udc68\u200d\ud83c\udfa8": "man_artist",
-  "\ud83d\udc68\u200d\ud83c\udfeb": "man_teacher",
-  "\ud83d\udc68\u200d\ud83c\udfed": "man_factory_worker",
-  "\ud83d\udc68\u200d\ud83d\udc66": "family_man_boy",
-  "\ud83d\udc68\u200d\ud83d\udc66\u200d\ud83d\udc66": "family_man_boy_boy",
-  "\ud83d\udc68\u200d\ud83d\udc67": "family_man_girl",
-  "\ud83d\udc68\u200d\ud83d\udc67\u200d\ud83d\udc66": "family_man_girl_boy",
-  "\ud83d\udc68\u200d\ud83d\udc67\u200d\ud83d\udc67": "family_man_girl_girl",
-  "\ud83d\udc68\u200d\ud83d\udc68\u200d\ud83d\udc66": "family_man_man_boy",
-  "\ud83d\udc68\u200d\ud83d\udc68\u200d\ud83d\udc66\u200d\ud83d\udc66": "family_man_man_boy_boy",
-  "\ud83d\udc68\u200d\ud83d\udc68\u200d\ud83d\udc67": "family_man_man_girl",
-  "\ud83d\udc68\u200d\ud83d\udc68\u200d\ud83d\udc67\u200d\ud83d\udc66": "family_man_man_girl_boy",
-  "\ud83d\udc68\u200d\ud83d\udc68\u200d\ud83d\udc67\u200d\ud83d\udc67": "family_man_man_girl_girl",
-  "\ud83d\udc68\u200d\ud83d\udc69\u200d\ud83d\udc66": "family_man_woman_boy",
-  "\ud83d\udc68\u200d\ud83d\udc69\u200d\ud83d\udc66\u200d\ud83d\udc66": "family_man_woman_boy_boy",
-  "\ud83d\udc68\u200d\ud83d\udc69\u200d\ud83d\udc67": "family_man_woman_girl",
-  "\ud83d\udc68\u200d\ud83d\udc69\u200d\ud83d\udc67\u200d\ud83d\udc66": "family_man_woman_girl_boy",
-  "\ud83d\udc68\u200d\ud83d\udc69\u200d\ud83d\udc67\u200d\ud83d\udc67": "family_man_woman_girl_girl",
-  "\ud83d\udc68\u200d\ud83d\udcbb": "man_technologist",
-  "\ud83d\udc68\u200d\ud83d\udcbc": "man_office_worker",
-  "\ud83d\udc68\u200d\ud83d\udd27": "man_mechanic",
-  "\ud83d\udc68\u200d\ud83d\udd2c": "man_scientist",
-  "\ud83d\udc68\u200d\ud83d\ude80": "man_astronaut",
-  "\ud83d\udc68\u200d\ud83d\ude92": "man_firefighter",
-  "\ud83d\udc68\u200d\ud83e\uddaf": "man_with_white_cane",
-  "\ud83d\udc68\u200d\ud83e\uddaf\u200d\u27a1": "man_with_white_cane_facing_right",
-  "\ud83d\udc68\u200d\ud83e\uddaf\u200d\u27a1\ufe0f": "man_with_white_cane_facing_right",
-  "\ud83d\udc68\u200d\ud83e\uddb0": "man_red_hair",
-  "\ud83d\udc68\u200d\ud83e\uddb1": "man_curly_hair",
-  "\ud83d\udc68\u200d\ud83e\uddb2": "man_bald",
-  "\ud83d\udc68\u200d\ud83e\uddb3": "man_white_hair",
-  "\ud83d\udc68\u200d\ud83e\uddbc": "man_in_motorized_wheelchair",
-  "\ud83d\udc68\u200d\ud83e\uddbc\u200d\u27a1": "man_in_motorized_wheelchair_facing_right",
-  "\ud83d\udc68\u200d\ud83e\uddbc\u200d\u27a1\ufe0f": "man_in_motorized_wheelchair_facing_right",
-  "\ud83d\udc68\u200d\ud83e\uddbd": "man_in_manual_wheelchair",
-  "\ud83d\udc68\u200d\ud83e\uddbd\u200d\u27a1": "man_in_manual_wheelchair_facing_right",
-  "\ud83d\udc68\u200d\ud83e\uddbd\u200d\u27a1\ufe0f": "man_in_manual_wheelchair_facing_right",
-  "\ud83d\udc68\ud83c\udffb": "man_light_skin_tone",
-  "\ud83d\udc68\ud83c\udffb\u200d\u2695": "man_health_worker_light_skin_tone",
-  "\ud83d\udc68\ud83c\udffb\u200d\u2695\ufe0f": "man_health_worker_light_skin_tone",
-  "\ud83d\udc68\ud83c\udffb\u200d\u2696": "man_judge_light_skin_tone",
-  "\ud83d\udc68\ud83c\udffb\u200d\u2696\ufe0f": "man_judge_light_skin_tone",
-  "\ud83d\udc68\ud83c\udffb\u200d\u2708": "man_pilot_light_skin_tone",
-  "\ud83d\udc68\ud83c\udffb\u200d\u2708\ufe0f": "man_pilot_light_skin_tone",
-  "\ud83d\udc68\ud83c\udffb\u200d\u2764\u200d\ud83d\udc68\ud83c\udffb": "couple_with_heart_man_man_light_skin_tone",
-  "\ud83d\udc68\ud83c\udffb\u200d\u2764\u200d\ud83d\udc68\ud83c\udffc": "couple_with_heart_man_man_light_skin_tone_medium-light_skin_tone",
-  "\ud83d\udc68\ud83c\udffb\u200d\u2764\u200d\ud83d\udc68\ud83c\udffd": "couple_with_heart_man_man_light_skin_tone_medium_skin_tone",
-  "\ud83d\udc68\ud83c\udffb\u200d\u2764\u200d\ud83d\udc68\ud83c\udffe": "couple_with_heart_man_man_light_skin_tone_medium-dark_skin_tone",
-  "\ud83d\udc68\ud83c\udffb\u200d\u2764\u200d\ud83d\udc68\ud83c\udfff": "couple_with_heart_man_man_light_skin_tone_dark_skin_tone",
-  "\ud83d\udc68\ud83c\udffb\u200d\u2764\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udffb": "kiss_man_man_light_skin_tone",
-  "\ud83d\udc68\ud83c\udffb\u200d\u2764\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udffc": "kiss_man_man_light_skin_tone_medium-light_skin_tone",
-  "\ud83d\udc68\ud83c\udffb\u200d\u2764\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udffd": "kiss_man_man_light_skin_tone_medium_skin_tone",
-  "\ud83d\udc68\ud83c\udffb\u200d\u2764\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udffe": "kiss_man_man_light_skin_tone_medium-dark_skin_tone",
-  "\ud83d\udc68\ud83c\udffb\u200d\u2764\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udfff": "kiss_man_man_light_skin_tone_dark_skin_tone",
-  "\ud83d\udc68\ud83c\udffb\u200d\u2764\ufe0f\u200d\ud83d\udc68\ud83c\udffb": "couple_with_heart_man_man_light_skin_tone",
-  "\ud83d\udc68\ud83c\udffb\u200d\u2764\ufe0f\u200d\ud83d\udc68\ud83c\udffc": "couple_with_heart_man_man_light_skin_tone_medium-light_skin_tone",
-  "\ud83d\udc68\ud83c\udffb\u200d\u2764\ufe0f\u200d\ud83d\udc68\ud83c\udffd": "couple_with_heart_man_man_light_skin_tone_medium_skin_tone",
-  "\ud83d\udc68\ud83c\udffb\u200d\u2764\ufe0f\u200d\ud83d\udc68\ud83c\udffe": "couple_with_heart_man_man_light_skin_tone_medium-dark_skin_tone",
-  "\ud83d\udc68\ud83c\udffb\u200d\u2764\ufe0f\u200d\ud83d\udc68\ud83c\udfff": "couple_with_heart_man_man_light_skin_tone_dark_skin_tone",
-  "\ud83d\udc68\ud83c\udffb\u200d\u2764\ufe0f\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udffb": "kiss_man_man_light_skin_tone",
-  "\ud83d\udc68\ud83c\udffb\u200d\u2764\ufe0f\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udffc": "kiss_man_man_light_skin_tone_medium-light_skin_tone",
-  "\ud83d\udc68\ud83c\udffb\u200d\u2764\ufe0f\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udffd": "kiss_man_man_light_skin_tone_medium_skin_tone",
-  "\ud83d\udc68\ud83c\udffb\u200d\u2764\ufe0f\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udffe": "kiss_man_man_light_skin_tone_medium-dark_skin_tone",
-  "\ud83d\udc68\ud83c\udffb\u200d\u2764\ufe0f\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udfff": "kiss_man_man_light_skin_tone_dark_skin_tone",
-  "\ud83d\udc68\ud83c\udffb\u200d\ud83c\udf3e": "man_farmer_light_skin_tone",
-  "\ud83d\udc68\ud83c\udffb\u200d\ud83c\udf73": "man_cook_light_skin_tone",
-  "\ud83d\udc68\ud83c\udffb\u200d\ud83c\udf7c": "man_feeding_baby_light_skin_tone",
-  "\ud83d\udc68\ud83c\udffb\u200d\ud83c\udf93": "man_student_light_skin_tone",
-  "\ud83d\udc68\ud83c\udffb\u200d\ud83c\udfa4": "man_singer_light_skin_tone",
-  "\ud83d\udc68\ud83c\udffb\u200d\ud83c\udfa8": "man_artist_light_skin_tone",
-  "\ud83d\udc68\ud83c\udffb\u200d\ud83c\udfeb": "man_teacher_light_skin_tone",
-  "\ud83d\udc68\ud83c\udffb\u200d\ud83c\udfed": "man_factory_worker_light_skin_tone",
-  "\ud83d\udc68\ud83c\udffb\u200d\ud83d\udcbb": "man_technologist_light_skin_tone",
-  "\ud83d\udc68\ud83c\udffb\u200d\ud83d\udcbc": "man_office_worker_light_skin_tone",
-  "\ud83d\udc68\ud83c\udffb\u200d\ud83d\udd27": "man_mechanic_light_skin_tone",
-  "\ud83d\udc68\ud83c\udffb\u200d\ud83d\udd2c": "man_scientist_light_skin_tone",
-  "\ud83d\udc68\ud83c\udffb\u200d\ud83d\ude80": "man_astronaut_light_skin_tone",
-  "\ud83d\udc68\ud83c\udffb\u200d\ud83d\ude92": "man_firefighter_light_skin_tone",
-  "\ud83d\udc68\ud83c\udffb\u200d\ud83e\udd1d\u200d\ud83d\udc68\ud83c\udffc": "men_holding_hands_light_skin_tone_medium-light_skin_tone",
-  "\ud83d\udc68\ud83c\udffb\u200d\ud83e\udd1d\u200d\ud83d\udc68\ud83c\udffd": "men_holding_hands_light_skin_tone_medium_skin_tone",
-  "\ud83d\udc68\ud83c\udffb\u200d\ud83e\udd1d\u200d\ud83d\udc68\ud83c\udffe": "men_holding_hands_light_skin_tone_medium-dark_skin_tone",
-  "\ud83d\udc68\ud83c\udffb\u200d\ud83e\udd1d\u200d\ud83d\udc68\ud83c\udfff": "men_holding_hands_light_skin_tone_dark_skin_tone",
-  "\ud83d\udc68\ud83c\udffb\u200d\ud83e\uddaf": "man_with_white_cane_light_skin_tone",
-  "\ud83d\udc68\ud83c\udffb\u200d\ud83e\uddaf\u200d\u27a1": "man_with_white_cane_facing_right_light_skin_tone",
-  "\ud83d\udc68\ud83c\udffb\u200d\ud83e\uddaf\u200d\u27a1\ufe0f": "man_with_white_cane_facing_right_light_skin_tone",
-  "\ud83d\udc68\ud83c\udffb\u200d\ud83e\uddb0": "man_light_skin_tone_red_hair",
-  "\ud83d\udc68\ud83c\udffb\u200d\ud83e\uddb1": "man_light_skin_tone_curly_hair",
-  "\ud83d\udc68\ud83c\udffb\u200d\ud83e\uddb2": "man_light_skin_tone_bald",
-  "\ud83d\udc68\ud83c\udffb\u200d\ud83e\uddb3": "man_light_skin_tone_white_hair",
-  "\ud83d\udc68\ud83c\udffb\u200d\ud83e\uddbc": "man_in_motorized_wheelchair_light_skin_tone",
-  "\ud83d\udc68\ud83c\udffb\u200d\ud83e\uddbc\u200d\u27a1": "man_in_motorized_wheelchair_facing_right_light_skin_tone",
-  "\ud83d\udc68\ud83c\udffb\u200d\ud83e\uddbc\u200d\u27a1\ufe0f": "man_in_motorized_wheelchair_facing_right_light_skin_tone",
-  "\ud83d\udc68\ud83c\udffb\u200d\ud83e\uddbd": "man_in_manual_wheelchair_light_skin_tone",
-  "\ud83d\udc68\ud83c\udffb\u200d\ud83e\uddbd\u200d\u27a1": "man_in_manual_wheelchair_facing_right_light_skin_tone",
-  "\ud83d\udc68\ud83c\udffb\u200d\ud83e\uddbd\u200d\u27a1\ufe0f": "man_in_manual_wheelchair_facing_right_light_skin_tone",
-  "\ud83d\udc68\ud83c\udffc": "man_medium-light_skin_tone",
-  "\ud83d\udc68\ud83c\udffc\u200d\u2695": "man_health_worker_medium-light_skin_tone",
-  "\ud83d\udc68\ud83c\udffc\u200d\u2695\ufe0f": "man_health_worker_medium-light_skin_tone",
-  "\ud83d\udc68\ud83c\udffc\u200d\u2696": "man_judge_medium-light_skin_tone",
-  "\ud83d\udc68\ud83c\udffc\u200d\u2696\ufe0f": "man_judge_medium-light_skin_tone",
-  "\ud83d\udc68\ud83c\udffc\u200d\u2708": "man_pilot_medium-light_skin_tone",
-  "\ud83d\udc68\ud83c\udffc\u200d\u2708\ufe0f": "man_pilot_medium-light_skin_tone",
-  "\ud83d\udc68\ud83c\udffc\u200d\u2764\u200d\ud83d\udc68\ud83c\udffb": "couple_with_heart_man_man_medium-light_skin_tone_light_skin_tone",
-  "\ud83d\udc68\ud83c\udffc\u200d\u2764\u200d\ud83d\udc68\ud83c\udffc": "couple_with_heart_man_man_medium-light_skin_tone",
-  "\ud83d\udc68\ud83c\udffc\u200d\u2764\u200d\ud83d\udc68\ud83c\udffd": "couple_with_heart_man_man_medium-light_skin_tone_medium_skin_tone",
-  "\ud83d\udc68\ud83c\udffc\u200d\u2764\u200d\ud83d\udc68\ud83c\udffe": "couple_with_heart_man_man_medium-light_skin_tone_medium-dark_skin_tone",
-  "\ud83d\udc68\ud83c\udffc\u200d\u2764\u200d\ud83d\udc68\ud83c\udfff": "couple_with_heart_man_man_medium-light_skin_tone_dark_skin_tone",
-  "\ud83d\udc68\ud83c\udffc\u200d\u2764\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udffb": "kiss_man_man_medium-light_skin_tone_light_skin_tone",
-  "\ud83d\udc68\ud83c\udffc\u200d\u2764\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udffc": "kiss_man_man_medium-light_skin_tone",
-  "\ud83d\udc68\ud83c\udffc\u200d\u2764\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udffd": "kiss_man_man_medium-light_skin_tone_medium_skin_tone",
-  "\ud83d\udc68\ud83c\udffc\u200d\u2764\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udffe": "kiss_man_man_medium-light_skin_tone_medium-dark_skin_tone",
-  "\ud83d\udc68\ud83c\udffc\u200d\u2764\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udfff": "kiss_man_man_medium-light_skin_tone_dark_skin_tone",
-  "\ud83d\udc68\ud83c\udffc\u200d\u2764\ufe0f\u200d\ud83d\udc68\ud83c\udffb": "couple_with_heart_man_man_medium-light_skin_tone_light_skin_tone",
-  "\ud83d\udc68\ud83c\udffc\u200d\u2764\ufe0f\u200d\ud83d\udc68\ud83c\udffc": "couple_with_heart_man_man_medium-light_skin_tone",
-  "\ud83d\udc68\ud83c\udffc\u200d\u2764\ufe0f\u200d\ud83d\udc68\ud83c\udffd": "couple_with_heart_man_man_medium-light_skin_tone_medium_skin_tone",
-  "\ud83d\udc68\ud83c\udffc\u200d\u2764\ufe0f\u200d\ud83d\udc68\ud83c\udffe": "couple_with_heart_man_man_medium-light_skin_tone_medium-dark_skin_tone",
-  "\ud83d\udc68\ud83c\udffc\u200d\u2764\ufe0f\u200d\ud83d\udc68\ud83c\udfff": "couple_with_heart_man_man_medium-light_skin_tone_dark_skin_tone",
-  "\ud83d\udc68\ud83c\udffc\u200d\u2764\ufe0f\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udffb": "kiss_man_man_medium-light_skin_tone_light_skin_tone",
-  "\ud83d\udc68\ud83c\udffc\u200d\u2764\ufe0f\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udffc": "kiss_man_man_medium-light_skin_tone",
-  "\ud83d\udc68\ud83c\udffc\u200d\u2764\ufe0f\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udffd": "kiss_man_man_medium-light_skin_tone_medium_skin_tone",
-  "\ud83d\udc68\ud83c\udffc\u200d\u2764\ufe0f\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udffe": "kiss_man_man_medium-light_skin_tone_medium-dark_skin_tone",
-  "\ud83d\udc68\ud83c\udffc\u200d\u2764\ufe0f\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udfff": "kiss_man_man_medium-light_skin_tone_dark_skin_tone",
-  "\ud83d\udc68\ud83c\udffc\u200d\ud83c\udf3e": "man_farmer_medium-light_skin_tone",
-  "\ud83d\udc68\ud83c\udffc\u200d\ud83c\udf73": "man_cook_medium-light_skin_tone",
-  "\ud83d\udc68\ud83c\udffc\u200d\ud83c\udf7c": "man_feeding_baby_medium-light_skin_tone",
-  "\ud83d\udc68\ud83c\udffc\u200d\ud83c\udf93": "man_student_medium-light_skin_tone",
-  "\ud83d\udc68\ud83c\udffc\u200d\ud83c\udfa4": "man_singer_medium-light_skin_tone",
-  "\ud83d\udc68\ud83c\udffc\u200d\ud83c\udfa8": "man_artist_medium-light_skin_tone",
-  "\ud83d\udc68\ud83c\udffc\u200d\ud83c\udfeb": "man_teacher_medium-light_skin_tone",
-  "\ud83d\udc68\ud83c\udffc\u200d\ud83c\udfed": "man_factory_worker_medium-light_skin_tone",
-  "\ud83d\udc68\ud83c\udffc\u200d\ud83d\udcbb": "man_technologist_medium-light_skin_tone",
-  "\ud83d\udc68\ud83c\udffc\u200d\ud83d\udcbc": "man_office_worker_medium-light_skin_tone",
-  "\ud83d\udc68\ud83c\udffc\u200d\ud83d\udd27": "man_mechanic_medium-light_skin_tone",
-  "\ud83d\udc68\ud83c\udffc\u200d\ud83d\udd2c": "man_scientist_medium-light_skin_tone",
-  "\ud83d\udc68\ud83c\udffc\u200d\ud83d\ude80": "man_astronaut_medium-light_skin_tone",
-  "\ud83d\udc68\ud83c\udffc\u200d\ud83d\ude92": "man_firefighter_medium-light_skin_tone",
-  "\ud83d\udc68\ud83c\udffc\u200d\ud83e\udd1d\u200d\ud83d\udc68\ud83c\udffb": "men_holding_hands_medium-light_skin_tone_light_skin_tone",
-  "\ud83d\udc68\ud83c\udffc\u200d\ud83e\udd1d\u200d\ud83d\udc68\ud83c\udffd": "men_holding_hands_medium-light_skin_tone_medium_skin_tone",
-  "\ud83d\udc68\ud83c\udffc\u200d\ud83e\udd1d\u200d\ud83d\udc68\ud83c\udffe": "men_holding_hands_medium-light_skin_tone_medium-dark_skin_tone",
-  "\ud83d\udc68\ud83c\udffc\u200d\ud83e\udd1d\u200d\ud83d\udc68\ud83c\udfff": "men_holding_hands_medium-light_skin_tone_dark_skin_tone",
-  "\ud83d\udc68\ud83c\udffc\u200d\ud83e\uddaf": "man_with_white_cane_medium-light_skin_tone",
-  "\ud83d\udc68\ud83c\udffc\u200d\ud83e\uddaf\u200d\u27a1": "man_with_white_cane_facing_right_medium-light_skin_tone",
-  "\ud83d\udc68\ud83c\udffc\u200d\ud83e\uddaf\u200d\u27a1\ufe0f": "man_with_white_cane_facing_right_medium-light_skin_tone",
-  "\ud83d\udc68\ud83c\udffc\u200d\ud83e\uddb0": "man_medium-light_skin_tone_red_hair",
-  "\ud83d\udc68\ud83c\udffc\u200d\ud83e\uddb1": "man_medium-light_skin_tone_curly_hair",
-  "\ud83d\udc68\ud83c\udffc\u200d\ud83e\uddb2": "man_medium-light_skin_tone_bald",
-  "\ud83d\udc68\ud83c\udffc\u200d\ud83e\uddb3": "man_medium-light_skin_tone_white_hair",
-  "\ud83d\udc68\ud83c\udffc\u200d\ud83e\uddbc": "man_in_motorized_wheelchair_medium-light_skin_tone",
-  "\ud83d\udc68\ud83c\udffc\u200d\ud83e\uddbc\u200d\u27a1": "man_in_motorized_wheelchair_facing_right_medium-light_skin_tone",
-  "\ud83d\udc68\ud83c\udffc\u200d\ud83e\uddbc\u200d\u27a1\ufe0f": "man_in_motorized_wheelchair_facing_right_medium-light_skin_tone",
-  "\ud83d\udc68\ud83c\udffc\u200d\ud83e\uddbd": "man_in_manual_wheelchair_medium-light_skin_tone",
-  "\ud83d\udc68\ud83c\udffc\u200d\ud83e\uddbd\u200d\u27a1": "man_in_manual_wheelchair_facing_right_medium-light_skin_tone",
-  "\ud83d\udc68\ud83c\udffc\u200d\ud83e\uddbd\u200d\u27a1\ufe0f": "man_in_manual_wheelchair_facing_right_medium-light_skin_tone",
-  "\ud83d\udc68\ud83c\udffd": "man_medium_skin_tone",
-  "\ud83d\udc68\ud83c\udffd\u200d\u2695": "man_health_worker_medium_skin_tone",
-  "\ud83d\udc68\ud83c\udffd\u200d\u2695\ufe0f": "man_health_worker_medium_skin_tone",
-  "\ud83d\udc68\ud83c\udffd\u200d\u2696": "man_judge_medium_skin_tone",
-  "\ud83d\udc68\ud83c\udffd\u200d\u2696\ufe0f": "man_judge_medium_skin_tone",
-  "\ud83d\udc68\ud83c\udffd\u200d\u2708": "man_pilot_medium_skin_tone",
-  "\ud83d\udc68\ud83c\udffd\u200d\u2708\ufe0f": "man_pilot_medium_skin_tone",
-  "\ud83d\udc68\ud83c\udffd\u200d\u2764\u200d\ud83d\udc68\ud83c\udffb": "couple_with_heart_man_man_medium_skin_tone_light_skin_tone",
-  "\ud83d\udc68\ud83c\udffd\u200d\u2764\u200d\ud83d\udc68\ud83c\udffc": "couple_with_heart_man_man_medium_skin_tone_medium-light_skin_tone",
-  "\ud83d\udc68\ud83c\udffd\u200d\u2764\u200d\ud83d\udc68\ud83c\udffd": "couple_with_heart_man_man_medium_skin_tone",
-  "\ud83d\udc68\ud83c\udffd\u200d\u2764\u200d\ud83d\udc68\ud83c\udffe": "couple_with_heart_man_man_medium_skin_tone_medium-dark_skin_tone",
-  "\ud83d\udc68\ud83c\udffd\u200d\u2764\u200d\ud83d\udc68\ud83c\udfff": "couple_with_heart_man_man_medium_skin_tone_dark_skin_tone",
-  "\ud83d\udc68\ud83c\udffd\u200d\u2764\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udffb": "kiss_man_man_medium_skin_tone_light_skin_tone",
-  "\ud83d\udc68\ud83c\udffd\u200d\u2764\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udffc": "kiss_man_man_medium_skin_tone_medium-light_skin_tone",
-  "\ud83d\udc68\ud83c\udffd\u200d\u2764\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udffd": "kiss_man_man_medium_skin_tone",
-  "\ud83d\udc68\ud83c\udffd\u200d\u2764\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udffe": "kiss_man_man_medium_skin_tone_medium-dark_skin_tone",
-  "\ud83d\udc68\ud83c\udffd\u200d\u2764\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udfff": "kiss_man_man_medium_skin_tone_dark_skin_tone",
-  "\ud83d\udc68\ud83c\udffd\u200d\u2764\ufe0f\u200d\ud83d\udc68\ud83c\udffb": "couple_with_heart_man_man_medium_skin_tone_light_skin_tone",
-  "\ud83d\udc68\ud83c\udffd\u200d\u2764\ufe0f\u200d\ud83d\udc68\ud83c\udffc": "couple_with_heart_man_man_medium_skin_tone_medium-light_skin_tone",
-  "\ud83d\udc68\ud83c\udffd\u200d\u2764\ufe0f\u200d\ud83d\udc68\ud83c\udffd": "couple_with_heart_man_man_medium_skin_tone",
-  "\ud83d\udc68\ud83c\udffd\u200d\u2764\ufe0f\u200d\ud83d\udc68\ud83c\udffe": "couple_with_heart_man_man_medium_skin_tone_medium-dark_skin_tone",
-  "\ud83d\udc68\ud83c\udffd\u200d\u2764\ufe0f\u200d\ud83d\udc68\ud83c\udfff": "couple_with_heart_man_man_medium_skin_tone_dark_skin_tone",
-  "\ud83d\udc68\ud83c\udffd\u200d\u2764\ufe0f\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udffb": "kiss_man_man_medium_skin_tone_light_skin_tone",
-  "\ud83d\udc68\ud83c\udffd\u200d\u2764\ufe0f\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udffc": "kiss_man_man_medium_skin_tone_medium-light_skin_tone",
-  "\ud83d\udc68\ud83c\udffd\u200d\u2764\ufe0f\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udffd": "kiss_man_man_medium_skin_tone",
-  "\ud83d\udc68\ud83c\udffd\u200d\u2764\ufe0f\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udffe": "kiss_man_man_medium_skin_tone_medium-dark_skin_tone",
-  "\ud83d\udc68\ud83c\udffd\u200d\u2764\ufe0f\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udfff": "kiss_man_man_medium_skin_tone_dark_skin_tone",
-  "\ud83d\udc68\ud83c\udffd\u200d\ud83c\udf3e": "man_farmer_medium_skin_tone",
-  "\ud83d\udc68\ud83c\udffd\u200d\ud83c\udf73": "man_cook_medium_skin_tone",
-  "\ud83d\udc68\ud83c\udffd\u200d\ud83c\udf7c": "man_feeding_baby_medium_skin_tone",
-  "\ud83d\udc68\ud83c\udffd\u200d\ud83c\udf93": "man_student_medium_skin_tone",
-  "\ud83d\udc68\ud83c\udffd\u200d\ud83c\udfa4": "man_singer_medium_skin_tone",
-  "\ud83d\udc68\ud83c\udffd\u200d\ud83c\udfa8": "man_artist_medium_skin_tone",
-  "\ud83d\udc68\ud83c\udffd\u200d\ud83c\udfeb": "man_teacher_medium_skin_tone",
-  "\ud83d\udc68\ud83c\udffd\u200d\ud83c\udfed": "man_factory_worker_medium_skin_tone",
-  "\ud83d\udc68\ud83c\udffd\u200d\ud83d\udcbb": "man_technologist_medium_skin_tone",
-  "\ud83d\udc68\ud83c\udffd\u200d\ud83d\udcbc": "man_office_worker_medium_skin_tone",
-  "\ud83d\udc68\ud83c\udffd\u200d\ud83d\udd27": "man_mechanic_medium_skin_tone",
-  "\ud83d\udc68\ud83c\udffd\u200d\ud83d\udd2c": "man_scientist_medium_skin_tone",
-  "\ud83d\udc68\ud83c\udffd\u200d\ud83d\ude80": "man_astronaut_medium_skin_tone",
-  "\ud83d\udc68\ud83c\udffd\u200d\ud83d\ude92": "man_firefighter_medium_skin_tone",
-  "\ud83d\udc68\ud83c\udffd\u200d\ud83e\udd1d\u200d\ud83d\udc68\ud83c\udffb": "men_holding_hands_medium_skin_tone_light_skin_tone",
-  "\ud83d\udc68\ud83c\udffd\u200d\ud83e\udd1d\u200d\ud83d\udc68\ud83c\udffc": "men_holding_hands_medium_skin_tone_medium-light_skin_tone",
-  "\ud83d\udc68\ud83c\udffd\u200d\ud83e\udd1d\u200d\ud83d\udc68\ud83c\udffe": "men_holding_hands_medium_skin_tone_medium-dark_skin_tone",
-  "\ud83d\udc68\ud83c\udffd\u200d\ud83e\udd1d\u200d\ud83d\udc68\ud83c\udfff": "men_holding_hands_medium_skin_tone_dark_skin_tone",
-  "\ud83d\udc68\ud83c\udffd\u200d\ud83e\uddaf": "man_with_white_cane_medium_skin_tone",
-  "\ud83d\udc68\ud83c\udffd\u200d\ud83e\uddaf\u200d\u27a1": "man_with_white_cane_facing_right_medium_skin_tone",
-  "\ud83d\udc68\ud83c\udffd\u200d\ud83e\uddaf\u200d\u27a1\ufe0f": "man_with_white_cane_facing_right_medium_skin_tone",
-  "\ud83d\udc68\ud83c\udffd\u200d\ud83e\uddb0": "man_medium_skin_tone_red_hair",
-  "\ud83d\udc68\ud83c\udffd\u200d\ud83e\uddb1": "man_medium_skin_tone_curly_hair",
-  "\ud83d\udc68\ud83c\udffd\u200d\ud83e\uddb2": "man_medium_skin_tone_bald",
-  "\ud83d\udc68\ud83c\udffd\u200d\ud83e\uddb3": "man_medium_skin_tone_white_hair",
-  "\ud83d\udc68\ud83c\udffd\u200d\ud83e\uddbc": "man_in_motorized_wheelchair_medium_skin_tone",
-  "\ud83d\udc68\ud83c\udffd\u200d\ud83e\uddbc\u200d\u27a1": "man_in_motorized_wheelchair_facing_right_medium_skin_tone",
-  "\ud83d\udc68\ud83c\udffd\u200d\ud83e\uddbc\u200d\u27a1\ufe0f": "man_in_motorized_wheelchair_facing_right_medium_skin_tone",
-  "\ud83d\udc68\ud83c\udffd\u200d\ud83e\uddbd": "man_in_manual_wheelchair_medium_skin_tone",
-  "\ud83d\udc68\ud83c\udffd\u200d\ud83e\uddbd\u200d\u27a1": "man_in_manual_wheelchair_facing_right_medium_skin_tone",
-  "\ud83d\udc68\ud83c\udffd\u200d\ud83e\uddbd\u200d\u27a1\ufe0f": "man_in_manual_wheelchair_facing_right_medium_skin_tone",
-  "\ud83d\udc68\ud83c\udffe": "man_medium-dark_skin_tone",
-  "\ud83d\udc68\ud83c\udffe\u200d\u2695": "man_health_worker_medium-dark_skin_tone",
-  "\ud83d\udc68\ud83c\udffe\u200d\u2695\ufe0f": "man_health_worker_medium-dark_skin_tone",
-  "\ud83d\udc68\ud83c\udffe\u200d\u2696": "man_judge_medium-dark_skin_tone",
-  "\ud83d\udc68\ud83c\udffe\u200d\u2696\ufe0f": "man_judge_medium-dark_skin_tone",
-  "\ud83d\udc68\ud83c\udffe\u200d\u2708": "man_pilot_medium-dark_skin_tone",
-  "\ud83d\udc68\ud83c\udffe\u200d\u2708\ufe0f": "man_pilot_medium-dark_skin_tone",
-  "\ud83d\udc68\ud83c\udffe\u200d\u2764\u200d\ud83d\udc68\ud83c\udffb": "couple_with_heart_man_man_medium-dark_skin_tone_light_skin_tone",
-  "\ud83d\udc68\ud83c\udffe\u200d\u2764\u200d\ud83d\udc68\ud83c\udffc": "couple_with_heart_man_man_medium-dark_skin_tone_medium-light_skin_tone",
-  "\ud83d\udc68\ud83c\udffe\u200d\u2764\u200d\ud83d\udc68\ud83c\udffd": "couple_with_heart_man_man_medium-dark_skin_tone_medium_skin_tone",
-  "\ud83d\udc68\ud83c\udffe\u200d\u2764\u200d\ud83d\udc68\ud83c\udffe": "couple_with_heart_man_man_medium-dark_skin_tone",
-  "\ud83d\udc68\ud83c\udffe\u200d\u2764\u200d\ud83d\udc68\ud83c\udfff": "couple_with_heart_man_man_medium-dark_skin_tone_dark_skin_tone",
-  "\ud83d\udc68\ud83c\udffe\u200d\u2764\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udffb": "kiss_man_man_medium-dark_skin_tone_light_skin_tone",
-  "\ud83d\udc68\ud83c\udffe\u200d\u2764\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udffc": "kiss_man_man_medium-dark_skin_tone_medium-light_skin_tone",
-  "\ud83d\udc68\ud83c\udffe\u200d\u2764\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udffd": "kiss_man_man_medium-dark_skin_tone_medium_skin_tone",
-  "\ud83d\udc68\ud83c\udffe\u200d\u2764\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udffe": "kiss_man_man_medium-dark_skin_tone",
-  "\ud83d\udc68\ud83c\udffe\u200d\u2764\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udfff": "kiss_man_man_medium-dark_skin_tone_dark_skin_tone",
-  "\ud83d\udc68\ud83c\udffe\u200d\u2764\ufe0f\u200d\ud83d\udc68\ud83c\udffb": "couple_with_heart_man_man_medium-dark_skin_tone_light_skin_tone",
-  "\ud83d\udc68\ud83c\udffe\u200d\u2764\ufe0f\u200d\ud83d\udc68\ud83c\udffc": "couple_with_heart_man_man_medium-dark_skin_tone_medium-light_skin_tone",
-  "\ud83d\udc68\ud83c\udffe\u200d\u2764\ufe0f\u200d\ud83d\udc68\ud83c\udffd": "couple_with_heart_man_man_medium-dark_skin_tone_medium_skin_tone",
-  "\ud83d\udc68\ud83c\udffe\u200d\u2764\ufe0f\u200d\ud83d\udc68\ud83c\udffe": "couple_with_heart_man_man_medium-dark_skin_tone",
-  "\ud83d\udc68\ud83c\udffe\u200d\u2764\ufe0f\u200d\ud83d\udc68\ud83c\udfff": "couple_with_heart_man_man_medium-dark_skin_tone_dark_skin_tone",
-  "\ud83d\udc68\ud83c\udffe\u200d\u2764\ufe0f\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udffb": "kiss_man_man_medium-dark_skin_tone_light_skin_tone",
-  "\ud83d\udc68\ud83c\udffe\u200d\u2764\ufe0f\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udffc": "kiss_man_man_medium-dark_skin_tone_medium-light_skin_tone",
-  "\ud83d\udc68\ud83c\udffe\u200d\u2764\ufe0f\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udffd": "kiss_man_man_medium-dark_skin_tone_medium_skin_tone",
-  "\ud83d\udc68\ud83c\udffe\u200d\u2764\ufe0f\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udffe": "kiss_man_man_medium-dark_skin_tone",
-  "\ud83d\udc68\ud83c\udffe\u200d\u2764\ufe0f\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udfff": "kiss_man_man_medium-dark_skin_tone_dark_skin_tone",
-  "\ud83d\udc68\ud83c\udffe\u200d\ud83c\udf3e": "man_farmer_medium-dark_skin_tone",
-  "\ud83d\udc68\ud83c\udffe\u200d\ud83c\udf73": "man_cook_medium-dark_skin_tone",
-  "\ud83d\udc68\ud83c\udffe\u200d\ud83c\udf7c": "man_feeding_baby_medium-dark_skin_tone",
-  "\ud83d\udc68\ud83c\udffe\u200d\ud83c\udf93": "man_student_medium-dark_skin_tone",
-  "\ud83d\udc68\ud83c\udffe\u200d\ud83c\udfa4": "man_singer_medium-dark_skin_tone",
-  "\ud83d\udc68\ud83c\udffe\u200d\ud83c\udfa8": "man_artist_medium-dark_skin_tone",
-  "\ud83d\udc68\ud83c\udffe\u200d\ud83c\udfeb": "man_teacher_medium-dark_skin_tone",
-  "\ud83d\udc68\ud83c\udffe\u200d\ud83c\udfed": "man_factory_worker_medium-dark_skin_tone",
-  "\ud83d\udc68\ud83c\udffe\u200d\ud83d\udcbb": "man_technologist_medium-dark_skin_tone",
-  "\ud83d\udc68\ud83c\udffe\u200d\ud83d\udcbc": "man_office_worker_medium-dark_skin_tone",
-  "\ud83d\udc68\ud83c\udffe\u200d\ud83d\udd27": "man_mechanic_medium-dark_skin_tone",
-  "\ud83d\udc68\ud83c\udffe\u200d\ud83d\udd2c": "man_scientist_medium-dark_skin_tone",
-  "\ud83d\udc68\ud83c\udffe\u200d\ud83d\ude80": "man_astronaut_medium-dark_skin_tone",
-  "\ud83d\udc68\ud83c\udffe\u200d\ud83d\ude92": "man_firefighter_medium-dark_skin_tone",
-  "\ud83d\udc68\ud83c\udffe\u200d\ud83e\udd1d\u200d\ud83d\udc68\ud83c\udffb": "men_holding_hands_medium-dark_skin_tone_light_skin_tone",
-  "\ud83d\udc68\ud83c\udffe\u200d\ud83e\udd1d\u200d\ud83d\udc68\ud83c\udffc": "men_holding_hands_medium-dark_skin_tone_medium-light_skin_tone",
-  "\ud83d\udc68\ud83c\udffe\u200d\ud83e\udd1d\u200d\ud83d\udc68\ud83c\udffd": "men_holding_hands_medium-dark_skin_tone_medium_skin_tone",
-  "\ud83d\udc68\ud83c\udffe\u200d\ud83e\udd1d\u200d\ud83d\udc68\ud83c\udfff": "men_holding_hands_medium-dark_skin_tone_dark_skin_tone",
-  "\ud83d\udc68\ud83c\udffe\u200d\ud83e\uddaf": "man_with_white_cane_medium-dark_skin_tone",
-  "\ud83d\udc68\ud83c\udffe\u200d\ud83e\uddaf\u200d\u27a1": "man_with_white_cane_facing_right_medium-dark_skin_tone",
-  "\ud83d\udc68\ud83c\udffe\u200d\ud83e\uddaf\u200d\u27a1\ufe0f": "man_with_white_cane_facing_right_medium-dark_skin_tone",
-  "\ud83d\udc68\ud83c\udffe\u200d\ud83e\uddb0": "man_medium-dark_skin_tone_red_hair",
-  "\ud83d\udc68\ud83c\udffe\u200d\ud83e\uddb1": "man_medium-dark_skin_tone_curly_hair",
-  "\ud83d\udc68\ud83c\udffe\u200d\ud83e\uddb2": "man_medium-dark_skin_tone_bald",
-  "\ud83d\udc68\ud83c\udffe\u200d\ud83e\uddb3": "man_medium-dark_skin_tone_white_hair",
-  "\ud83d\udc68\ud83c\udffe\u200d\ud83e\uddbc": "man_in_motorized_wheelchair_medium-dark_skin_tone",
-  "\ud83d\udc68\ud83c\udffe\u200d\ud83e\uddbc\u200d\u27a1": "man_in_motorized_wheelchair_facing_right_medium-dark_skin_tone",
-  "\ud83d\udc68\ud83c\udffe\u200d\ud83e\uddbc\u200d\u27a1\ufe0f": "man_in_motorized_wheelchair_facing_right_medium-dark_skin_tone",
-  "\ud83d\udc68\ud83c\udffe\u200d\ud83e\uddbd": "man_in_manual_wheelchair_medium-dark_skin_tone",
-  "\ud83d\udc68\ud83c\udffe\u200d\ud83e\uddbd\u200d\u27a1": "man_in_manual_wheelchair_facing_right_medium-dark_skin_tone",
-  "\ud83d\udc68\ud83c\udffe\u200d\ud83e\uddbd\u200d\u27a1\ufe0f": "man_in_manual_wheelchair_facing_right_medium-dark_skin_tone",
-  "\ud83d\udc68\ud83c\udfff": "man_dark_skin_tone",
-  "\ud83d\udc68\ud83c\udfff\u200d\u2695": "man_health_worker_dark_skin_tone",
-  "\ud83d\udc68\ud83c\udfff\u200d\u2695\ufe0f": "man_health_worker_dark_skin_tone",
-  "\ud83d\udc68\ud83c\udfff\u200d\u2696": "man_judge_dark_skin_tone",
-  "\ud83d\udc68\ud83c\udfff\u200d\u2696\ufe0f": "man_judge_dark_skin_tone",
-  "\ud83d\udc68\ud83c\udfff\u200d\u2708": "man_pilot_dark_skin_tone",
-  "\ud83d\udc68\ud83c\udfff\u200d\u2708\ufe0f": "man_pilot_dark_skin_tone",
-  "\ud83d\udc68\ud83c\udfff\u200d\u2764\u200d\ud83d\udc68\ud83c\udffb": "couple_with_heart_man_man_dark_skin_tone_light_skin_tone",
-  "\ud83d\udc68\ud83c\udfff\u200d\u2764\u200d\ud83d\udc68\ud83c\udffc": "couple_with_heart_man_man_dark_skin_tone_medium-light_skin_tone",
-  "\ud83d\udc68\ud83c\udfff\u200d\u2764\u200d\ud83d\udc68\ud83c\udffd": "couple_with_heart_man_man_dark_skin_tone_medium_skin_tone",
-  "\ud83d\udc68\ud83c\udfff\u200d\u2764\u200d\ud83d\udc68\ud83c\udffe": "couple_with_heart_man_man_dark_skin_tone_medium-dark_skin_tone",
-  "\ud83d\udc68\ud83c\udfff\u200d\u2764\u200d\ud83d\udc68\ud83c\udfff": "couple_with_heart_man_man_dark_skin_tone",
-  "\ud83d\udc68\ud83c\udfff\u200d\u2764\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udffb": "kiss_man_man_dark_skin_tone_light_skin_tone",
-  "\ud83d\udc68\ud83c\udfff\u200d\u2764\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udffc": "kiss_man_man_dark_skin_tone_medium-light_skin_tone",
-  "\ud83d\udc68\ud83c\udfff\u200d\u2764\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udffd": "kiss_man_man_dark_skin_tone_medium_skin_tone",
-  "\ud83d\udc68\ud83c\udfff\u200d\u2764\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udffe": "kiss_man_man_dark_skin_tone_medium-dark_skin_tone",
-  "\ud83d\udc68\ud83c\udfff\u200d\u2764\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udfff": "kiss_man_man_dark_skin_tone",
-  "\ud83d\udc68\ud83c\udfff\u200d\u2764\ufe0f\u200d\ud83d\udc68\ud83c\udffb": "couple_with_heart_man_man_dark_skin_tone_light_skin_tone",
-  "\ud83d\udc68\ud83c\udfff\u200d\u2764\ufe0f\u200d\ud83d\udc68\ud83c\udffc": "couple_with_heart_man_man_dark_skin_tone_medium-light_skin_tone",
-  "\ud83d\udc68\ud83c\udfff\u200d\u2764\ufe0f\u200d\ud83d\udc68\ud83c\udffd": "couple_with_heart_man_man_dark_skin_tone_medium_skin_tone",
-  "\ud83d\udc68\ud83c\udfff\u200d\u2764\ufe0f\u200d\ud83d\udc68\ud83c\udffe": "couple_with_heart_man_man_dark_skin_tone_medium-dark_skin_tone",
-  "\ud83d\udc68\ud83c\udfff\u200d\u2764\ufe0f\u200d\ud83d\udc68\ud83c\udfff": "couple_with_heart_man_man_dark_skin_tone",
-  "\ud83d\udc68\ud83c\udfff\u200d\u2764\ufe0f\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udffb": "kiss_man_man_dark_skin_tone_light_skin_tone",
-  "\ud83d\udc68\ud83c\udfff\u200d\u2764\ufe0f\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udffc": "kiss_man_man_dark_skin_tone_medium-light_skin_tone",
-  "\ud83d\udc68\ud83c\udfff\u200d\u2764\ufe0f\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udffd": "kiss_man_man_dark_skin_tone_medium_skin_tone",
-  "\ud83d\udc68\ud83c\udfff\u200d\u2764\ufe0f\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udffe": "kiss_man_man_dark_skin_tone_medium-dark_skin_tone",
-  "\ud83d\udc68\ud83c\udfff\u200d\u2764\ufe0f\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udfff": "kiss_man_man_dark_skin_tone",
-  "\ud83d\udc68\ud83c\udfff\u200d\ud83c\udf3e": "man_farmer_dark_skin_tone",
-  "\ud83d\udc68\ud83c\udfff\u200d\ud83c\udf73": "man_cook_dark_skin_tone",
-  "\ud83d\udc68\ud83c\udfff\u200d\ud83c\udf7c": "man_feeding_baby_dark_skin_tone",
-  "\ud83d\udc68\ud83c\udfff\u200d\ud83c\udf93": "man_student_dark_skin_tone",
-  "\ud83d\udc68\ud83c\udfff\u200d\ud83c\udfa4": "man_singer_dark_skin_tone",
-  "\ud83d\udc68\ud83c\udfff\u200d\ud83c\udfa8": "man_artist_dark_skin_tone",
-  "\ud83d\udc68\ud83c\udfff\u200d\ud83c\udfeb": "man_teacher_dark_skin_tone",
-  "\ud83d\udc68\ud83c\udfff\u200d\ud83c\udfed": "man_factory_worker_dark_skin_tone",
-  "\ud83d\udc68\ud83c\udfff\u200d\ud83d\udcbb": "man_technologist_dark_skin_tone",
-  "\ud83d\udc68\ud83c\udfff\u200d\ud83d\udcbc": "man_office_worker_dark_skin_tone",
-  "\ud83d\udc68\ud83c\udfff\u200d\ud83d\udd27": "man_mechanic_dark_skin_tone",
-  "\ud83d\udc68\ud83c\udfff\u200d\ud83d\udd2c": "man_scientist_dark_skin_tone",
-  "\ud83d\udc68\ud83c\udfff\u200d\ud83d\ude80": "man_astronaut_dark_skin_tone",
-  "\ud83d\udc68\ud83c\udfff\u200d\ud83d\ude92": "man_firefighter_dark_skin_tone",
-  "\ud83d\udc68\ud83c\udfff\u200d\ud83e\udd1d\u200d\ud83d\udc68\ud83c\udffb": "men_holding_hands_dark_skin_tone_light_skin_tone",
-  "\ud83d\udc68\ud83c\udfff\u200d\ud83e\udd1d\u200d\ud83d\udc68\ud83c\udffc": "men_holding_hands_dark_skin_tone_medium-light_skin_tone",
-  "\ud83d\udc68\ud83c\udfff\u200d\ud83e\udd1d\u200d\ud83d\udc68\ud83c\udffd": "men_holding_hands_dark_skin_tone_medium_skin_tone",
-  "\ud83d\udc68\ud83c\udfff\u200d\ud83e\udd1d\u200d\ud83d\udc68\ud83c\udffe": "men_holding_hands_dark_skin_tone_medium-dark_skin_tone",
-  "\ud83d\udc68\ud83c\udfff\u200d\ud83e\uddaf": "man_with_white_cane_dark_skin_tone",
-  "\ud83d\udc68\ud83c\udfff\u200d\ud83e\uddaf\u200d\u27a1": "man_with_white_cane_facing_right_dark_skin_tone",
-  "\ud83d\udc68\ud83c\udfff\u200d\ud83e\uddaf\u200d\u27a1\ufe0f": "man_with_white_cane_facing_right_dark_skin_tone",
-  "\ud83d\udc68\ud83c\udfff\u200d\ud83e\uddb0": "man_dark_skin_tone_red_hair",
-  "\ud83d\udc68\ud83c\udfff\u200d\ud83e\uddb1": "man_dark_skin_tone_curly_hair",
-  "\ud83d\udc68\ud83c\udfff\u200d\ud83e\uddb2": "man_dark_skin_tone_bald",
-  "\ud83d\udc68\ud83c\udfff\u200d\ud83e\uddb3": "man_dark_skin_tone_white_hair",
-  "\ud83d\udc68\ud83c\udfff\u200d\ud83e\uddbc": "man_in_motorized_wheelchair_dark_skin_tone",
-  "\ud83d\udc68\ud83c\udfff\u200d\ud83e\uddbc\u200d\u27a1": "man_in_motorized_wheelchair_facing_right_dark_skin_tone",
-  "\ud83d\udc68\ud83c\udfff\u200d\ud83e\uddbc\u200d\u27a1\ufe0f": "man_in_motorized_wheelchair_facing_right_dark_skin_tone",
-  "\ud83d\udc68\ud83c\udfff\u200d\ud83e\uddbd": "man_in_manual_wheelchair_dark_skin_tone",
-  "\ud83d\udc68\ud83c\udfff\u200d\ud83e\uddbd\u200d\u27a1": "man_in_manual_wheelchair_facing_right_dark_skin_tone",
-  "\ud83d\udc68\ud83c\udfff\u200d\ud83e\uddbd\u200d\u27a1\ufe0f": "man_in_manual_wheelchair_facing_right_dark_skin_tone",
-  "\ud83d\udc69": "woman",
-  "\ud83d\udc69\u200d\u2695": "woman_health_worker",
-  "\ud83d\udc69\u200d\u2695\ufe0f": "woman_health_worker",
-  "\ud83d\udc69\u200d\u2696": "woman_judge",
-  "\ud83d\udc69\u200d\u2696\ufe0f": "woman_judge",
-  "\ud83d\udc69\u200d\u2708": "woman_pilot",
-  "\ud83d\udc69\u200d\u2708\ufe0f": "woman_pilot",
-  "\ud83d\udc69\u200d\u2764\u200d\ud83d\udc68": "couple_with_heart_woman_man",
-  "\ud83d\udc69\u200d\u2764\u200d\ud83d\udc69": "couple_with_heart_woman_woman",
-  "\ud83d\udc69\u200d\u2764\u200d\ud83d\udc8b\u200d\ud83d\udc68": "kiss_woman_man",
-  "\ud83d\udc69\u200d\u2764\u200d\ud83d\udc8b\u200d\ud83d\udc69": "kiss_woman_woman",
-  "\ud83d\udc69\u200d\u2764\ufe0f\u200d\ud83d\udc68": "couple_with_heart_woman_man",
-  "\ud83d\udc69\u200d\u2764\ufe0f\u200d\ud83d\udc69": "couple_with_heart_woman_woman",
-  "\ud83d\udc69\u200d\u2764\ufe0f\u200d\ud83d\udc8b\u200d\ud83d\udc68": "kiss_woman_man",
-  "\ud83d\udc69\u200d\u2764\ufe0f\u200d\ud83d\udc8b\u200d\ud83d\udc69": "kiss_woman_woman",
-  "\ud83d\udc69\u200d\ud83c\udf3e": "woman_farmer",
-  "\ud83d\udc69\u200d\ud83c\udf73": "woman_cook",
-  "\ud83d\udc69\u200d\ud83c\udf7c": "woman_feeding_baby",
-  "\ud83d\udc69\u200d\ud83c\udf93": "woman_student",
-  "\ud83d\udc69\u200d\ud83c\udfa4": "woman_singer",
-  "\ud83d\udc69\u200d\ud83c\udfa8": "woman_artist",
-  "\ud83d\udc69\u200d\ud83c\udfeb": "woman_teacher",
-  "\ud83d\udc69\u200d\ud83c\udfed": "woman_factory_worker",
-  "\ud83d\udc69\u200d\ud83d\udc66": "family_woman_boy",
-  "\ud83d\udc69\u200d\ud83d\udc66\u200d\ud83d\udc66": "family_woman_boy_boy",
-  "\ud83d\udc69\u200d\ud83d\udc67": "family_woman_girl",
-  "\ud83d\udc69\u200d\ud83d\udc67\u200d\ud83d\udc66": "family_woman_girl_boy",
-  "\ud83d\udc69\u200d\ud83d\udc67\u200d\ud83d\udc67": "family_woman_girl_girl",
-  "\ud83d\udc69\u200d\ud83d\udc69\u200d\ud83d\udc66": "family_woman_woman_boy",
-  "\ud83d\udc69\u200d\ud83d\udc69\u200d\ud83d\udc66\u200d\ud83d\udc66": "family_woman_woman_boy_boy",
-  "\ud83d\udc69\u200d\ud83d\udc69\u200d\ud83d\udc67": "family_woman_woman_girl",
-  "\ud83d\udc69\u200d\ud83d\udc69\u200d\ud83d\udc67\u200d\ud83d\udc66": "family_woman_woman_girl_boy",
-  "\ud83d\udc69\u200d\ud83d\udc69\u200d\ud83d\udc67\u200d\ud83d\udc67": "family_woman_woman_girl_girl",
-  "\ud83d\udc69\u200d\ud83d\udcbb": "woman_technologist",
-  "\ud83d\udc69\u200d\ud83d\udcbc": "woman_office_worker",
-  "\ud83d\udc69\u200d\ud83d\udd27": "woman_mechanic",
-  "\ud83d\udc69\u200d\ud83d\udd2c": "woman_scientist",
-  "\ud83d\udc69\u200d\ud83d\ude80": "woman_astronaut",
-  "\ud83d\udc69\u200d\ud83d\ude92": "woman_firefighter",
-  "\ud83d\udc69\u200d\ud83e\uddaf": "woman_with_white_cane",
-  "\ud83d\udc69\u200d\ud83e\uddaf\u200d\u27a1": "woman_with_white_cane_facing_right",
-  "\ud83d\udc69\u200d\ud83e\uddaf\u200d\u27a1\ufe0f": "woman_with_white_cane_facing_right",
-  "\ud83d\udc69\u200d\ud83e\uddb0": "woman_red_hair",
-  "\ud83d\udc69\u200d\ud83e\uddb1": "woman_curly_hair",
-  "\ud83d\udc69\u200d\ud83e\uddb2": "woman_bald",
-  "\ud83d\udc69\u200d\ud83e\uddb3": "woman_white_hair",
-  "\ud83d\udc69\u200d\ud83e\uddbc": "woman_in_motorized_wheelchair",
-  "\ud83d\udc69\u200d\ud83e\uddbc\u200d\u27a1": "woman_in_motorized_wheelchair_facing_right",
-  "\ud83d\udc69\u200d\ud83e\uddbc\u200d\u27a1\ufe0f": "woman_in_motorized_wheelchair_facing_right",
-  "\ud83d\udc69\u200d\ud83e\uddbd": "woman_in_manual_wheelchair",
-  "\ud83d\udc69\u200d\ud83e\uddbd\u200d\u27a1": "woman_in_manual_wheelchair_facing_right",
-  "\ud83d\udc69\u200d\ud83e\uddbd\u200d\u27a1\ufe0f": "woman_in_manual_wheelchair_facing_right",
-  "\ud83d\udc69\ud83c\udffb": "woman_light_skin_tone",
-  "\ud83d\udc69\ud83c\udffb\u200d\u2695": "woman_health_worker_light_skin_tone",
-  "\ud83d\udc69\ud83c\udffb\u200d\u2695\ufe0f": "woman_health_worker_light_skin_tone",
-  "\ud83d\udc69\ud83c\udffb\u200d\u2696": "woman_judge_light_skin_tone",
-  "\ud83d\udc69\ud83c\udffb\u200d\u2696\ufe0f": "woman_judge_light_skin_tone",
-  "\ud83d\udc69\ud83c\udffb\u200d\u2708": "woman_pilot_light_skin_tone",
-  "\ud83d\udc69\ud83c\udffb\u200d\u2708\ufe0f": "woman_pilot_light_skin_tone",
-  "\ud83d\udc69\ud83c\udffb\u200d\u2764\u200d\ud83d\udc68\ud83c\udffb": "couple_with_heart_woman_man_light_skin_tone",
-  "\ud83d\udc69\ud83c\udffb\u200d\u2764\u200d\ud83d\udc68\ud83c\udffc": "couple_with_heart_woman_man_light_skin_tone_medium-light_skin_tone",
-  "\ud83d\udc69\ud83c\udffb\u200d\u2764\u200d\ud83d\udc68\ud83c\udffd": "couple_with_heart_woman_man_light_skin_tone_medium_skin_tone",
-  "\ud83d\udc69\ud83c\udffb\u200d\u2764\u200d\ud83d\udc68\ud83c\udffe": "couple_with_heart_woman_man_light_skin_tone_medium-dark_skin_tone",
-  "\ud83d\udc69\ud83c\udffb\u200d\u2764\u200d\ud83d\udc68\ud83c\udfff": "couple_with_heart_woman_man_light_skin_tone_dark_skin_tone",
-  "\ud83d\udc69\ud83c\udffb\u200d\u2764\u200d\ud83d\udc69\ud83c\udffb": "couple_with_heart_woman_woman_light_skin_tone",
-  "\ud83d\udc69\ud83c\udffb\u200d\u2764\u200d\ud83d\udc69\ud83c\udffc": "couple_with_heart_woman_woman_light_skin_tone_medium-light_skin_tone",
-  "\ud83d\udc69\ud83c\udffb\u200d\u2764\u200d\ud83d\udc69\ud83c\udffd": "couple_with_heart_woman_woman_light_skin_tone_medium_skin_tone",
-  "\ud83d\udc69\ud83c\udffb\u200d\u2764\u200d\ud83d\udc69\ud83c\udffe": "couple_with_heart_woman_woman_light_skin_tone_medium-dark_skin_tone",
-  "\ud83d\udc69\ud83c\udffb\u200d\u2764\u200d\ud83d\udc69\ud83c\udfff": "couple_with_heart_woman_woman_light_skin_tone_dark_skin_tone",
-  "\ud83d\udc69\ud83c\udffb\u200d\u2764\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udffb": "kiss_woman_man_light_skin_tone",
-  "\ud83d\udc69\ud83c\udffb\u200d\u2764\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udffc": "kiss_woman_man_light_skin_tone_medium-light_skin_tone",
-  "\ud83d\udc69\ud83c\udffb\u200d\u2764\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udffd": "kiss_woman_man_light_skin_tone_medium_skin_tone",
-  "\ud83d\udc69\ud83c\udffb\u200d\u2764\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udffe": "kiss_woman_man_light_skin_tone_medium-dark_skin_tone",
-  "\ud83d\udc69\ud83c\udffb\u200d\u2764\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udfff": "kiss_woman_man_light_skin_tone_dark_skin_tone",
-  "\ud83d\udc69\ud83c\udffb\u200d\u2764\u200d\ud83d\udc8b\u200d\ud83d\udc69\ud83c\udffb": "kiss_woman_woman_light_skin_tone",
-  "\ud83d\udc69\ud83c\udffb\u200d\u2764\u200d\ud83d\udc8b\u200d\ud83d\udc69\ud83c\udffc": "kiss_woman_woman_light_skin_tone_medium-light_skin_tone",
-  "\ud83d\udc69\ud83c\udffb\u200d\u2764\u200d\ud83d\udc8b\u200d\ud83d\udc69\ud83c\udffd": "kiss_woman_woman_light_skin_tone_medium_skin_tone",
-  "\ud83d\udc69\ud83c\udffb\u200d\u2764\u200d\ud83d\udc8b\u200d\ud83d\udc69\ud83c\udffe": "kiss_woman_woman_light_skin_tone_medium-dark_skin_tone",
-  "\ud83d\udc69\ud83c\udffb\u200d\u2764\u200d\ud83d\udc8b\u200d\ud83d\udc69\ud83c\udfff": "kiss_woman_woman_light_skin_tone_dark_skin_tone",
-  "\ud83d\udc69\ud83c\udffb\u200d\u2764\ufe0f\u200d\ud83d\udc68\ud83c\udffb": "couple_with_heart_woman_man_light_skin_tone",
-  "\ud83d\udc69\ud83c\udffb\u200d\u2764\ufe0f\u200d\ud83d\udc68\ud83c\udffc": "couple_with_heart_woman_man_light_skin_tone_medium-light_skin_tone",
-  "\ud83d\udc69\ud83c\udffb\u200d\u2764\ufe0f\u200d\ud83d\udc68\ud83c\udffd": "couple_with_heart_woman_man_light_skin_tone_medium_skin_tone",
-  "\ud83d\udc69\ud83c\udffb\u200d\u2764\ufe0f\u200d\ud83d\udc68\ud83c\udffe": "couple_with_heart_woman_man_light_skin_tone_medium-dark_skin_tone",
-  "\ud83d\udc69\ud83c\udffb\u200d\u2764\ufe0f\u200d\ud83d\udc68\ud83c\udfff": "couple_with_heart_woman_man_light_skin_tone_dark_skin_tone",
-  "\ud83d\udc69\ud83c\udffb\u200d\u2764\ufe0f\u200d\ud83d\udc69\ud83c\udffb": "couple_with_heart_woman_woman_light_skin_tone",
-  "\ud83d\udc69\ud83c\udffb\u200d\u2764\ufe0f\u200d\ud83d\udc69\ud83c\udffc": "couple_with_heart_woman_woman_light_skin_tone_medium-light_skin_tone",
-  "\ud83d\udc69\ud83c\udffb\u200d\u2764\ufe0f\u200d\ud83d\udc69\ud83c\udffd": "couple_with_heart_woman_woman_light_skin_tone_medium_skin_tone",
-  "\ud83d\udc69\ud83c\udffb\u200d\u2764\ufe0f\u200d\ud83d\udc69\ud83c\udffe": "couple_with_heart_woman_woman_light_skin_tone_medium-dark_skin_tone",
-  "\ud83d\udc69\ud83c\udffb\u200d\u2764\ufe0f\u200d\ud83d\udc69\ud83c\udfff": "couple_with_heart_woman_woman_light_skin_tone_dark_skin_tone",
-  "\ud83d\udc69\ud83c\udffb\u200d\u2764\ufe0f\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udffb": "kiss_woman_man_light_skin_tone",
-  "\ud83d\udc69\ud83c\udffb\u200d\u2764\ufe0f\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udffc": "kiss_woman_man_light_skin_tone_medium-light_skin_tone",
-  "\ud83d\udc69\ud83c\udffb\u200d\u2764\ufe0f\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udffd": "kiss_woman_man_light_skin_tone_medium_skin_tone",
-  "\ud83d\udc69\ud83c\udffb\u200d\u2764\ufe0f\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udffe": "kiss_woman_man_light_skin_tone_medium-dark_skin_tone",
-  "\ud83d\udc69\ud83c\udffb\u200d\u2764\ufe0f\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udfff": "kiss_woman_man_light_skin_tone_dark_skin_tone",
-  "\ud83d\udc69\ud83c\udffb\u200d\u2764\ufe0f\u200d\ud83d\udc8b\u200d\ud83d\udc69\ud83c\udffb": "kiss_woman_woman_light_skin_tone",
-  "\ud83d\udc69\ud83c\udffb\u200d\u2764\ufe0f\u200d\ud83d\udc8b\u200d\ud83d\udc69\ud83c\udffc": "kiss_woman_woman_light_skin_tone_medium-light_skin_tone",
-  "\ud83d\udc69\ud83c\udffb\u200d\u2764\ufe0f\u200d\ud83d\udc8b\u200d\ud83d\udc69\ud83c\udffd": "kiss_woman_woman_light_skin_tone_medium_skin_tone",
-  "\ud83d\udc69\ud83c\udffb\u200d\u2764\ufe0f\u200d\ud83d\udc8b\u200d\ud83d\udc69\ud83c\udffe": "kiss_woman_woman_light_skin_tone_medium-dark_skin_tone",
-  "\ud83d\udc69\ud83c\udffb\u200d\u2764\ufe0f\u200d\ud83d\udc8b\u200d\ud83d\udc69\ud83c\udfff": "kiss_woman_woman_light_skin_tone_dark_skin_tone",
-  "\ud83d\udc69\ud83c\udffb\u200d\ud83c\udf3e": "woman_farmer_light_skin_tone",
-  "\ud83d\udc69\ud83c\udffb\u200d\ud83c\udf73": "woman_cook_light_skin_tone",
-  "\ud83d\udc69\ud83c\udffb\u200d\ud83c\udf7c": "woman_feeding_baby_light_skin_tone",
-  "\ud83d\udc69\ud83c\udffb\u200d\ud83c\udf93": "woman_student_light_skin_tone",
-  "\ud83d\udc69\ud83c\udffb\u200d\ud83c\udfa4": "woman_singer_light_skin_tone",
-  "\ud83d\udc69\ud83c\udffb\u200d\ud83c\udfa8": "woman_artist_light_skin_tone",
-  "\ud83d\udc69\ud83c\udffb\u200d\ud83c\udfeb": "woman_teacher_light_skin_tone",
-  "\ud83d\udc69\ud83c\udffb\u200d\ud83c\udfed": "woman_factory_worker_light_skin_tone",
-  "\ud83d\udc69\ud83c\udffb\u200d\ud83d\udcbb": "woman_technologist_light_skin_tone",
-  "\ud83d\udc69\ud83c\udffb\u200d\ud83d\udcbc": "woman_office_worker_light_skin_tone",
-  "\ud83d\udc69\ud83c\udffb\u200d\ud83d\udd27": "woman_mechanic_light_skin_tone",
-  "\ud83d\udc69\ud83c\udffb\u200d\ud83d\udd2c": "woman_scientist_light_skin_tone",
-  "\ud83d\udc69\ud83c\udffb\u200d\ud83d\ude80": "woman_astronaut_light_skin_tone",
-  "\ud83d\udc69\ud83c\udffb\u200d\ud83d\ude92": "woman_firefighter_light_skin_tone",
-  "\ud83d\udc69\ud83c\udffb\u200d\ud83e\udd1d\u200d\ud83d\udc68\ud83c\udffc": "woman_and_man_holding_hands_light_skin_tone_medium-light_skin_tone",
-  "\ud83d\udc69\ud83c\udffb\u200d\ud83e\udd1d\u200d\ud83d\udc68\ud83c\udffd": "woman_and_man_holding_hands_light_skin_tone_medium_skin_tone",
-  "\ud83d\udc69\ud83c\udffb\u200d\ud83e\udd1d\u200d\ud83d\udc68\ud83c\udffe": "woman_and_man_holding_hands_light_skin_tone_medium-dark_skin_tone",
-  "\ud83d\udc69\ud83c\udffb\u200d\ud83e\udd1d\u200d\ud83d\udc68\ud83c\udfff": "woman_and_man_holding_hands_light_skin_tone_dark_skin_tone",
-  "\ud83d\udc69\ud83c\udffb\u200d\ud83e\udd1d\u200d\ud83d\udc69\ud83c\udffc": "women_holding_hands_light_skin_tone_medium-light_skin_tone",
-  "\ud83d\udc69\ud83c\udffb\u200d\ud83e\udd1d\u200d\ud83d\udc69\ud83c\udffd": "women_holding_hands_light_skin_tone_medium_skin_tone",
-  "\ud83d\udc69\ud83c\udffb\u200d\ud83e\udd1d\u200d\ud83d\udc69\ud83c\udffe": "women_holding_hands_light_skin_tone_medium-dark_skin_tone",
-  "\ud83d\udc69\ud83c\udffb\u200d\ud83e\udd1d\u200d\ud83d\udc69\ud83c\udfff": "women_holding_hands_light_skin_tone_dark_skin_tone",
-  "\ud83d\udc69\ud83c\udffb\u200d\ud83e\uddaf": "woman_with_white_cane_light_skin_tone",
-  "\ud83d\udc69\ud83c\udffb\u200d\ud83e\uddaf\u200d\u27a1": "woman_with_white_cane_facing_right_light_skin_tone",
-  "\ud83d\udc69\ud83c\udffb\u200d\ud83e\uddaf\u200d\u27a1\ufe0f": "woman_with_white_cane_facing_right_light_skin_tone",
-  "\ud83d\udc69\ud83c\udffb\u200d\ud83e\uddb0": "woman_light_skin_tone_red_hair",
-  "\ud83d\udc69\ud83c\udffb\u200d\ud83e\uddb1": "woman_light_skin_tone_curly_hair",
-  "\ud83d\udc69\ud83c\udffb\u200d\ud83e\uddb2": "woman_light_skin_tone_bald",
-  "\ud83d\udc69\ud83c\udffb\u200d\ud83e\uddb3": "woman_light_skin_tone_white_hair",
-  "\ud83d\udc69\ud83c\udffb\u200d\ud83e\uddbc": "woman_in_motorized_wheelchair_light_skin_tone",
-  "\ud83d\udc69\ud83c\udffb\u200d\ud83e\uddbc\u200d\u27a1": "woman_in_motorized_wheelchair_facing_right_light_skin_tone",
-  "\ud83d\udc69\ud83c\udffb\u200d\ud83e\uddbc\u200d\u27a1\ufe0f": "woman_in_motorized_wheelchair_facing_right_light_skin_tone",
-  "\ud83d\udc69\ud83c\udffb\u200d\ud83e\uddbd": "woman_in_manual_wheelchair_light_skin_tone",
-  "\ud83d\udc69\ud83c\udffb\u200d\ud83e\uddbd\u200d\u27a1": "woman_in_manual_wheelchair_facing_right_light_skin_tone",
-  "\ud83d\udc69\ud83c\udffb\u200d\ud83e\uddbd\u200d\u27a1\ufe0f": "woman_in_manual_wheelchair_facing_right_light_skin_tone",
-  "\ud83d\udc69\ud83c\udffc": "woman_medium-light_skin_tone",
-  "\ud83d\udc69\ud83c\udffc\u200d\u2695": "woman_health_worker_medium-light_skin_tone",
-  "\ud83d\udc69\ud83c\udffc\u200d\u2695\ufe0f": "woman_health_worker_medium-light_skin_tone",
-  "\ud83d\udc69\ud83c\udffc\u200d\u2696": "woman_judge_medium-light_skin_tone",
-  "\ud83d\udc69\ud83c\udffc\u200d\u2696\ufe0f": "woman_judge_medium-light_skin_tone",
-  "\ud83d\udc69\ud83c\udffc\u200d\u2708": "woman_pilot_medium-light_skin_tone",
-  "\ud83d\udc69\ud83c\udffc\u200d\u2708\ufe0f": "woman_pilot_medium-light_skin_tone",
-  "\ud83d\udc69\ud83c\udffc\u200d\u2764\u200d\ud83d\udc68\ud83c\udffb": "couple_with_heart_woman_man_medium-light_skin_tone_light_skin_tone",
-  "\ud83d\udc69\ud83c\udffc\u200d\u2764\u200d\ud83d\udc68\ud83c\udffc": "couple_with_heart_woman_man_medium-light_skin_tone",
-  "\ud83d\udc69\ud83c\udffc\u200d\u2764\u200d\ud83d\udc68\ud83c\udffd": "couple_with_heart_woman_man_medium-light_skin_tone_medium_skin_tone",
-  "\ud83d\udc69\ud83c\udffc\u200d\u2764\u200d\ud83d\udc68\ud83c\udffe": "couple_with_heart_woman_man_medium-light_skin_tone_medium-dark_skin_tone",
-  "\ud83d\udc69\ud83c\udffc\u200d\u2764\u200d\ud83d\udc68\ud83c\udfff": "couple_with_heart_woman_man_medium-light_skin_tone_dark_skin_tone",
-  "\ud83d\udc69\ud83c\udffc\u200d\u2764\u200d\ud83d\udc69\ud83c\udffb": "couple_with_heart_woman_woman_medium-light_skin_tone_light_skin_tone",
-  "\ud83d\udc69\ud83c\udffc\u200d\u2764\u200d\ud83d\udc69\ud83c\udffc": "couple_with_heart_woman_woman_medium-light_skin_tone",
-  "\ud83d\udc69\ud83c\udffc\u200d\u2764\u200d\ud83d\udc69\ud83c\udffd": "couple_with_heart_woman_woman_medium-light_skin_tone_medium_skin_tone",
-  "\ud83d\udc69\ud83c\udffc\u200d\u2764\u200d\ud83d\udc69\ud83c\udffe": "couple_with_heart_woman_woman_medium-light_skin_tone_medium-dark_skin_tone",
-  "\ud83d\udc69\ud83c\udffc\u200d\u2764\u200d\ud83d\udc69\ud83c\udfff": "couple_with_heart_woman_woman_medium-light_skin_tone_dark_skin_tone",
-  "\ud83d\udc69\ud83c\udffc\u200d\u2764\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udffb": "kiss_woman_man_medium-light_skin_tone_light_skin_tone",
-  "\ud83d\udc69\ud83c\udffc\u200d\u2764\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udffc": "kiss_woman_man_medium-light_skin_tone",
-  "\ud83d\udc69\ud83c\udffc\u200d\u2764\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udffd": "kiss_woman_man_medium-light_skin_tone_medium_skin_tone",
-  "\ud83d\udc69\ud83c\udffc\u200d\u2764\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udffe": "kiss_woman_man_medium-light_skin_tone_medium-dark_skin_tone",
-  "\ud83d\udc69\ud83c\udffc\u200d\u2764\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udfff": "kiss_woman_man_medium-light_skin_tone_dark_skin_tone",
-  "\ud83d\udc69\ud83c\udffc\u200d\u2764\u200d\ud83d\udc8b\u200d\ud83d\udc69\ud83c\udffb": "kiss_woman_woman_medium-light_skin_tone_light_skin_tone",
-  "\ud83d\udc69\ud83c\udffc\u200d\u2764\u200d\ud83d\udc8b\u200d\ud83d\udc69\ud83c\udffc": "kiss_woman_woman_medium-light_skin_tone",
-  "\ud83d\udc69\ud83c\udffc\u200d\u2764\u200d\ud83d\udc8b\u200d\ud83d\udc69\ud83c\udffd": "kiss_woman_woman_medium-light_skin_tone_medium_skin_tone",
-  "\ud83d\udc69\ud83c\udffc\u200d\u2764\u200d\ud83d\udc8b\u200d\ud83d\udc69\ud83c\udffe": "kiss_woman_woman_medium-light_skin_tone_medium-dark_skin_tone",
-  "\ud83d\udc69\ud83c\udffc\u200d\u2764\u200d\ud83d\udc8b\u200d\ud83d\udc69\ud83c\udfff": "kiss_woman_woman_medium-light_skin_tone_dark_skin_tone",
-  "\ud83d\udc69\ud83c\udffc\u200d\u2764\ufe0f\u200d\ud83d\udc68\ud83c\udffb": "couple_with_heart_woman_man_medium-light_skin_tone_light_skin_tone",
-  "\ud83d\udc69\ud83c\udffc\u200d\u2764\ufe0f\u200d\ud83d\udc68\ud83c\udffc": "couple_with_heart_woman_man_medium-light_skin_tone",
-  "\ud83d\udc69\ud83c\udffc\u200d\u2764\ufe0f\u200d\ud83d\udc68\ud83c\udffd": "couple_with_heart_woman_man_medium-light_skin_tone_medium_skin_tone",
-  "\ud83d\udc69\ud83c\udffc\u200d\u2764\ufe0f\u200d\ud83d\udc68\ud83c\udffe": "couple_with_heart_woman_man_medium-light_skin_tone_medium-dark_skin_tone",
-  "\ud83d\udc69\ud83c\udffc\u200d\u2764\ufe0f\u200d\ud83d\udc68\ud83c\udfff": "couple_with_heart_woman_man_medium-light_skin_tone_dark_skin_tone",
-  "\ud83d\udc69\ud83c\udffc\u200d\u2764\ufe0f\u200d\ud83d\udc69\ud83c\udffb": "couple_with_heart_woman_woman_medium-light_skin_tone_light_skin_tone",
-  "\ud83d\udc69\ud83c\udffc\u200d\u2764\ufe0f\u200d\ud83d\udc69\ud83c\udffc": "couple_with_heart_woman_woman_medium-light_skin_tone",
-  "\ud83d\udc69\ud83c\udffc\u200d\u2764\ufe0f\u200d\ud83d\udc69\ud83c\udffd": "couple_with_heart_woman_woman_medium-light_skin_tone_medium_skin_tone",
-  "\ud83d\udc69\ud83c\udffc\u200d\u2764\ufe0f\u200d\ud83d\udc69\ud83c\udffe": "couple_with_heart_woman_woman_medium-light_skin_tone_medium-dark_skin_tone",
-  "\ud83d\udc69\ud83c\udffc\u200d\u2764\ufe0f\u200d\ud83d\udc69\ud83c\udfff": "couple_with_heart_woman_woman_medium-light_skin_tone_dark_skin_tone",
-  "\ud83d\udc69\ud83c\udffc\u200d\u2764\ufe0f\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udffb": "kiss_woman_man_medium-light_skin_tone_light_skin_tone",
-  "\ud83d\udc69\ud83c\udffc\u200d\u2764\ufe0f\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udffc": "kiss_woman_man_medium-light_skin_tone",
-  "\ud83d\udc69\ud83c\udffc\u200d\u2764\ufe0f\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udffd": "kiss_woman_man_medium-light_skin_tone_medium_skin_tone",
-  "\ud83d\udc69\ud83c\udffc\u200d\u2764\ufe0f\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udffe": "kiss_woman_man_medium-light_skin_tone_medium-dark_skin_tone",
-  "\ud83d\udc69\ud83c\udffc\u200d\u2764\ufe0f\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udfff": "kiss_woman_man_medium-light_skin_tone_dark_skin_tone",
-  "\ud83d\udc69\ud83c\udffc\u200d\u2764\ufe0f\u200d\ud83d\udc8b\u200d\ud83d\udc69\ud83c\udffb": "kiss_woman_woman_medium-light_skin_tone_light_skin_tone",
-  "\ud83d\udc69\ud83c\udffc\u200d\u2764\ufe0f\u200d\ud83d\udc8b\u200d\ud83d\udc69\ud83c\udffc": "kiss_woman_woman_medium-light_skin_tone",
-  "\ud83d\udc69\ud83c\udffc\u200d\u2764\ufe0f\u200d\ud83d\udc8b\u200d\ud83d\udc69\ud83c\udffd": "kiss_woman_woman_medium-light_skin_tone_medium_skin_tone",
-  "\ud83d\udc69\ud83c\udffc\u200d\u2764\ufe0f\u200d\ud83d\udc8b\u200d\ud83d\udc69\ud83c\udffe": "kiss_woman_woman_medium-light_skin_tone_medium-dark_skin_tone",
-  "\ud83d\udc69\ud83c\udffc\u200d\u2764\ufe0f\u200d\ud83d\udc8b\u200d\ud83d\udc69\ud83c\udfff": "kiss_woman_woman_medium-light_skin_tone_dark_skin_tone",
-  "\ud83d\udc69\ud83c\udffc\u200d\ud83c\udf3e": "woman_farmer_medium-light_skin_tone",
-  "\ud83d\udc69\ud83c\udffc\u200d\ud83c\udf73": "woman_cook_medium-light_skin_tone",
-  "\ud83d\udc69\ud83c\udffc\u200d\ud83c\udf7c": "woman_feeding_baby_medium-light_skin_tone",
-  "\ud83d\udc69\ud83c\udffc\u200d\ud83c\udf93": "woman_student_medium-light_skin_tone",
-  "\ud83d\udc69\ud83c\udffc\u200d\ud83c\udfa4": "woman_singer_medium-light_skin_tone",
-  "\ud83d\udc69\ud83c\udffc\u200d\ud83c\udfa8": "woman_artist_medium-light_skin_tone",
-  "\ud83d\udc69\ud83c\udffc\u200d\ud83c\udfeb": "woman_teacher_medium-light_skin_tone",
-  "\ud83d\udc69\ud83c\udffc\u200d\ud83c\udfed": "woman_factory_worker_medium-light_skin_tone",
-  "\ud83d\udc69\ud83c\udffc\u200d\ud83d\udcbb": "woman_technologist_medium-light_skin_tone",
-  "\ud83d\udc69\ud83c\udffc\u200d\ud83d\udcbc": "woman_office_worker_medium-light_skin_tone",
-  "\ud83d\udc69\ud83c\udffc\u200d\ud83d\udd27": "woman_mechanic_medium-light_skin_tone",
-  "\ud83d\udc69\ud83c\udffc\u200d\ud83d\udd2c": "woman_scientist_medium-light_skin_tone",
-  "\ud83d\udc69\ud83c\udffc\u200d\ud83d\ude80": "woman_astronaut_medium-light_skin_tone",
-  "\ud83d\udc69\ud83c\udffc\u200d\ud83d\ude92": "woman_firefighter_medium-light_skin_tone",
-  "\ud83d\udc69\ud83c\udffc\u200d\ud83e\udd1d\u200d\ud83d\udc68\ud83c\udffb": "woman_and_man_holding_hands_medium-light_skin_tone_light_skin_tone",
-  "\ud83d\udc69\ud83c\udffc\u200d\ud83e\udd1d\u200d\ud83d\udc68\ud83c\udffd": "woman_and_man_holding_hands_medium-light_skin_tone_medium_skin_tone",
-  "\ud83d\udc69\ud83c\udffc\u200d\ud83e\udd1d\u200d\ud83d\udc68\ud83c\udffe": "woman_and_man_holding_hands_medium-light_skin_tone_medium-dark_skin_tone",
-  "\ud83d\udc69\ud83c\udffc\u200d\ud83e\udd1d\u200d\ud83d\udc68\ud83c\udfff": "woman_and_man_holding_hands_medium-light_skin_tone_dark_skin_tone",
-  "\ud83d\udc69\ud83c\udffc\u200d\ud83e\udd1d\u200d\ud83d\udc69\ud83c\udffb": "women_holding_hands_medium-light_skin_tone_light_skin_tone",
-  "\ud83d\udc69\ud83c\udffc\u200d\ud83e\udd1d\u200d\ud83d\udc69\ud83c\udffd": "women_holding_hands_medium-light_skin_tone_medium_skin_tone",
-  "\ud83d\udc69\ud83c\udffc\u200d\ud83e\udd1d\u200d\ud83d\udc69\ud83c\udffe": "women_holding_hands_medium-light_skin_tone_medium-dark_skin_tone",
-  "\ud83d\udc69\ud83c\udffc\u200d\ud83e\udd1d\u200d\ud83d\udc69\ud83c\udfff": "women_holding_hands_medium-light_skin_tone_dark_skin_tone",
-  "\ud83d\udc69\ud83c\udffc\u200d\ud83e\uddaf": "woman_with_white_cane_medium-light_skin_tone",
-  "\ud83d\udc69\ud83c\udffc\u200d\ud83e\uddaf\u200d\u27a1": "woman_with_white_cane_facing_right_medium-light_skin_tone",
-  "\ud83d\udc69\ud83c\udffc\u200d\ud83e\uddaf\u200d\u27a1\ufe0f": "woman_with_white_cane_facing_right_medium-light_skin_tone",
-  "\ud83d\udc69\ud83c\udffc\u200d\ud83e\uddb0": "woman_medium-light_skin_tone_red_hair",
-  "\ud83d\udc69\ud83c\udffc\u200d\ud83e\uddb1": "woman_medium-light_skin_tone_curly_hair",
-  "\ud83d\udc69\ud83c\udffc\u200d\ud83e\uddb2": "woman_medium-light_skin_tone_bald",
-  "\ud83d\udc69\ud83c\udffc\u200d\ud83e\uddb3": "woman_medium-light_skin_tone_white_hair",
-  "\ud83d\udc69\ud83c\udffc\u200d\ud83e\uddbc": "woman_in_motorized_wheelchair_medium-light_skin_tone",
-  "\ud83d\udc69\ud83c\udffc\u200d\ud83e\uddbc\u200d\u27a1": "woman_in_motorized_wheelchair_facing_right_medium-light_skin_tone",
-  "\ud83d\udc69\ud83c\udffc\u200d\ud83e\uddbc\u200d\u27a1\ufe0f": "woman_in_motorized_wheelchair_facing_right_medium-light_skin_tone",
-  "\ud83d\udc69\ud83c\udffc\u200d\ud83e\uddbd": "woman_in_manual_wheelchair_medium-light_skin_tone",
-  "\ud83d\udc69\ud83c\udffc\u200d\ud83e\uddbd\u200d\u27a1": "woman_in_manual_wheelchair_facing_right_medium-light_skin_tone",
-  "\ud83d\udc69\ud83c\udffc\u200d\ud83e\uddbd\u200d\u27a1\ufe0f": "woman_in_manual_wheelchair_facing_right_medium-light_skin_tone",
-  "\ud83d\udc69\ud83c\udffd": "woman_medium_skin_tone",
-  "\ud83d\udc69\ud83c\udffd\u200d\u2695": "woman_health_worker_medium_skin_tone",
-  "\ud83d\udc69\ud83c\udffd\u200d\u2695\ufe0f": "woman_health_worker_medium_skin_tone",
-  "\ud83d\udc69\ud83c\udffd\u200d\u2696": "woman_judge_medium_skin_tone",
-  "\ud83d\udc69\ud83c\udffd\u200d\u2696\ufe0f": "woman_judge_medium_skin_tone",
-  "\ud83d\udc69\ud83c\udffd\u200d\u2708": "woman_pilot_medium_skin_tone",
-  "\ud83d\udc69\ud83c\udffd\u200d\u2708\ufe0f": "woman_pilot_medium_skin_tone",
-  "\ud83d\udc69\ud83c\udffd\u200d\u2764\u200d\ud83d\udc68\ud83c\udffb": "couple_with_heart_woman_man_medium_skin_tone_light_skin_tone",
-  "\ud83d\udc69\ud83c\udffd\u200d\u2764\u200d\ud83d\udc68\ud83c\udffc": "couple_with_heart_woman_man_medium_skin_tone_medium-light_skin_tone",
-  "\ud83d\udc69\ud83c\udffd\u200d\u2764\u200d\ud83d\udc68\ud83c\udffd": "couple_with_heart_woman_man_medium_skin_tone",
-  "\ud83d\udc69\ud83c\udffd\u200d\u2764\u200d\ud83d\udc68\ud83c\udffe": "couple_with_heart_woman_man_medium_skin_tone_medium-dark_skin_tone",
-  "\ud83d\udc69\ud83c\udffd\u200d\u2764\u200d\ud83d\udc68\ud83c\udfff": "couple_with_heart_woman_man_medium_skin_tone_dark_skin_tone",
-  "\ud83d\udc69\ud83c\udffd\u200d\u2764\u200d\ud83d\udc69\ud83c\udffb": "couple_with_heart_woman_woman_medium_skin_tone_light_skin_tone",
-  "\ud83d\udc69\ud83c\udffd\u200d\u2764\u200d\ud83d\udc69\ud83c\udffc": "couple_with_heart_woman_woman_medium_skin_tone_medium-light_skin_tone",
-  "\ud83d\udc69\ud83c\udffd\u200d\u2764\u200d\ud83d\udc69\ud83c\udffd": "couple_with_heart_woman_woman_medium_skin_tone",
-  "\ud83d\udc69\ud83c\udffd\u200d\u2764\u200d\ud83d\udc69\ud83c\udffe": "couple_with_heart_woman_woman_medium_skin_tone_medium-dark_skin_tone",
-  "\ud83d\udc69\ud83c\udffd\u200d\u2764\u200d\ud83d\udc69\ud83c\udfff": "couple_with_heart_woman_woman_medium_skin_tone_dark_skin_tone",
-  "\ud83d\udc69\ud83c\udffd\u200d\u2764\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udffb": "kiss_woman_man_medium_skin_tone_light_skin_tone",
-  "\ud83d\udc69\ud83c\udffd\u200d\u2764\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udffc": "kiss_woman_man_medium_skin_tone_medium-light_skin_tone",
-  "\ud83d\udc69\ud83c\udffd\u200d\u2764\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udffd": "kiss_woman_man_medium_skin_tone",
-  "\ud83d\udc69\ud83c\udffd\u200d\u2764\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udffe": "kiss_woman_man_medium_skin_tone_medium-dark_skin_tone",
-  "\ud83d\udc69\ud83c\udffd\u200d\u2764\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udfff": "kiss_woman_man_medium_skin_tone_dark_skin_tone",
-  "\ud83d\udc69\ud83c\udffd\u200d\u2764\u200d\ud83d\udc8b\u200d\ud83d\udc69\ud83c\udffb": "kiss_woman_woman_medium_skin_tone_light_skin_tone",
-  "\ud83d\udc69\ud83c\udffd\u200d\u2764\u200d\ud83d\udc8b\u200d\ud83d\udc69\ud83c\udffc": "kiss_woman_woman_medium_skin_tone_medium-light_skin_tone",
-  "\ud83d\udc69\ud83c\udffd\u200d\u2764\u200d\ud83d\udc8b\u200d\ud83d\udc69\ud83c\udffd": "kiss_woman_woman_medium_skin_tone",
-  "\ud83d\udc69\ud83c\udffd\u200d\u2764\u200d\ud83d\udc8b\u200d\ud83d\udc69\ud83c\udffe": "kiss_woman_woman_medium_skin_tone_medium-dark_skin_tone",
-  "\ud83d\udc69\ud83c\udffd\u200d\u2764\u200d\ud83d\udc8b\u200d\ud83d\udc69\ud83c\udfff": "kiss_woman_woman_medium_skin_tone_dark_skin_tone",
-  "\ud83d\udc69\ud83c\udffd\u200d\u2764\ufe0f\u200d\ud83d\udc68\ud83c\udffb": "couple_with_heart_woman_man_medium_skin_tone_light_skin_tone",
-  "\ud83d\udc69\ud83c\udffd\u200d\u2764\ufe0f\u200d\ud83d\udc68\ud83c\udffc": "couple_with_heart_woman_man_medium_skin_tone_medium-light_skin_tone",
-  "\ud83d\udc69\ud83c\udffd\u200d\u2764\ufe0f\u200d\ud83d\udc68\ud83c\udffd": "couple_with_heart_woman_man_medium_skin_tone",
-  "\ud83d\udc69\ud83c\udffd\u200d\u2764\ufe0f\u200d\ud83d\udc68\ud83c\udffe": "couple_with_heart_woman_man_medium_skin_tone_medium-dark_skin_tone",
-  "\ud83d\udc69\ud83c\udffd\u200d\u2764\ufe0f\u200d\ud83d\udc68\ud83c\udfff": "couple_with_heart_woman_man_medium_skin_tone_dark_skin_tone",
-  "\ud83d\udc69\ud83c\udffd\u200d\u2764\ufe0f\u200d\ud83d\udc69\ud83c\udffb": "couple_with_heart_woman_woman_medium_skin_tone_light_skin_tone",
-  "\ud83d\udc69\ud83c\udffd\u200d\u2764\ufe0f\u200d\ud83d\udc69\ud83c\udffc": "couple_with_heart_woman_woman_medium_skin_tone_medium-light_skin_tone",
-  "\ud83d\udc69\ud83c\udffd\u200d\u2764\ufe0f\u200d\ud83d\udc69\ud83c\udffd": "couple_with_heart_woman_woman_medium_skin_tone",
-  "\ud83d\udc69\ud83c\udffd\u200d\u2764\ufe0f\u200d\ud83d\udc69\ud83c\udffe": "couple_with_heart_woman_woman_medium_skin_tone_medium-dark_skin_tone",
-  "\ud83d\udc69\ud83c\udffd\u200d\u2764\ufe0f\u200d\ud83d\udc69\ud83c\udfff": "couple_with_heart_woman_woman_medium_skin_tone_dark_skin_tone",
-  "\ud83d\udc69\ud83c\udffd\u200d\u2764\ufe0f\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udffb": "kiss_woman_man_medium_skin_tone_light_skin_tone",
-  "\ud83d\udc69\ud83c\udffd\u200d\u2764\ufe0f\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udffc": "kiss_woman_man_medium_skin_tone_medium-light_skin_tone",
-  "\ud83d\udc69\ud83c\udffd\u200d\u2764\ufe0f\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udffd": "kiss_woman_man_medium_skin_tone",
-  "\ud83d\udc69\ud83c\udffd\u200d\u2764\ufe0f\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udffe": "kiss_woman_man_medium_skin_tone_medium-dark_skin_tone",
-  "\ud83d\udc69\ud83c\udffd\u200d\u2764\ufe0f\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udfff": "kiss_woman_man_medium_skin_tone_dark_skin_tone",
-  "\ud83d\udc69\ud83c\udffd\u200d\u2764\ufe0f\u200d\ud83d\udc8b\u200d\ud83d\udc69\ud83c\udffb": "kiss_woman_woman_medium_skin_tone_light_skin_tone",
-  "\ud83d\udc69\ud83c\udffd\u200d\u2764\ufe0f\u200d\ud83d\udc8b\u200d\ud83d\udc69\ud83c\udffc": "kiss_woman_woman_medium_skin_tone_medium-light_skin_tone",
-  "\ud83d\udc69\ud83c\udffd\u200d\u2764\ufe0f\u200d\ud83d\udc8b\u200d\ud83d\udc69\ud83c\udffd": "kiss_woman_woman_medium_skin_tone",
-  "\ud83d\udc69\ud83c\udffd\u200d\u2764\ufe0f\u200d\ud83d\udc8b\u200d\ud83d\udc69\ud83c\udffe": "kiss_woman_woman_medium_skin_tone_medium-dark_skin_tone",
-  "\ud83d\udc69\ud83c\udffd\u200d\u2764\ufe0f\u200d\ud83d\udc8b\u200d\ud83d\udc69\ud83c\udfff": "kiss_woman_woman_medium_skin_tone_dark_skin_tone",
-  "\ud83d\udc69\ud83c\udffd\u200d\ud83c\udf3e": "woman_farmer_medium_skin_tone",
-  "\ud83d\udc69\ud83c\udffd\u200d\ud83c\udf73": "woman_cook_medium_skin_tone",
-  "\ud83d\udc69\ud83c\udffd\u200d\ud83c\udf7c": "woman_feeding_baby_medium_skin_tone",
-  "\ud83d\udc69\ud83c\udffd\u200d\ud83c\udf93": "woman_student_medium_skin_tone",
-  "\ud83d\udc69\ud83c\udffd\u200d\ud83c\udfa4": "woman_singer_medium_skin_tone",
-  "\ud83d\udc69\ud83c\udffd\u200d\ud83c\udfa8": "woman_artist_medium_skin_tone",
-  "\ud83d\udc69\ud83c\udffd\u200d\ud83c\udfeb": "woman_teacher_medium_skin_tone",
-  "\ud83d\udc69\ud83c\udffd\u200d\ud83c\udfed": "woman_factory_worker_medium_skin_tone",
-  "\ud83d\udc69\ud83c\udffd\u200d\ud83d\udcbb": "woman_technologist_medium_skin_tone",
-  "\ud83d\udc69\ud83c\udffd\u200d\ud83d\udcbc": "woman_office_worker_medium_skin_tone",
-  "\ud83d\udc69\ud83c\udffd\u200d\ud83d\udd27": "woman_mechanic_medium_skin_tone",
-  "\ud83d\udc69\ud83c\udffd\u200d\ud83d\udd2c": "woman_scientist_medium_skin_tone",
-  "\ud83d\udc69\ud83c\udffd\u200d\ud83d\ude80": "woman_astronaut_medium_skin_tone",
-  "\ud83d\udc69\ud83c\udffd\u200d\ud83d\ude92": "woman_firefighter_medium_skin_tone",
-  "\ud83d\udc69\ud83c\udffd\u200d\ud83e\udd1d\u200d\ud83d\udc68\ud83c\udffb": "woman_and_man_holding_hands_medium_skin_tone_light_skin_tone",
-  "\ud83d\udc69\ud83c\udffd\u200d\ud83e\udd1d\u200d\ud83d\udc68\ud83c\udffc": "woman_and_man_holding_hands_medium_skin_tone_medium-light_skin_tone",
-  "\ud83d\udc69\ud83c\udffd\u200d\ud83e\udd1d\u200d\ud83d\udc68\ud83c\udffe": "woman_and_man_holding_hands_medium_skin_tone_medium-dark_skin_tone",
-  "\ud83d\udc69\ud83c\udffd\u200d\ud83e\udd1d\u200d\ud83d\udc68\ud83c\udfff": "woman_and_man_holding_hands_medium_skin_tone_dark_skin_tone",
-  "\ud83d\udc69\ud83c\udffd\u200d\ud83e\udd1d\u200d\ud83d\udc69\ud83c\udffb": "women_holding_hands_medium_skin_tone_light_skin_tone",
-  "\ud83d\udc69\ud83c\udffd\u200d\ud83e\udd1d\u200d\ud83d\udc69\ud83c\udffc": "women_holding_hands_medium_skin_tone_medium-light_skin_tone",
-  "\ud83d\udc69\ud83c\udffd\u200d\ud83e\udd1d\u200d\ud83d\udc69\ud83c\udffe": "women_holding_hands_medium_skin_tone_medium-dark_skin_tone",
-  "\ud83d\udc69\ud83c\udffd\u200d\ud83e\udd1d\u200d\ud83d\udc69\ud83c\udfff": "women_holding_hands_medium_skin_tone_dark_skin_tone",
-  "\ud83d\udc69\ud83c\udffd\u200d\ud83e\uddaf": "woman_with_white_cane_medium_skin_tone",
-  "\ud83d\udc69\ud83c\udffd\u200d\ud83e\uddaf\u200d\u27a1": "woman_with_white_cane_facing_right_medium_skin_tone",
-  "\ud83d\udc69\ud83c\udffd\u200d\ud83e\uddaf\u200d\u27a1\ufe0f": "woman_with_white_cane_facing_right_medium_skin_tone",
-  "\ud83d\udc69\ud83c\udffd\u200d\ud83e\uddb0": "woman_medium_skin_tone_red_hair",
-  "\ud83d\udc69\ud83c\udffd\u200d\ud83e\uddb1": "woman_medium_skin_tone_curly_hair",
-  "\ud83d\udc69\ud83c\udffd\u200d\ud83e\uddb2": "woman_medium_skin_tone_bald",
-  "\ud83d\udc69\ud83c\udffd\u200d\ud83e\uddb3": "woman_medium_skin_tone_white_hair",
-  "\ud83d\udc69\ud83c\udffd\u200d\ud83e\uddbc": "woman_in_motorized_wheelchair_medium_skin_tone",
-  "\ud83d\udc69\ud83c\udffd\u200d\ud83e\uddbc\u200d\u27a1": "woman_in_motorized_wheelchair_facing_right_medium_skin_tone",
-  "\ud83d\udc69\ud83c\udffd\u200d\ud83e\uddbc\u200d\u27a1\ufe0f": "woman_in_motorized_wheelchair_facing_right_medium_skin_tone",
-  "\ud83d\udc69\ud83c\udffd\u200d\ud83e\uddbd": "woman_in_manual_wheelchair_medium_skin_tone",
-  "\ud83d\udc69\ud83c\udffd\u200d\ud83e\uddbd\u200d\u27a1": "woman_in_manual_wheelchair_facing_right_medium_skin_tone",
-  "\ud83d\udc69\ud83c\udffd\u200d\ud83e\uddbd\u200d\u27a1\ufe0f": "woman_in_manual_wheelchair_facing_right_medium_skin_tone",
-  "\ud83d\udc69\ud83c\udffe": "woman_medium-dark_skin_tone",
-  "\ud83d\udc69\ud83c\udffe\u200d\u2695": "woman_health_worker_medium-dark_skin_tone",
-  "\ud83d\udc69\ud83c\udffe\u200d\u2695\ufe0f": "woman_health_worker_medium-dark_skin_tone",
-  "\ud83d\udc69\ud83c\udffe\u200d\u2696": "woman_judge_medium-dark_skin_tone",
-  "\ud83d\udc69\ud83c\udffe\u200d\u2696\ufe0f": "woman_judge_medium-dark_skin_tone",
-  "\ud83d\udc69\ud83c\udffe\u200d\u2708": "woman_pilot_medium-dark_skin_tone",
-  "\ud83d\udc69\ud83c\udffe\u200d\u2708\ufe0f": "woman_pilot_medium-dark_skin_tone",
-  "\ud83d\udc69\ud83c\udffe\u200d\u2764\u200d\ud83d\udc68\ud83c\udffb": "couple_with_heart_woman_man_medium-dark_skin_tone_light_skin_tone",
-  "\ud83d\udc69\ud83c\udffe\u200d\u2764\u200d\ud83d\udc68\ud83c\udffc": "couple_with_heart_woman_man_medium-dark_skin_tone_medium-light_skin_tone",
-  "\ud83d\udc69\ud83c\udffe\u200d\u2764\u200d\ud83d\udc68\ud83c\udffd": "couple_with_heart_woman_man_medium-dark_skin_tone_medium_skin_tone",
-  "\ud83d\udc69\ud83c\udffe\u200d\u2764\u200d\ud83d\udc68\ud83c\udffe": "couple_with_heart_woman_man_medium-dark_skin_tone",
-  "\ud83d\udc69\ud83c\udffe\u200d\u2764\u200d\ud83d\udc68\ud83c\udfff": "couple_with_heart_woman_man_medium-dark_skin_tone_dark_skin_tone",
-  "\ud83d\udc69\ud83c\udffe\u200d\u2764\u200d\ud83d\udc69\ud83c\udffb": "couple_with_heart_woman_woman_medium-dark_skin_tone_light_skin_tone",
-  "\ud83d\udc69\ud83c\udffe\u200d\u2764\u200d\ud83d\udc69\ud83c\udffc": "couple_with_heart_woman_woman_medium-dark_skin_tone_medium-light_skin_tone",
-  "\ud83d\udc69\ud83c\udffe\u200d\u2764\u200d\ud83d\udc69\ud83c\udffd": "couple_with_heart_woman_woman_medium-dark_skin_tone_medium_skin_tone",
-  "\ud83d\udc69\ud83c\udffe\u200d\u2764\u200d\ud83d\udc69\ud83c\udffe": "couple_with_heart_woman_woman_medium-dark_skin_tone",
-  "\ud83d\udc69\ud83c\udffe\u200d\u2764\u200d\ud83d\udc69\ud83c\udfff": "couple_with_heart_woman_woman_medium-dark_skin_tone_dark_skin_tone",
-  "\ud83d\udc69\ud83c\udffe\u200d\u2764\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udffb": "kiss_woman_man_medium-dark_skin_tone_light_skin_tone",
-  "\ud83d\udc69\ud83c\udffe\u200d\u2764\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udffc": "kiss_woman_man_medium-dark_skin_tone_medium-light_skin_tone",
-  "\ud83d\udc69\ud83c\udffe\u200d\u2764\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udffd": "kiss_woman_man_medium-dark_skin_tone_medium_skin_tone",
-  "\ud83d\udc69\ud83c\udffe\u200d\u2764\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udffe": "kiss_woman_man_medium-dark_skin_tone",
-  "\ud83d\udc69\ud83c\udffe\u200d\u2764\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udfff": "kiss_woman_man_medium-dark_skin_tone_dark_skin_tone",
-  "\ud83d\udc69\ud83c\udffe\u200d\u2764\u200d\ud83d\udc8b\u200d\ud83d\udc69\ud83c\udffb": "kiss_woman_woman_medium-dark_skin_tone_light_skin_tone",
-  "\ud83d\udc69\ud83c\udffe\u200d\u2764\u200d\ud83d\udc8b\u200d\ud83d\udc69\ud83c\udffc": "kiss_woman_woman_medium-dark_skin_tone_medium-light_skin_tone",
-  "\ud83d\udc69\ud83c\udffe\u200d\u2764\u200d\ud83d\udc8b\u200d\ud83d\udc69\ud83c\udffd": "kiss_woman_woman_medium-dark_skin_tone_medium_skin_tone",
-  "\ud83d\udc69\ud83c\udffe\u200d\u2764\u200d\ud83d\udc8b\u200d\ud83d\udc69\ud83c\udffe": "kiss_woman_woman_medium-dark_skin_tone",
-  "\ud83d\udc69\ud83c\udffe\u200d\u2764\u200d\ud83d\udc8b\u200d\ud83d\udc69\ud83c\udfff": "kiss_woman_woman_medium-dark_skin_tone_dark_skin_tone",
-  "\ud83d\udc69\ud83c\udffe\u200d\u2764\ufe0f\u200d\ud83d\udc68\ud83c\udffb": "couple_with_heart_woman_man_medium-dark_skin_tone_light_skin_tone",
-  "\ud83d\udc69\ud83c\udffe\u200d\u2764\ufe0f\u200d\ud83d\udc68\ud83c\udffc": "couple_with_heart_woman_man_medium-dark_skin_tone_medium-light_skin_tone",
-  "\ud83d\udc69\ud83c\udffe\u200d\u2764\ufe0f\u200d\ud83d\udc68\ud83c\udffd": "couple_with_heart_woman_man_medium-dark_skin_tone_medium_skin_tone",
-  "\ud83d\udc69\ud83c\udffe\u200d\u2764\ufe0f\u200d\ud83d\udc68\ud83c\udffe": "couple_with_heart_woman_man_medium-dark_skin_tone",
-  "\ud83d\udc69\ud83c\udffe\u200d\u2764\ufe0f\u200d\ud83d\udc68\ud83c\udfff": "couple_with_heart_woman_man_medium-dark_skin_tone_dark_skin_tone",
-  "\ud83d\udc69\ud83c\udffe\u200d\u2764\ufe0f\u200d\ud83d\udc69\ud83c\udffb": "couple_with_heart_woman_woman_medium-dark_skin_tone_light_skin_tone",
-  "\ud83d\udc69\ud83c\udffe\u200d\u2764\ufe0f\u200d\ud83d\udc69\ud83c\udffc": "couple_with_heart_woman_woman_medium-dark_skin_tone_medium-light_skin_tone",
-  "\ud83d\udc69\ud83c\udffe\u200d\u2764\ufe0f\u200d\ud83d\udc69\ud83c\udffd": "couple_with_heart_woman_woman_medium-dark_skin_tone_medium_skin_tone",
-  "\ud83d\udc69\ud83c\udffe\u200d\u2764\ufe0f\u200d\ud83d\udc69\ud83c\udffe": "couple_with_heart_woman_woman_medium-dark_skin_tone",
-  "\ud83d\udc69\ud83c\udffe\u200d\u2764\ufe0f\u200d\ud83d\udc69\ud83c\udfff": "couple_with_heart_woman_woman_medium-dark_skin_tone_dark_skin_tone",
-  "\ud83d\udc69\ud83c\udffe\u200d\u2764\ufe0f\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udffb": "kiss_woman_man_medium-dark_skin_tone_light_skin_tone",
-  "\ud83d\udc69\ud83c\udffe\u200d\u2764\ufe0f\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udffc": "kiss_woman_man_medium-dark_skin_tone_medium-light_skin_tone",
-  "\ud83d\udc69\ud83c\udffe\u200d\u2764\ufe0f\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udffd": "kiss_woman_man_medium-dark_skin_tone_medium_skin_tone",
-  "\ud83d\udc69\ud83c\udffe\u200d\u2764\ufe0f\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udffe": "kiss_woman_man_medium-dark_skin_tone",
-  "\ud83d\udc69\ud83c\udffe\u200d\u2764\ufe0f\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udfff": "kiss_woman_man_medium-dark_skin_tone_dark_skin_tone",
-  "\ud83d\udc69\ud83c\udffe\u200d\u2764\ufe0f\u200d\ud83d\udc8b\u200d\ud83d\udc69\ud83c\udffb": "kiss_woman_woman_medium-dark_skin_tone_light_skin_tone",
-  "\ud83d\udc69\ud83c\udffe\u200d\u2764\ufe0f\u200d\ud83d\udc8b\u200d\ud83d\udc69\ud83c\udffc": "kiss_woman_woman_medium-dark_skin_tone_medium-light_skin_tone",
-  "\ud83d\udc69\ud83c\udffe\u200d\u2764\ufe0f\u200d\ud83d\udc8b\u200d\ud83d\udc69\ud83c\udffd": "kiss_woman_woman_medium-dark_skin_tone_medium_skin_tone",
-  "\ud83d\udc69\ud83c\udffe\u200d\u2764\ufe0f\u200d\ud83d\udc8b\u200d\ud83d\udc69\ud83c\udffe": "kiss_woman_woman_medium-dark_skin_tone",
-  "\ud83d\udc69\ud83c\udffe\u200d\u2764\ufe0f\u200d\ud83d\udc8b\u200d\ud83d\udc69\ud83c\udfff": "kiss_woman_woman_medium-dark_skin_tone_dark_skin_tone",
-  "\ud83d\udc69\ud83c\udffe\u200d\ud83c\udf3e": "woman_farmer_medium-dark_skin_tone",
-  "\ud83d\udc69\ud83c\udffe\u200d\ud83c\udf73": "woman_cook_medium-dark_skin_tone",
-  "\ud83d\udc69\ud83c\udffe\u200d\ud83c\udf7c": "woman_feeding_baby_medium-dark_skin_tone",
-  "\ud83d\udc69\ud83c\udffe\u200d\ud83c\udf93": "woman_student_medium-dark_skin_tone",
-  "\ud83d\udc69\ud83c\udffe\u200d\ud83c\udfa4": "woman_singer_medium-dark_skin_tone",
-  "\ud83d\udc69\ud83c\udffe\u200d\ud83c\udfa8": "woman_artist_medium-dark_skin_tone",
-  "\ud83d\udc69\ud83c\udffe\u200d\ud83c\udfeb": "woman_teacher_medium-dark_skin_tone",
-  "\ud83d\udc69\ud83c\udffe\u200d\ud83c\udfed": "woman_factory_worker_medium-dark_skin_tone",
-  "\ud83d\udc69\ud83c\udffe\u200d\ud83d\udcbb": "woman_technologist_medium-dark_skin_tone",
-  "\ud83d\udc69\ud83c\udffe\u200d\ud83d\udcbc": "woman_office_worker_medium-dark_skin_tone",
-  "\ud83d\udc69\ud83c\udffe\u200d\ud83d\udd27": "woman_mechanic_medium-dark_skin_tone",
-  "\ud83d\udc69\ud83c\udffe\u200d\ud83d\udd2c": "woman_scientist_medium-dark_skin_tone",
-  "\ud83d\udc69\ud83c\udffe\u200d\ud83d\ude80": "woman_astronaut_medium-dark_skin_tone",
-  "\ud83d\udc69\ud83c\udffe\u200d\ud83d\ude92": "woman_firefighter_medium-dark_skin_tone",
-  "\ud83d\udc69\ud83c\udffe\u200d\ud83e\udd1d\u200d\ud83d\udc68\ud83c\udffb": "woman_and_man_holding_hands_medium-dark_skin_tone_light_skin_tone",
-  "\ud83d\udc69\ud83c\udffe\u200d\ud83e\udd1d\u200d\ud83d\udc68\ud83c\udffc": "woman_and_man_holding_hands_medium-dark_skin_tone_medium-light_skin_tone",
-  "\ud83d\udc69\ud83c\udffe\u200d\ud83e\udd1d\u200d\ud83d\udc68\ud83c\udffd": "woman_and_man_holding_hands_medium-dark_skin_tone_medium_skin_tone",
-  "\ud83d\udc69\ud83c\udffe\u200d\ud83e\udd1d\u200d\ud83d\udc68\ud83c\udfff": "woman_and_man_holding_hands_medium-dark_skin_tone_dark_skin_tone",
-  "\ud83d\udc69\ud83c\udffe\u200d\ud83e\udd1d\u200d\ud83d\udc69\ud83c\udffb": "women_holding_hands_medium-dark_skin_tone_light_skin_tone",
-  "\ud83d\udc69\ud83c\udffe\u200d\ud83e\udd1d\u200d\ud83d\udc69\ud83c\udffc": "women_holding_hands_medium-dark_skin_tone_medium-light_skin_tone",
-  "\ud83d\udc69\ud83c\udffe\u200d\ud83e\udd1d\u200d\ud83d\udc69\ud83c\udffd": "women_holding_hands_medium-dark_skin_tone_medium_skin_tone",
-  "\ud83d\udc69\ud83c\udffe\u200d\ud83e\udd1d\u200d\ud83d\udc69\ud83c\udfff": "women_holding_hands_medium-dark_skin_tone_dark_skin_tone",
-  "\ud83d\udc69\ud83c\udffe\u200d\ud83e\uddaf": "woman_with_white_cane_medium-dark_skin_tone",
-  "\ud83d\udc69\ud83c\udffe\u200d\ud83e\uddaf\u200d\u27a1": "woman_with_white_cane_facing_right_medium-dark_skin_tone",
-  "\ud83d\udc69\ud83c\udffe\u200d\ud83e\uddaf\u200d\u27a1\ufe0f": "woman_with_white_cane_facing_right_medium-dark_skin_tone",
-  "\ud83d\udc69\ud83c\udffe\u200d\ud83e\uddb0": "woman_medium-dark_skin_tone_red_hair",
-  "\ud83d\udc69\ud83c\udffe\u200d\ud83e\uddb1": "woman_medium-dark_skin_tone_curly_hair",
-  "\ud83d\udc69\ud83c\udffe\u200d\ud83e\uddb2": "woman_medium-dark_skin_tone_bald",
-  "\ud83d\udc69\ud83c\udffe\u200d\ud83e\uddb3": "woman_medium-dark_skin_tone_white_hair",
-  "\ud83d\udc69\ud83c\udffe\u200d\ud83e\uddbc": "woman_in_motorized_wheelchair_medium-dark_skin_tone",
-  "\ud83d\udc69\ud83c\udffe\u200d\ud83e\uddbc\u200d\u27a1": "woman_in_motorized_wheelchair_facing_right_medium-dark_skin_tone",
-  "\ud83d\udc69\ud83c\udffe\u200d\ud83e\uddbc\u200d\u27a1\ufe0f": "woman_in_motorized_wheelchair_facing_right_medium-dark_skin_tone",
-  "\ud83d\udc69\ud83c\udffe\u200d\ud83e\uddbd": "woman_in_manual_wheelchair_medium-dark_skin_tone",
-  "\ud83d\udc69\ud83c\udffe\u200d\ud83e\uddbd\u200d\u27a1": "woman_in_manual_wheelchair_facing_right_medium-dark_skin_tone",
-  "\ud83d\udc69\ud83c\udffe\u200d\ud83e\uddbd\u200d\u27a1\ufe0f": "woman_in_manual_wheelchair_facing_right_medium-dark_skin_tone",
-  "\ud83d\udc69\ud83c\udfff": "woman_dark_skin_tone",
-  "\ud83d\udc69\ud83c\udfff\u200d\u2695": "woman_health_worker_dark_skin_tone",
-  "\ud83d\udc69\ud83c\udfff\u200d\u2695\ufe0f": "woman_health_worker_dark_skin_tone",
-  "\ud83d\udc69\ud83c\udfff\u200d\u2696": "woman_judge_dark_skin_tone",
-  "\ud83d\udc69\ud83c\udfff\u200d\u2696\ufe0f": "woman_judge_dark_skin_tone",
-  "\ud83d\udc69\ud83c\udfff\u200d\u2708": "woman_pilot_dark_skin_tone",
-  "\ud83d\udc69\ud83c\udfff\u200d\u2708\ufe0f": "woman_pilot_dark_skin_tone",
-  "\ud83d\udc69\ud83c\udfff\u200d\u2764\u200d\ud83d\udc68\ud83c\udffb": "couple_with_heart_woman_man_dark_skin_tone_light_skin_tone",
-  "\ud83d\udc69\ud83c\udfff\u200d\u2764\u200d\ud83d\udc68\ud83c\udffc": "couple_with_heart_woman_man_dark_skin_tone_medium-light_skin_tone",
-  "\ud83d\udc69\ud83c\udfff\u200d\u2764\u200d\ud83d\udc68\ud83c\udffd": "couple_with_heart_woman_man_dark_skin_tone_medium_skin_tone",
-  "\ud83d\udc69\ud83c\udfff\u200d\u2764\u200d\ud83d\udc68\ud83c\udffe": "couple_with_heart_woman_man_dark_skin_tone_medium-dark_skin_tone",
-  "\ud83d\udc69\ud83c\udfff\u200d\u2764\u200d\ud83d\udc68\ud83c\udfff": "couple_with_heart_woman_man_dark_skin_tone",
-  "\ud83d\udc69\ud83c\udfff\u200d\u2764\u200d\ud83d\udc69\ud83c\udffb": "couple_with_heart_woman_woman_dark_skin_tone_light_skin_tone",
-  "\ud83d\udc69\ud83c\udfff\u200d\u2764\u200d\ud83d\udc69\ud83c\udffc": "couple_with_heart_woman_woman_dark_skin_tone_medium-light_skin_tone",
-  "\ud83d\udc69\ud83c\udfff\u200d\u2764\u200d\ud83d\udc69\ud83c\udffd": "couple_with_heart_woman_woman_dark_skin_tone_medium_skin_tone",
-  "\ud83d\udc69\ud83c\udfff\u200d\u2764\u200d\ud83d\udc69\ud83c\udffe": "couple_with_heart_woman_woman_dark_skin_tone_medium-dark_skin_tone",
-  "\ud83d\udc69\ud83c\udfff\u200d\u2764\u200d\ud83d\udc69\ud83c\udfff": "couple_with_heart_woman_woman_dark_skin_tone",
-  "\ud83d\udc69\ud83c\udfff\u200d\u2764\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udffb": "kiss_woman_man_dark_skin_tone_light_skin_tone",
-  "\ud83d\udc69\ud83c\udfff\u200d\u2764\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udffc": "kiss_woman_man_dark_skin_tone_medium-light_skin_tone",
-  "\ud83d\udc69\ud83c\udfff\u200d\u2764\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udffd": "kiss_woman_man_dark_skin_tone_medium_skin_tone",
-  "\ud83d\udc69\ud83c\udfff\u200d\u2764\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udffe": "kiss_woman_man_dark_skin_tone_medium-dark_skin_tone",
-  "\ud83d\udc69\ud83c\udfff\u200d\u2764\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udfff": "kiss_woman_man_dark_skin_tone",
-  "\ud83d\udc69\ud83c\udfff\u200d\u2764\u200d\ud83d\udc8b\u200d\ud83d\udc69\ud83c\udffb": "kiss_woman_woman_dark_skin_tone_light_skin_tone",
-  "\ud83d\udc69\ud83c\udfff\u200d\u2764\u200d\ud83d\udc8b\u200d\ud83d\udc69\ud83c\udffc": "kiss_woman_woman_dark_skin_tone_medium-light_skin_tone",
-  "\ud83d\udc69\ud83c\udfff\u200d\u2764\u200d\ud83d\udc8b\u200d\ud83d\udc69\ud83c\udffd": "kiss_woman_woman_dark_skin_tone_medium_skin_tone",
-  "\ud83d\udc69\ud83c\udfff\u200d\u2764\u200d\ud83d\udc8b\u200d\ud83d\udc69\ud83c\udffe": "kiss_woman_woman_dark_skin_tone_medium-dark_skin_tone",
-  "\ud83d\udc69\ud83c\udfff\u200d\u2764\u200d\ud83d\udc8b\u200d\ud83d\udc69\ud83c\udfff": "kiss_woman_woman_dark_skin_tone",
-  "\ud83d\udc69\ud83c\udfff\u200d\u2764\ufe0f\u200d\ud83d\udc68\ud83c\udffb": "couple_with_heart_woman_man_dark_skin_tone_light_skin_tone",
-  "\ud83d\udc69\ud83c\udfff\u200d\u2764\ufe0f\u200d\ud83d\udc68\ud83c\udffc": "couple_with_heart_woman_man_dark_skin_tone_medium-light_skin_tone",
-  "\ud83d\udc69\ud83c\udfff\u200d\u2764\ufe0f\u200d\ud83d\udc68\ud83c\udffd": "couple_with_heart_woman_man_dark_skin_tone_medium_skin_tone",
-  "\ud83d\udc69\ud83c\udfff\u200d\u2764\ufe0f\u200d\ud83d\udc68\ud83c\udffe": "couple_with_heart_woman_man_dark_skin_tone_medium-dark_skin_tone",
-  "\ud83d\udc69\ud83c\udfff\u200d\u2764\ufe0f\u200d\ud83d\udc68\ud83c\udfff": "couple_with_heart_woman_man_dark_skin_tone",
-  "\ud83d\udc69\ud83c\udfff\u200d\u2764\ufe0f\u200d\ud83d\udc69\ud83c\udffb": "couple_with_heart_woman_woman_dark_skin_tone_light_skin_tone",
-  "\ud83d\udc69\ud83c\udfff\u200d\u2764\ufe0f\u200d\ud83d\udc69\ud83c\udffc": "couple_with_heart_woman_woman_dark_skin_tone_medium-light_skin_tone",
-  "\ud83d\udc69\ud83c\udfff\u200d\u2764\ufe0f\u200d\ud83d\udc69\ud83c\udffd": "couple_with_heart_woman_woman_dark_skin_tone_medium_skin_tone",
-  "\ud83d\udc69\ud83c\udfff\u200d\u2764\ufe0f\u200d\ud83d\udc69\ud83c\udffe": "couple_with_heart_woman_woman_dark_skin_tone_medium-dark_skin_tone",
-  "\ud83d\udc69\ud83c\udfff\u200d\u2764\ufe0f\u200d\ud83d\udc69\ud83c\udfff": "couple_with_heart_woman_woman_dark_skin_tone",
-  "\ud83d\udc69\ud83c\udfff\u200d\u2764\ufe0f\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udffb": "kiss_woman_man_dark_skin_tone_light_skin_tone",
-  "\ud83d\udc69\ud83c\udfff\u200d\u2764\ufe0f\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udffc": "kiss_woman_man_dark_skin_tone_medium-light_skin_tone",
-  "\ud83d\udc69\ud83c\udfff\u200d\u2764\ufe0f\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udffd": "kiss_woman_man_dark_skin_tone_medium_skin_tone",
-  "\ud83d\udc69\ud83c\udfff\u200d\u2764\ufe0f\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udffe": "kiss_woman_man_dark_skin_tone_medium-dark_skin_tone",
-  "\ud83d\udc69\ud83c\udfff\u200d\u2764\ufe0f\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udfff": "kiss_woman_man_dark_skin_tone",
-  "\ud83d\udc69\ud83c\udfff\u200d\u2764\ufe0f\u200d\ud83d\udc8b\u200d\ud83d\udc69\ud83c\udffb": "kiss_woman_woman_dark_skin_tone_light_skin_tone",
-  "\ud83d\udc69\ud83c\udfff\u200d\u2764\ufe0f\u200d\ud83d\udc8b\u200d\ud83d\udc69\ud83c\udffc": "kiss_woman_woman_dark_skin_tone_medium-light_skin_tone",
-  "\ud83d\udc69\ud83c\udfff\u200d\u2764\ufe0f\u200d\ud83d\udc8b\u200d\ud83d\udc69\ud83c\udffd": "kiss_woman_woman_dark_skin_tone_medium_skin_tone",
-  "\ud83d\udc69\ud83c\udfff\u200d\u2764\ufe0f\u200d\ud83d\udc8b\u200d\ud83d\udc69\ud83c\udffe": "kiss_woman_woman_dark_skin_tone_medium-dark_skin_tone",
-  "\ud83d\udc69\ud83c\udfff\u200d\u2764\ufe0f\u200d\ud83d\udc8b\u200d\ud83d\udc69\ud83c\udfff": "kiss_woman_woman_dark_skin_tone",
-  "\ud83d\udc69\ud83c\udfff\u200d\ud83c\udf3e": "woman_farmer_dark_skin_tone",
-  "\ud83d\udc69\ud83c\udfff\u200d\ud83c\udf73": "woman_cook_dark_skin_tone",
-  "\ud83d\udc69\ud83c\udfff\u200d\ud83c\udf7c": "woman_feeding_baby_dark_skin_tone",
-  "\ud83d\udc69\ud83c\udfff\u200d\ud83c\udf93": "woman_student_dark_skin_tone",
-  "\ud83d\udc69\ud83c\udfff\u200d\ud83c\udfa4": "woman_singer_dark_skin_tone",
-  "\ud83d\udc69\ud83c\udfff\u200d\ud83c\udfa8": "woman_artist_dark_skin_tone",
-  "\ud83d\udc69\ud83c\udfff\u200d\ud83c\udfeb": "woman_teacher_dark_skin_tone",
-  "\ud83d\udc69\ud83c\udfff\u200d\ud83c\udfed": "woman_factory_worker_dark_skin_tone",
-  "\ud83d\udc69\ud83c\udfff\u200d\ud83d\udcbb": "woman_technologist_dark_skin_tone",
-  "\ud83d\udc69\ud83c\udfff\u200d\ud83d\udcbc": "woman_office_worker_dark_skin_tone",
-  "\ud83d\udc69\ud83c\udfff\u200d\ud83d\udd27": "woman_mechanic_dark_skin_tone",
-  "\ud83d\udc69\ud83c\udfff\u200d\ud83d\udd2c": "woman_scientist_dark_skin_tone",
-  "\ud83d\udc69\ud83c\udfff\u200d\ud83d\ude80": "woman_astronaut_dark_skin_tone",
-  "\ud83d\udc69\ud83c\udfff\u200d\ud83d\ude92": "woman_firefighter_dark_skin_tone",
-  "\ud83d\udc69\ud83c\udfff\u200d\ud83e\udd1d\u200d\ud83d\udc68\ud83c\udffb": "woman_and_man_holding_hands_dark_skin_tone_light_skin_tone",
-  "\ud83d\udc69\ud83c\udfff\u200d\ud83e\udd1d\u200d\ud83d\udc68\ud83c\udffc": "woman_and_man_holding_hands_dark_skin_tone_medium-light_skin_tone",
-  "\ud83d\udc69\ud83c\udfff\u200d\ud83e\udd1d\u200d\ud83d\udc68\ud83c\udffd": "woman_and_man_holding_hands_dark_skin_tone_medium_skin_tone",
-  "\ud83d\udc69\ud83c\udfff\u200d\ud83e\udd1d\u200d\ud83d\udc68\ud83c\udffe": "woman_and_man_holding_hands_dark_skin_tone_medium-dark_skin_tone",
-  "\ud83d\udc69\ud83c\udfff\u200d\ud83e\udd1d\u200d\ud83d\udc69\ud83c\udffb": "women_holding_hands_dark_skin_tone_light_skin_tone",
-  "\ud83d\udc69\ud83c\udfff\u200d\ud83e\udd1d\u200d\ud83d\udc69\ud83c\udffc": "women_holding_hands_dark_skin_tone_medium-light_skin_tone",
-  "\ud83d\udc69\ud83c\udfff\u200d\ud83e\udd1d\u200d\ud83d\udc69\ud83c\udffd": "women_holding_hands_dark_skin_tone_medium_skin_tone",
-  "\ud83d\udc69\ud83c\udfff\u200d\ud83e\udd1d\u200d\ud83d\udc69\ud83c\udffe": "women_holding_hands_dark_skin_tone_medium-dark_skin_tone",
-  "\ud83d\udc69\ud83c\udfff\u200d\ud83e\uddaf": "woman_with_white_cane_dark_skin_tone",
-  "\ud83d\udc69\ud83c\udfff\u200d\ud83e\uddaf\u200d\u27a1": "woman_with_white_cane_facing_right_dark_skin_tone",
-  "\ud83d\udc69\ud83c\udfff\u200d\ud83e\uddaf\u200d\u27a1\ufe0f": "woman_with_white_cane_facing_right_dark_skin_tone",
-  "\ud83d\udc69\ud83c\udfff\u200d\ud83e\uddb0": "woman_dark_skin_tone_red_hair",
-  "\ud83d\udc69\ud83c\udfff\u200d\ud83e\uddb1": "woman_dark_skin_tone_curly_hair",
-  "\ud83d\udc69\ud83c\udfff\u200d\ud83e\uddb2": "woman_dark_skin_tone_bald",
-  "\ud83d\udc69\ud83c\udfff\u200d\ud83e\uddb3": "woman_dark_skin_tone_white_hair",
-  "\ud83d\udc69\ud83c\udfff\u200d\ud83e\uddbc": "woman_in_motorized_wheelchair_dark_skin_tone",
-  "\ud83d\udc69\ud83c\udfff\u200d\ud83e\uddbc\u200d\u27a1": "woman_in_motorized_wheelchair_facing_right_dark_skin_tone",
-  "\ud83d\udc69\ud83c\udfff\u200d\ud83e\uddbc\u200d\u27a1\ufe0f": "woman_in_motorized_wheelchair_facing_right_dark_skin_tone",
-  "\ud83d\udc69\ud83c\udfff\u200d\ud83e\uddbd": "woman_in_manual_wheelchair_dark_skin_tone",
-  "\ud83d\udc69\ud83c\udfff\u200d\ud83e\uddbd\u200d\u27a1": "woman_in_manual_wheelchair_facing_right_dark_skin_tone",
-  "\ud83d\udc69\ud83c\udfff\u200d\ud83e\uddbd\u200d\u27a1\ufe0f": "woman_in_manual_wheelchair_facing_right_dark_skin_tone",
-  "\ud83d\udc6a": "family",
-  "\ud83d\udc6b": "woman_and_man_holding_hands",
-  "\ud83d\udc6b\ud83c\udffb": "woman_and_man_holding_hands_light_skin_tone",
-  "\ud83d\udc6b\ud83c\udffc": "woman_and_man_holding_hands_medium-light_skin_tone",
-  "\ud83d\udc6b\ud83c\udffd": "woman_and_man_holding_hands_medium_skin_tone",
-  "\ud83d\udc6b\ud83c\udffe": "woman_and_man_holding_hands_medium-dark_skin_tone",
-  "\ud83d\udc6b\ud83c\udfff": "woman_and_man_holding_hands_dark_skin_tone",
-  "\ud83d\udc6c": "men_holding_hands",
-  "\ud83d\udc6c\ud83c\udffb": "men_holding_hands_light_skin_tone",
-  "\ud83d\udc6c\ud83c\udffc": "men_holding_hands_medium-light_skin_tone",
-  "\ud83d\udc6c\ud83c\udffd": "men_holding_hands_medium_skin_tone",
-  "\ud83d\udc6c\ud83c\udffe": "men_holding_hands_medium-dark_skin_tone",
-  "\ud83d\udc6c\ud83c\udfff": "men_holding_hands_dark_skin_tone",
-  "\ud83d\udc6d": "women_holding_hands",
-  "\ud83d\udc6d\ud83c\udffb": "women_holding_hands_light_skin_tone",
-  "\ud83d\udc6d\ud83c\udffc": "women_holding_hands_medium-light_skin_tone",
-  "\ud83d\udc6d\ud83c\udffd": "women_holding_hands_medium_skin_tone",
-  "\ud83d\udc6d\ud83c\udffe": "women_holding_hands_medium-dark_skin_tone",
-  "\ud83d\udc6d\ud83c\udfff": "women_holding_hands_dark_skin_tone",
-  "\ud83d\udc6e": "police_officer",
-  "\ud83d\udc6e\u200d\u2640": "woman_police_officer",
-  "\ud83d\udc6e\u200d\u2640\ufe0f": "woman_police_officer",
-  "\ud83d\udc6e\u200d\u2642": "man_police_officer",
-  "\ud83d\udc6e\u200d\u2642\ufe0f": "man_police_officer",
-  "\ud83d\udc6e\ud83c\udffb": "police_officer_light_skin_tone",
-  "\ud83d\udc6e\ud83c\udffb\u200d\u2640": "woman_police_officer_light_skin_tone",
-  "\ud83d\udc6e\ud83c\udffb\u200d\u2640\ufe0f": "woman_police_officer_light_skin_tone",
-  "\ud83d\udc6e\ud83c\udffb\u200d\u2642": "man_police_officer_light_skin_tone",
-  "\ud83d\udc6e\ud83c\udffb\u200d\u2642\ufe0f": "man_police_officer_light_skin_tone",
-  "\ud83d\udc6e\ud83c\udffc": "police_officer_medium-light_skin_tone",
-  "\ud83d\udc6e\ud83c\udffc\u200d\u2640": "woman_police_officer_medium-light_skin_tone",
-  "\ud83d\udc6e\ud83c\udffc\u200d\u2640\ufe0f": "woman_police_officer_medium-light_skin_tone",
-  "\ud83d\udc6e\ud83c\udffc\u200d\u2642": "man_police_officer_medium-light_skin_tone",
-  "\ud83d\udc6e\ud83c\udffc\u200d\u2642\ufe0f": "man_police_officer_medium-light_skin_tone",
-  "\ud83d\udc6e\ud83c\udffd": "police_officer_medium_skin_tone",
-  "\ud83d\udc6e\ud83c\udffd\u200d\u2640": "woman_police_officer_medium_skin_tone",
-  "\ud83d\udc6e\ud83c\udffd\u200d\u2640\ufe0f": "woman_police_officer_medium_skin_tone",
-  "\ud83d\udc6e\ud83c\udffd\u200d\u2642": "man_police_officer_medium_skin_tone",
-  "\ud83d\udc6e\ud83c\udffd\u200d\u2642\ufe0f": "man_police_officer_medium_skin_tone",
-  "\ud83d\udc6e\ud83c\udffe": "police_officer_medium-dark_skin_tone",
-  "\ud83d\udc6e\ud83c\udffe\u200d\u2640": "woman_police_officer_medium-dark_skin_tone",
-  "\ud83d\udc6e\ud83c\udffe\u200d\u2640\ufe0f": "woman_police_officer_medium-dark_skin_tone",
-  "\ud83d\udc6e\ud83c\udffe\u200d\u2642": "man_police_officer_medium-dark_skin_tone",
-  "\ud83d\udc6e\ud83c\udffe\u200d\u2642\ufe0f": "man_police_officer_medium-dark_skin_tone",
-  "\ud83d\udc6e\ud83c\udfff": "police_officer_dark_skin_tone",
-  "\ud83d\udc6e\ud83c\udfff\u200d\u2640": "woman_police_officer_dark_skin_tone",
-  "\ud83d\udc6e\ud83c\udfff\u200d\u2640\ufe0f": "woman_police_officer_dark_skin_tone",
-  "\ud83d\udc6e\ud83c\udfff\u200d\u2642": "man_police_officer_dark_skin_tone",
-  "\ud83d\udc6e\ud83c\udfff\u200d\u2642\ufe0f": "man_police_officer_dark_skin_tone",
-  "\ud83d\udc6f": "people_with_bunny_ears",
-  "\ud83d\udc6f\u200d\u2640": "women_with_bunny_ears",
-  "\ud83d\udc6f\u200d\u2640\ufe0f": "women_with_bunny_ears",
-  "\ud83d\udc6f\u200d\u2642": "men_with_bunny_ears",
-  "\ud83d\udc6f\u200d\u2642\ufe0f": "men_with_bunny_ears",
-  "\ud83d\udc70": "person_with_veil",
-  "\ud83d\udc70\u200d\u2640": "woman_with_veil",
-  "\ud83d\udc70\u200d\u2640\ufe0f": "woman_with_veil",
-  "\ud83d\udc70\u200d\u2642": "man_with_veil",
-  "\ud83d\udc70\u200d\u2642\ufe0f": "man_with_veil",
-  "\ud83d\udc70\ud83c\udffb": "person_with_veil_light_skin_tone",
-  "\ud83d\udc70\ud83c\udffb\u200d\u2640": "woman_with_veil_light_skin_tone",
-  "\ud83d\udc70\ud83c\udffb\u200d\u2640\ufe0f": "woman_with_veil_light_skin_tone",
-  "\ud83d\udc70\ud83c\udffb\u200d\u2642": "man_with_veil_light_skin_tone",
-  "\ud83d\udc70\ud83c\udffb\u200d\u2642\ufe0f": "man_with_veil_light_skin_tone",
-  "\ud83d\udc70\ud83c\udffc": "person_with_veil_medium-light_skin_tone",
-  "\ud83d\udc70\ud83c\udffc\u200d\u2640": "woman_with_veil_medium-light_skin_tone",
-  "\ud83d\udc70\ud83c\udffc\u200d\u2640\ufe0f": "woman_with_veil_medium-light_skin_tone",
-  "\ud83d\udc70\ud83c\udffc\u200d\u2642": "man_with_veil_medium-light_skin_tone",
-  "\ud83d\udc70\ud83c\udffc\u200d\u2642\ufe0f": "man_with_veil_medium-light_skin_tone",
-  "\ud83d\udc70\ud83c\udffd": "person_with_veil_medium_skin_tone",
-  "\ud83d\udc70\ud83c\udffd\u200d\u2640": "woman_with_veil_medium_skin_tone",
-  "\ud83d\udc70\ud83c\udffd\u200d\u2640\ufe0f": "woman_with_veil_medium_skin_tone",
-  "\ud83d\udc70\ud83c\udffd\u200d\u2642": "man_with_veil_medium_skin_tone",
-  "\ud83d\udc70\ud83c\udffd\u200d\u2642\ufe0f": "man_with_veil_medium_skin_tone",
-  "\ud83d\udc70\ud83c\udffe": "person_with_veil_medium-dark_skin_tone",
-  "\ud83d\udc70\ud83c\udffe\u200d\u2640": "woman_with_veil_medium-dark_skin_tone",
-  "\ud83d\udc70\ud83c\udffe\u200d\u2640\ufe0f": "woman_with_veil_medium-dark_skin_tone",
-  "\ud83d\udc70\ud83c\udffe\u200d\u2642": "man_with_veil_medium-dark_skin_tone",
-  "\ud83d\udc70\ud83c\udffe\u200d\u2642\ufe0f": "man_with_veil_medium-dark_skin_tone",
-  "\ud83d\udc70\ud83c\udfff": "person_with_veil_dark_skin_tone",
-  "\ud83d\udc70\ud83c\udfff\u200d\u2640": "woman_with_veil_dark_skin_tone",
-  "\ud83d\udc70\ud83c\udfff\u200d\u2640\ufe0f": "woman_with_veil_dark_skin_tone",
-  "\ud83d\udc70\ud83c\udfff\u200d\u2642": "man_with_veil_dark_skin_tone",
-  "\ud83d\udc70\ud83c\udfff\u200d\u2642\ufe0f": "man_with_veil_dark_skin_tone",
-  "\ud83d\udc71": "person_blond_hair",
-  "\ud83d\udc71\u200d\u2640": "woman_blond_hair",
-  "\ud83d\udc71\u200d\u2640\ufe0f": "woman_blond_hair",
-  "\ud83d\udc71\u200d\u2642": "man_blond_hair",
-  "\ud83d\udc71\u200d\u2642\ufe0f": "man_blond_hair",
-  "\ud83d\udc71\ud83c\udffb": "person_light_skin_tone_blond_hair",
-  "\ud83d\udc71\ud83c\udffb\u200d\u2640": "woman_light_skin_tone_blond_hair",
-  "\ud83d\udc71\ud83c\udffb\u200d\u2640\ufe0f": "woman_light_skin_tone_blond_hair",
-  "\ud83d\udc71\ud83c\udffb\u200d\u2642": "man_light_skin_tone_blond_hair",
-  "\ud83d\udc71\ud83c\udffb\u200d\u2642\ufe0f": "man_light_skin_tone_blond_hair",
-  "\ud83d\udc71\ud83c\udffc": "person_medium-light_skin_tone_blond_hair",
-  "\ud83d\udc71\ud83c\udffc\u200d\u2640": "woman_medium-light_skin_tone_blond_hair",
-  "\ud83d\udc71\ud83c\udffc\u200d\u2640\ufe0f": "woman_medium-light_skin_tone_blond_hair",
-  "\ud83d\udc71\ud83c\udffc\u200d\u2642": "man_medium-light_skin_tone_blond_hair",
-  "\ud83d\udc71\ud83c\udffc\u200d\u2642\ufe0f": "man_medium-light_skin_tone_blond_hair",
-  "\ud83d\udc71\ud83c\udffd": "person_medium_skin_tone_blond_hair",
-  "\ud83d\udc71\ud83c\udffd\u200d\u2640": "woman_medium_skin_tone_blond_hair",
-  "\ud83d\udc71\ud83c\udffd\u200d\u2640\ufe0f": "woman_medium_skin_tone_blond_hair",
-  "\ud83d\udc71\ud83c\udffd\u200d\u2642": "man_medium_skin_tone_blond_hair",
-  "\ud83d\udc71\ud83c\udffd\u200d\u2642\ufe0f": "man_medium_skin_tone_blond_hair",
-  "\ud83d\udc71\ud83c\udffe": "person_medium-dark_skin_tone_blond_hair",
-  "\ud83d\udc71\ud83c\udffe\u200d\u2640": "woman_medium-dark_skin_tone_blond_hair",
-  "\ud83d\udc71\ud83c\udffe\u200d\u2640\ufe0f": "woman_medium-dark_skin_tone_blond_hair",
-  "\ud83d\udc71\ud83c\udffe\u200d\u2642": "man_medium-dark_skin_tone_blond_hair",
-  "\ud83d\udc71\ud83c\udffe\u200d\u2642\ufe0f": "man_medium-dark_skin_tone_blond_hair",
-  "\ud83d\udc71\ud83c\udfff": "person_dark_skin_tone_blond_hair",
-  "\ud83d\udc71\ud83c\udfff\u200d\u2640": "woman_dark_skin_tone_blond_hair",
-  "\ud83d\udc71\ud83c\udfff\u200d\u2640\ufe0f": "woman_dark_skin_tone_blond_hair",
-  "\ud83d\udc71\ud83c\udfff\u200d\u2642": "man_dark_skin_tone_blond_hair",
-  "\ud83d\udc71\ud83c\udfff\u200d\u2642\ufe0f": "man_dark_skin_tone_blond_hair",
-  "\ud83d\udc72": "person_with_skullcap",
-  "\ud83d\udc72\ud83c\udffb": "person_with_skullcap_light_skin_tone",
-  "\ud83d\udc72\ud83c\udffc": "person_with_skullcap_medium-light_skin_tone",
-  "\ud83d\udc72\ud83c\udffd": "person_with_skullcap_medium_skin_tone",
-  "\ud83d\udc72\ud83c\udffe": "person_with_skullcap_medium-dark_skin_tone",
-  "\ud83d\udc72\ud83c\udfff": "person_with_skullcap_dark_skin_tone",
-  "\ud83d\udc73": "person_wearing_turban",
-  "\ud83d\udc73\u200d\u2640": "woman_wearing_turban",
-  "\ud83d\udc73\u200d\u2640\ufe0f": "woman_wearing_turban",
-  "\ud83d\udc73\u200d\u2642": "man_wearing_turban",
-  "\ud83d\udc73\u200d\u2642\ufe0f": "man_wearing_turban",
-  "\ud83d\udc73\ud83c\udffb": "person_wearing_turban_light_skin_tone",
-  "\ud83d\udc73\ud83c\udffb\u200d\u2640": "woman_wearing_turban_light_skin_tone",
-  "\ud83d\udc73\ud83c\udffb\u200d\u2640\ufe0f": "woman_wearing_turban_light_skin_tone",
-  "\ud83d\udc73\ud83c\udffb\u200d\u2642": "man_wearing_turban_light_skin_tone",
-  "\ud83d\udc73\ud83c\udffb\u200d\u2642\ufe0f": "man_wearing_turban_light_skin_tone",
-  "\ud83d\udc73\ud83c\udffc": "person_wearing_turban_medium-light_skin_tone",
-  "\ud83d\udc73\ud83c\udffc\u200d\u2640": "woman_wearing_turban_medium-light_skin_tone",
-  "\ud83d\udc73\ud83c\udffc\u200d\u2640\ufe0f": "woman_wearing_turban_medium-light_skin_tone",
-  "\ud83d\udc73\ud83c\udffc\u200d\u2642": "man_wearing_turban_medium-light_skin_tone",
-  "\ud83d\udc73\ud83c\udffc\u200d\u2642\ufe0f": "man_wearing_turban_medium-light_skin_tone",
-  "\ud83d\udc73\ud83c\udffd": "person_wearing_turban_medium_skin_tone",
-  "\ud83d\udc73\ud83c\udffd\u200d\u2640": "woman_wearing_turban_medium_skin_tone",
-  "\ud83d\udc73\ud83c\udffd\u200d\u2640\ufe0f": "woman_wearing_turban_medium_skin_tone",
-  "\ud83d\udc73\ud83c\udffd\u200d\u2642": "man_wearing_turban_medium_skin_tone",
-  "\ud83d\udc73\ud83c\udffd\u200d\u2642\ufe0f": "man_wearing_turban_medium_skin_tone",
-  "\ud83d\udc73\ud83c\udffe": "person_wearing_turban_medium-dark_skin_tone",
-  "\ud83d\udc73\ud83c\udffe\u200d\u2640": "woman_wearing_turban_medium-dark_skin_tone",
-  "\ud83d\udc73\ud83c\udffe\u200d\u2640\ufe0f": "woman_wearing_turban_medium-dark_skin_tone",
-  "\ud83d\udc73\ud83c\udffe\u200d\u2642": "man_wearing_turban_medium-dark_skin_tone",
-  "\ud83d\udc73\ud83c\udffe\u200d\u2642\ufe0f": "man_wearing_turban_medium-dark_skin_tone",
-  "\ud83d\udc73\ud83c\udfff": "person_wearing_turban_dark_skin_tone",
-  "\ud83d\udc73\ud83c\udfff\u200d\u2640": "woman_wearing_turban_dark_skin_tone",
-  "\ud83d\udc73\ud83c\udfff\u200d\u2640\ufe0f": "woman_wearing_turban_dark_skin_tone",
-  "\ud83d\udc73\ud83c\udfff\u200d\u2642": "man_wearing_turban_dark_skin_tone",
-  "\ud83d\udc73\ud83c\udfff\u200d\u2642\ufe0f": "man_wearing_turban_dark_skin_tone",
-  "\ud83d\udc74": "old_man",
-  "\ud83d\udc74\ud83c\udffb": "old_man_light_skin_tone",
-  "\ud83d\udc74\ud83c\udffc": "old_man_medium-light_skin_tone",
-  "\ud83d\udc74\ud83c\udffd": "old_man_medium_skin_tone",
-  "\ud83d\udc74\ud83c\udffe": "old_man_medium-dark_skin_tone",
-  "\ud83d\udc74\ud83c\udfff": "old_man_dark_skin_tone",
-  "\ud83d\udc75": "old_woman",
-  "\ud83d\udc75\ud83c\udffb": "old_woman_light_skin_tone",
-  "\ud83d\udc75\ud83c\udffc": "old_woman_medium-light_skin_tone",
-  "\ud83d\udc75\ud83c\udffd": "old_woman_medium_skin_tone",
-  "\ud83d\udc75\ud83c\udffe": "old_woman_medium-dark_skin_tone",
-  "\ud83d\udc75\ud83c\udfff": "old_woman_dark_skin_tone",
-  "\ud83d\udc76": "baby",
-  "\ud83d\udc76\ud83c\udffb": "baby_light_skin_tone",
-  "\ud83d\udc76\ud83c\udffc": "baby_medium-light_skin_tone",
-  "\ud83d\udc76\ud83c\udffd": "baby_medium_skin_tone",
-  "\ud83d\udc76\ud83c\udffe": "baby_medium-dark_skin_tone",
-  "\ud83d\udc76\ud83c\udfff": "baby_dark_skin_tone",
-  "\ud83d\udc77": "construction_worker",
-  "\ud83d\udc77\u200d\u2640": "woman_construction_worker",
-  "\ud83d\udc77\u200d\u2640\ufe0f": "woman_construction_worker",
-  "\ud83d\udc77\u200d\u2642": "man_construction_worker",
-  "\ud83d\udc77\u200d\u2642\ufe0f": "man_construction_worker",
-  "\ud83d\udc77\ud83c\udffb": "construction_worker_light_skin_tone",
-  "\ud83d\udc77\ud83c\udffb\u200d\u2640": "woman_construction_worker_light_skin_tone",
-  "\ud83d\udc77\ud83c\udffb\u200d\u2640\ufe0f": "woman_construction_worker_light_skin_tone",
-  "\ud83d\udc77\ud83c\udffb\u200d\u2642": "man_construction_worker_light_skin_tone",
-  "\ud83d\udc77\ud83c\udffb\u200d\u2642\ufe0f": "man_construction_worker_light_skin_tone",
-  "\ud83d\udc77\ud83c\udffc": "construction_worker_medium-light_skin_tone",
-  "\ud83d\udc77\ud83c\udffc\u200d\u2640": "woman_construction_worker_medium-light_skin_tone",
-  "\ud83d\udc77\ud83c\udffc\u200d\u2640\ufe0f": "woman_construction_worker_medium-light_skin_tone",
-  "\ud83d\udc77\ud83c\udffc\u200d\u2642": "man_construction_worker_medium-light_skin_tone",
-  "\ud83d\udc77\ud83c\udffc\u200d\u2642\ufe0f": "man_construction_worker_medium-light_skin_tone",
-  "\ud83d\udc77\ud83c\udffd": "construction_worker_medium_skin_tone",
-  "\ud83d\udc77\ud83c\udffd\u200d\u2640": "woman_construction_worker_medium_skin_tone",
-  "\ud83d\udc77\ud83c\udffd\u200d\u2640\ufe0f": "woman_construction_worker_medium_skin_tone",
-  "\ud83d\udc77\ud83c\udffd\u200d\u2642": "man_construction_worker_medium_skin_tone",
-  "\ud83d\udc77\ud83c\udffd\u200d\u2642\ufe0f": "man_construction_worker_medium_skin_tone",
-  "\ud83d\udc77\ud83c\udffe": "construction_worker_medium-dark_skin_tone",
-  "\ud83d\udc77\ud83c\udffe\u200d\u2640": "woman_construction_worker_medium-dark_skin_tone",
-  "\ud83d\udc77\ud83c\udffe\u200d\u2640\ufe0f": "woman_construction_worker_medium-dark_skin_tone",
-  "\ud83d\udc77\ud83c\udffe\u200d\u2642": "man_construction_worker_medium-dark_skin_tone",
-  "\ud83d\udc77\ud83c\udffe\u200d\u2642\ufe0f": "man_construction_worker_medium-dark_skin_tone",
-  "\ud83d\udc77\ud83c\udfff": "construction_worker_dark_skin_tone",
-  "\ud83d\udc77\ud83c\udfff\u200d\u2640": "woman_construction_worker_dark_skin_tone",
-  "\ud83d\udc77\ud83c\udfff\u200d\u2640\ufe0f": "woman_construction_worker_dark_skin_tone",
-  "\ud83d\udc77\ud83c\udfff\u200d\u2642": "man_construction_worker_dark_skin_tone",
-  "\ud83d\udc77\ud83c\udfff\u200d\u2642\ufe0f": "man_construction_worker_dark_skin_tone",
-  "\ud83d\udc78": "princess",
-  "\ud83d\udc78\ud83c\udffb": "princess_light_skin_tone",
-  "\ud83d\udc78\ud83c\udffc": "princess_medium-light_skin_tone",
-  "\ud83d\udc78\ud83c\udffd": "princess_medium_skin_tone",
-  "\ud83d\udc78\ud83c\udffe": "princess_medium-dark_skin_tone",
-  "\ud83d\udc78\ud83c\udfff": "princess_dark_skin_tone",
-  "\ud83d\udc79": "ogre",
-  "\ud83d\udc7a": "goblin",
-  "\ud83d\udc7b": "ghost",
-  "\ud83d\udc7c": "baby_angel",
-  "\ud83d\udc7c\ud83c\udffb": "baby_angel_light_skin_tone",
-  "\ud83d\udc7c\ud83c\udffc": "baby_angel_medium-light_skin_tone",
-  "\ud83d\udc7c\ud83c\udffd": "baby_angel_medium_skin_tone",
-  "\ud83d\udc7c\ud83c\udffe": "baby_angel_medium-dark_skin_tone",
-  "\ud83d\udc7c\ud83c\udfff": "baby_angel_dark_skin_tone",
-  "\ud83d\udc7d": "alien",
-  "\ud83d\udc7e": "alien_monster",
-  "\ud83d\udc7f": "angry_face_with_horns",
-  "\ud83d\udc80": "skull",
-  "\ud83d\udc81": "person_tipping_hand",
-  "\ud83d\udc81\u200d\u2640": "woman_tipping_hand",
-  "\ud83d\udc81\u200d\u2640\ufe0f": "woman_tipping_hand",
-  "\ud83d\udc81\u200d\u2642": "man_tipping_hand",
-  "\ud83d\udc81\u200d\u2642\ufe0f": "man_tipping_hand",
-  "\ud83d\udc81\ud83c\udffb": "person_tipping_hand_light_skin_tone",
-  "\ud83d\udc81\ud83c\udffb\u200d\u2640": "woman_tipping_hand_light_skin_tone",
-  "\ud83d\udc81\ud83c\udffb\u200d\u2640\ufe0f": "woman_tipping_hand_light_skin_tone",
-  "\ud83d\udc81\ud83c\udffb\u200d\u2642": "man_tipping_hand_light_skin_tone",
-  "\ud83d\udc81\ud83c\udffb\u200d\u2642\ufe0f": "man_tipping_hand_light_skin_tone",
-  "\ud83d\udc81\ud83c\udffc": "person_tipping_hand_medium-light_skin_tone",
-  "\ud83d\udc81\ud83c\udffc\u200d\u2640": "woman_tipping_hand_medium-light_skin_tone",
-  "\ud83d\udc81\ud83c\udffc\u200d\u2640\ufe0f": "woman_tipping_hand_medium-light_skin_tone",
-  "\ud83d\udc81\ud83c\udffc\u200d\u2642": "man_tipping_hand_medium-light_skin_tone",
-  "\ud83d\udc81\ud83c\udffc\u200d\u2642\ufe0f": "man_tipping_hand_medium-light_skin_tone",
-  "\ud83d\udc81\ud83c\udffd": "person_tipping_hand_medium_skin_tone",
-  "\ud83d\udc81\ud83c\udffd\u200d\u2640": "woman_tipping_hand_medium_skin_tone",
-  "\ud83d\udc81\ud83c\udffd\u200d\u2640\ufe0f": "woman_tipping_hand_medium_skin_tone",
-  "\ud83d\udc81\ud83c\udffd\u200d\u2642": "man_tipping_hand_medium_skin_tone",
-  "\ud83d\udc81\ud83c\udffd\u200d\u2642\ufe0f": "man_tipping_hand_medium_skin_tone",
-  "\ud83d\udc81\ud83c\udffe": "person_tipping_hand_medium-dark_skin_tone",
-  "\ud83d\udc81\ud83c\udffe\u200d\u2640": "woman_tipping_hand_medium-dark_skin_tone",
-  "\ud83d\udc81\ud83c\udffe\u200d\u2640\ufe0f": "woman_tipping_hand_medium-dark_skin_tone",
-  "\ud83d\udc81\ud83c\udffe\u200d\u2642": "man_tipping_hand_medium-dark_skin_tone",
-  "\ud83d\udc81\ud83c\udffe\u200d\u2642\ufe0f": "man_tipping_hand_medium-dark_skin_tone",
-  "\ud83d\udc81\ud83c\udfff": "person_tipping_hand_dark_skin_tone",
-  "\ud83d\udc81\ud83c\udfff\u200d\u2640": "woman_tipping_hand_dark_skin_tone",
-  "\ud83d\udc81\ud83c\udfff\u200d\u2640\ufe0f": "woman_tipping_hand_dark_skin_tone",
-  "\ud83d\udc81\ud83c\udfff\u200d\u2642": "man_tipping_hand_dark_skin_tone",
-  "\ud83d\udc81\ud83c\udfff\u200d\u2642\ufe0f": "man_tipping_hand_dark_skin_tone",
-  "\ud83d\udc82": "guard",
-  "\ud83d\udc82\u200d\u2640": "woman_guard",
-  "\ud83d\udc82\u200d\u2640\ufe0f": "woman_guard",
-  "\ud83d\udc82\u200d\u2642": "man_guard",
-  "\ud83d\udc82\u200d\u2642\ufe0f": "man_guard",
-  "\ud83d\udc82\ud83c\udffb": "guard_light_skin_tone",
-  "\ud83d\udc82\ud83c\udffb\u200d\u2640": "woman_guard_light_skin_tone",
-  "\ud83d\udc82\ud83c\udffb\u200d\u2640\ufe0f": "woman_guard_light_skin_tone",
-  "\ud83d\udc82\ud83c\udffb\u200d\u2642": "man_guard_light_skin_tone",
-  "\ud83d\udc82\ud83c\udffb\u200d\u2642\ufe0f": "man_guard_light_skin_tone",
-  "\ud83d\udc82\ud83c\udffc": "guard_medium-light_skin_tone",
-  "\ud83d\udc82\ud83c\udffc\u200d\u2640": "woman_guard_medium-light_skin_tone",
-  "\ud83d\udc82\ud83c\udffc\u200d\u2640\ufe0f": "woman_guard_medium-light_skin_tone",
-  "\ud83d\udc82\ud83c\udffc\u200d\u2642": "man_guard_medium-light_skin_tone",
-  "\ud83d\udc82\ud83c\udffc\u200d\u2642\ufe0f": "man_guard_medium-light_skin_tone",
-  "\ud83d\udc82\ud83c\udffd": "guard_medium_skin_tone",
-  "\ud83d\udc82\ud83c\udffd\u200d\u2640": "woman_guard_medium_skin_tone",
-  "\ud83d\udc82\ud83c\udffd\u200d\u2640\ufe0f": "woman_guard_medium_skin_tone",
-  "\ud83d\udc82\ud83c\udffd\u200d\u2642": "man_guard_medium_skin_tone",
-  "\ud83d\udc82\ud83c\udffd\u200d\u2642\ufe0f": "man_guard_medium_skin_tone",
-  "\ud83d\udc82\ud83c\udffe": "guard_medium-dark_skin_tone",
-  "\ud83d\udc82\ud83c\udffe\u200d\u2640": "woman_guard_medium-dark_skin_tone",
-  "\ud83d\udc82\ud83c\udffe\u200d\u2640\ufe0f": "woman_guard_medium-dark_skin_tone",
-  "\ud83d\udc82\ud83c\udffe\u200d\u2642": "man_guard_medium-dark_skin_tone",
-  "\ud83d\udc82\ud83c\udffe\u200d\u2642\ufe0f": "man_guard_medium-dark_skin_tone",
-  "\ud83d\udc82\ud83c\udfff": "guard_dark_skin_tone",
-  "\ud83d\udc82\ud83c\udfff\u200d\u2640": "woman_guard_dark_skin_tone",
-  "\ud83d\udc82\ud83c\udfff\u200d\u2640\ufe0f": "woman_guard_dark_skin_tone",
-  "\ud83d\udc82\ud83c\udfff\u200d\u2642": "man_guard_dark_skin_tone",
-  "\ud83d\udc82\ud83c\udfff\u200d\u2642\ufe0f": "man_guard_dark_skin_tone",
-  "\ud83d\udc83": "woman_dancing",
-  "\ud83d\udc83\ud83c\udffb": "woman_dancing_light_skin_tone",
-  "\ud83d\udc83\ud83c\udffc": "woman_dancing_medium-light_skin_tone",
-  "\ud83d\udc83\ud83c\udffd": "woman_dancing_medium_skin_tone",
-  "\ud83d\udc83\ud83c\udffe": "woman_dancing_medium-dark_skin_tone",
-  "\ud83d\udc83\ud83c\udfff": "woman_dancing_dark_skin_tone",
-  "\ud83d\udc84": "lipstick",
-  "\ud83d\udc85": "nail_polish",
-  "\ud83d\udc85\ud83c\udffb": "nail_polish_light_skin_tone",
-  "\ud83d\udc85\ud83c\udffc": "nail_polish_medium-light_skin_tone",
-  "\ud83d\udc85\ud83c\udffd": "nail_polish_medium_skin_tone",
-  "\ud83d\udc85\ud83c\udffe": "nail_polish_medium-dark_skin_tone",
-  "\ud83d\udc85\ud83c\udfff": "nail_polish_dark_skin_tone",
-  "\ud83d\udc86": "person_getting_massage",
-  "\ud83d\udc86\u200d\u2640": "woman_getting_massage",
-  "\ud83d\udc86\u200d\u2640\ufe0f": "woman_getting_massage",
-  "\ud83d\udc86\u200d\u2642": "man_getting_massage",
-  "\ud83d\udc86\u200d\u2642\ufe0f": "man_getting_massage",
-  "\ud83d\udc86\ud83c\udffb": "person_getting_massage_light_skin_tone",
-  "\ud83d\udc86\ud83c\udffb\u200d\u2640": "woman_getting_massage_light_skin_tone",
-  "\ud83d\udc86\ud83c\udffb\u200d\u2640\ufe0f": "woman_getting_massage_light_skin_tone",
-  "\ud83d\udc86\ud83c\udffb\u200d\u2642": "man_getting_massage_light_skin_tone",
-  "\ud83d\udc86\ud83c\udffb\u200d\u2642\ufe0f": "man_getting_massage_light_skin_tone",
-  "\ud83d\udc86\ud83c\udffc": "person_getting_massage_medium-light_skin_tone",
-  "\ud83d\udc86\ud83c\udffc\u200d\u2640": "woman_getting_massage_medium-light_skin_tone",
-  "\ud83d\udc86\ud83c\udffc\u200d\u2640\ufe0f": "woman_getting_massage_medium-light_skin_tone",
-  "\ud83d\udc86\ud83c\udffc\u200d\u2642": "man_getting_massage_medium-light_skin_tone",
-  "\ud83d\udc86\ud83c\udffc\u200d\u2642\ufe0f": "man_getting_massage_medium-light_skin_tone",
-  "\ud83d\udc86\ud83c\udffd": "person_getting_massage_medium_skin_tone",
-  "\ud83d\udc86\ud83c\udffd\u200d\u2640": "woman_getting_massage_medium_skin_tone",
-  "\ud83d\udc86\ud83c\udffd\u200d\u2640\ufe0f": "woman_getting_massage_medium_skin_tone",
-  "\ud83d\udc86\ud83c\udffd\u200d\u2642": "man_getting_massage_medium_skin_tone",
-  "\ud83d\udc86\ud83c\udffd\u200d\u2642\ufe0f": "man_getting_massage_medium_skin_tone",
-  "\ud83d\udc86\ud83c\udffe": "person_getting_massage_medium-dark_skin_tone",
-  "\ud83d\udc86\ud83c\udffe\u200d\u2640": "woman_getting_massage_medium-dark_skin_tone",
-  "\ud83d\udc86\ud83c\udffe\u200d\u2640\ufe0f": "woman_getting_massage_medium-dark_skin_tone",
-  "\ud83d\udc86\ud83c\udffe\u200d\u2642": "man_getting_massage_medium-dark_skin_tone",
-  "\ud83d\udc86\ud83c\udffe\u200d\u2642\ufe0f": "man_getting_massage_medium-dark_skin_tone",
-  "\ud83d\udc86\ud83c\udfff": "person_getting_massage_dark_skin_tone",
-  "\ud83d\udc86\ud83c\udfff\u200d\u2640": "woman_getting_massage_dark_skin_tone",
-  "\ud83d\udc86\ud83c\udfff\u200d\u2640\ufe0f": "woman_getting_massage_dark_skin_tone",
-  "\ud83d\udc86\ud83c\udfff\u200d\u2642": "man_getting_massage_dark_skin_tone",
-  "\ud83d\udc86\ud83c\udfff\u200d\u2642\ufe0f": "man_getting_massage_dark_skin_tone",
-  "\ud83d\udc87": "person_getting_haircut",
-  "\ud83d\udc87\u200d\u2640": "woman_getting_haircut",
-  "\ud83d\udc87\u200d\u2640\ufe0f": "woman_getting_haircut",
-  "\ud83d\udc87\u200d\u2642": "man_getting_haircut",
-  "\ud83d\udc87\u200d\u2642\ufe0f": "man_getting_haircut",
-  "\ud83d\udc87\ud83c\udffb": "person_getting_haircut_light_skin_tone",
-  "\ud83d\udc87\ud83c\udffb\u200d\u2640": "woman_getting_haircut_light_skin_tone",
-  "\ud83d\udc87\ud83c\udffb\u200d\u2640\ufe0f": "woman_getting_haircut_light_skin_tone",
-  "\ud83d\udc87\ud83c\udffb\u200d\u2642": "man_getting_haircut_light_skin_tone",
-  "\ud83d\udc87\ud83c\udffb\u200d\u2642\ufe0f": "man_getting_haircut_light_skin_tone",
-  "\ud83d\udc87\ud83c\udffc": "person_getting_haircut_medium-light_skin_tone",
-  "\ud83d\udc87\ud83c\udffc\u200d\u2640": "woman_getting_haircut_medium-light_skin_tone",
-  "\ud83d\udc87\ud83c\udffc\u200d\u2640\ufe0f": "woman_getting_haircut_medium-light_skin_tone",
-  "\ud83d\udc87\ud83c\udffc\u200d\u2642": "man_getting_haircut_medium-light_skin_tone",
-  "\ud83d\udc87\ud83c\udffc\u200d\u2642\ufe0f": "man_getting_haircut_medium-light_skin_tone",
-  "\ud83d\udc87\ud83c\udffd": "person_getting_haircut_medium_skin_tone",
-  "\ud83d\udc87\ud83c\udffd\u200d\u2640": "woman_getting_haircut_medium_skin_tone",
-  "\ud83d\udc87\ud83c\udffd\u200d\u2640\ufe0f": "woman_getting_haircut_medium_skin_tone",
-  "\ud83d\udc87\ud83c\udffd\u200d\u2642": "man_getting_haircut_medium_skin_tone",
-  "\ud83d\udc87\ud83c\udffd\u200d\u2642\ufe0f": "man_getting_haircut_medium_skin_tone",
-  "\ud83d\udc87\ud83c\udffe": "person_getting_haircut_medium-dark_skin_tone",
-  "\ud83d\udc87\ud83c\udffe\u200d\u2640": "woman_getting_haircut_medium-dark_skin_tone",
-  "\ud83d\udc87\ud83c\udffe\u200d\u2640\ufe0f": "woman_getting_haircut_medium-dark_skin_tone",
-  "\ud83d\udc87\ud83c\udffe\u200d\u2642": "man_getting_haircut_medium-dark_skin_tone",
-  "\ud83d\udc87\ud83c\udffe\u200d\u2642\ufe0f": "man_getting_haircut_medium-dark_skin_tone",
-  "\ud83d\udc87\ud83c\udfff": "person_getting_haircut_dark_skin_tone",
-  "\ud83d\udc87\ud83c\udfff\u200d\u2640": "woman_getting_haircut_dark_skin_tone",
-  "\ud83d\udc87\ud83c\udfff\u200d\u2640\ufe0f": "woman_getting_haircut_dark_skin_tone",
-  "\ud83d\udc87\ud83c\udfff\u200d\u2642": "man_getting_haircut_dark_skin_tone",
-  "\ud83d\udc87\ud83c\udfff\u200d\u2642\ufe0f": "man_getting_haircut_dark_skin_tone",
-  "\ud83d\udc88": "barber_pole",
-  "\ud83d\udc89": "syringe",
-  "\ud83d\udc8a": "pill",
-  "\ud83d\udc8b": "kiss_mark",
-  "\ud83d\udc8c": "love_letter",
-  "\ud83d\udc8d": "ring",
-  "\ud83d\udc8e": "gem_stone",
-  "\ud83d\udc8f": "kiss",
-  "\ud83d\udc8f\ud83c\udffb": "kiss_light_skin_tone",
-  "\ud83d\udc8f\ud83c\udffc": "kiss_medium-light_skin_tone",
-  "\ud83d\udc8f\ud83c\udffd": "kiss_medium_skin_tone",
-  "\ud83d\udc8f\ud83c\udffe": "kiss_medium-dark_skin_tone",
-  "\ud83d\udc8f\ud83c\udfff": "kiss_dark_skin_tone",
-  "\ud83d\udc90": "bouquet",
-  "\ud83d\udc91": "couple_with_heart",
-  "\ud83d\udc91\ud83c\udffb": "couple_with_heart_light_skin_tone",
-  "\ud83d\udc91\ud83c\udffc": "couple_with_heart_medium-light_skin_tone",
-  "\ud83d\udc91\ud83c\udffd": "couple_with_heart_medium_skin_tone",
-  "\ud83d\udc91\ud83c\udffe": "couple_with_heart_medium-dark_skin_tone",
-  "\ud83d\udc91\ud83c\udfff": "couple_with_heart_dark_skin_tone",
-  "\ud83d\udc92": "wedding",
-  "\ud83d\udc93": "beating_heart",
-  "\ud83d\udc94": "broken_heart",
-  "\ud83d\udc95": "two_hearts",
-  "\ud83d\udc96": "sparkling_heart",
-  "\ud83d\udc97": "growing_heart",
-  "\ud83d\udc98": "heart_with_arrow",
-  "\ud83d\udc99": "blue_heart",
-  "\ud83d\udc9a": "green_heart",
-  "\ud83d\udc9b": "yellow_heart",
-  "\ud83d\udc9c": "purple_heart",
-  "\ud83d\udc9d": "heart_with_ribbon",
-  "\ud83d\udc9e": "revolving_hearts",
-  "\ud83d\udc9f": "heart_decoration",
-  "\ud83d\udca0": "diamond_with_a_dot",
-  "\ud83d\udca1": "light_bulb",
-  "\ud83d\udca2": "anger_symbol",
-  "\ud83d\udca3": "bomb",
-  "\ud83d\udca4": "zzz",
-  "\ud83d\udca5": "collision",
-  "\ud83d\udca6": "sweat_droplets",
-  "\ud83d\udca7": "droplet",
-  "\ud83d\udca8": "dashing_away",
-  "\ud83d\udca9": "pile_of_poo",
-  "\ud83d\udcaa": "flexed_biceps",
-  "\ud83d\udcaa\ud83c\udffb": "flexed_biceps_light_skin_tone",
-  "\ud83d\udcaa\ud83c\udffc": "flexed_biceps_medium-light_skin_tone",
-  "\ud83d\udcaa\ud83c\udffd": "flexed_biceps_medium_skin_tone",
-  "\ud83d\udcaa\ud83c\udffe": "flexed_biceps_medium-dark_skin_tone",
-  "\ud83d\udcaa\ud83c\udfff": "flexed_biceps_dark_skin_tone",
-  "\ud83d\udcab": "dizzy",
-  "\ud83d\udcac": "speech_balloon",
-  "\ud83d\udcad": "thought_balloon",
-  "\ud83d\udcae": "white_flower",
-  "\ud83d\udcaf": "hundred_points",
-  "\ud83d\udcb0": "money_bag",
-  "\ud83d\udcb1": "currency_exchange",
-  "\ud83d\udcb2": "heavy_dollar_sign",
-  "\ud83d\udcb3": "credit_card",
-  "\ud83d\udcb4": "yen_banknote",
-  "\ud83d\udcb5": "dollar_banknote",
-  "\ud83d\udcb6": "euro_banknote",
-  "\ud83d\udcb7": "pound_banknote",
-  "\ud83d\udcb8": "money_with_wings",
-  "\ud83d\udcb9": "chart_increasing_with_yen",
-  "\ud83d\udcba": "seat",
-  "\ud83d\udcbb": "laptop",
-  "\ud83d\udcbc": "briefcase",
-  "\ud83d\udcbd": "computer_disk",
-  "\ud83d\udcbe": "floppy_disk",
-  "\ud83d\udcbf": "optical_disk",
-  "\ud83d\udcc0": "dvd",
-  "\ud83d\udcc1": "file_folder",
-  "\ud83d\udcc2": "open_file_folder",
-  "\ud83d\udcc3": "page_with_curl",
-  "\ud83d\udcc4": "page_facing_up",
-  "\ud83d\udcc5": "calendar",
-  "\ud83d\udcc6": "tear-off_calendar",
-  "\ud83d\udcc7": "card_index",
-  "\ud83d\udcc8": "chart_increasing",
-  "\ud83d\udcc9": "chart_decreasing",
-  "\ud83d\udcca": "bar_chart",
-  "\ud83d\udccb": "clipboard",
-  "\ud83d\udccc": "pushpin",
-  "\ud83d\udccd": "round_pushpin",
-  "\ud83d\udcce": "paperclip",
-  "\ud83d\udccf": "straight_ruler",
-  "\ud83d\udcd0": "triangular_ruler",
-  "\ud83d\udcd1": "bookmark_tabs",
-  "\ud83d\udcd2": "ledger",
-  "\ud83d\udcd3": "notebook",
-  "\ud83d\udcd4": "notebook_with_decorative_cover",
-  "\ud83d\udcd5": "closed_book",
-  "\ud83d\udcd6": "open_book",
-  "\ud83d\udcd7": "green_book",
-  "\ud83d\udcd8": "blue_book",
-  "\ud83d\udcd9": "orange_book",
-  "\ud83d\udcda": "books",
-  "\ud83d\udcdb": "name_badge",
-  "\ud83d\udcdc": "scroll",
-  "\ud83d\udcdd": "memo",
-  "\ud83d\udcde": "telephone_receiver",
-  "\ud83d\udcdf": "pager",
-  "\ud83d\udce0": "fax_machine",
-  "\ud83d\udce1": "satellite_antenna",
-  "\ud83d\udce2": "loudspeaker",
-  "\ud83d\udce3": "megaphone",
-  "\ud83d\udce4": "outbox_tray",
-  "\ud83d\udce5": "inbox_tray",
-  "\ud83d\udce6": "package",
-  "\ud83d\udce7": "e-mail",
-  "\ud83d\udce8": "incoming_envelope",
-  "\ud83d\udce9": "envelope_with_arrow",
-  "\ud83d\udcea": "closed_mailbox_with_lowered_flag",
-  "\ud83d\udceb": "closed_mailbox_with_raised_flag",
-  "\ud83d\udcec": "open_mailbox_with_raised_flag",
-  "\ud83d\udced": "open_mailbox_with_lowered_flag",
-  "\ud83d\udcee": "postbox",
-  "\ud83d\udcef": "postal_horn",
-  "\ud83d\udcf0": "newspaper",
-  "\ud83d\udcf1": "mobile_phone",
-  "\ud83d\udcf2": "mobile_phone_with_arrow",
-  "\ud83d\udcf3": "vibration_mode",
-  "\ud83d\udcf4": "mobile_phone_off",
-  "\ud83d\udcf5": "no_mobile_phones",
-  "\ud83d\udcf6": "antenna_bars",
-  "\ud83d\udcf7": "camera",
-  "\ud83d\udcf8": "camera_with_flash",
-  "\ud83d\udcf9": "video_camera",
-  "\ud83d\udcfa": "television",
-  "\ud83d\udcfb": "radio",
-  "\ud83d\udcfc": "videocassette",
-  "\ud83d\udcfd": "film_projector",
-  "\ud83d\udcfd\ufe0f": "film_projector",
-  "\ud83d\udcff": "prayer_beads",
-  "\ud83d\udd00": "shuffle_tracks_button",
-  "\ud83d\udd01": "repeat_button",
-  "\ud83d\udd02": "repeat_single_button",
-  "\ud83d\udd03": "clockwise_vertical_arrows",
-  "\ud83d\udd04": "counterclockwise_arrows_button",
-  "\ud83d\udd05": "dim_button",
-  "\ud83d\udd06": "bright_button",
-  "\ud83d\udd07": "muted_speaker",
-  "\ud83d\udd08": "speaker_low_volume",
-  "\ud83d\udd09": "speaker_medium_volume",
-  "\ud83d\udd0a": "speaker_high_volume",
-  "\ud83d\udd0b": "battery",
-  "\ud83d\udd0c": "electric_plug",
-  "\ud83d\udd0d": "magnifying_glass_tilted_left",
-  "\ud83d\udd0e": "magnifying_glass_tilted_right",
-  "\ud83d\udd0f": "locked_with_pen",
-  "\ud83d\udd10": "locked_with_key",
-  "\ud83d\udd11": "key",
-  "\ud83d\udd12": "locked",
-  "\ud83d\udd13": "unlocked",
-  "\ud83d\udd14": "bell",
-  "\ud83d\udd15": "bell_with_slash",
-  "\ud83d\udd16": "bookmark",
-  "\ud83d\udd17": "link",
-  "\ud83d\udd18": "radio_button",
-  "\ud83d\udd19": "back_arrow",
-  "\ud83d\udd1a": "end_arrow",
-  "\ud83d\udd1b": "on!_arrow",
-  "\ud83d\udd1c": "soon_arrow",
-  "\ud83d\udd1d": "top_arrow",
-  "\ud83d\udd1e": "no_one_under_eighteen",
-  "\ud83d\udd1f": "keycap_10",
-  "\ud83d\udd20": "input_latin_uppercase",
-  "\ud83d\udd21": "input_latin_lowercase",
-  "\ud83d\udd22": "input_numbers",
-  "\ud83d\udd23": "input_symbols",
-  "\ud83d\udd24": "input_latin_letters",
-  "\ud83d\udd25": "fire",
-  "\ud83d\udd26": "flashlight",
-  "\ud83d\udd27": "wrench",
-  "\ud83d\udd28": "hammer",
-  "\ud83d\udd29": "nut_and_bolt",
-  "\ud83d\udd2a": "kitchen_knife",
-  "\ud83d\udd2b": "water_pistol",
-  "\ud83d\udd2c": "microscope",
-  "\ud83d\udd2d": "telescope",
-  "\ud83d\udd2e": "crystal_ball",
-  "\ud83d\udd2f": "dotted_six-pointed_star",
-  "\ud83d\udd30": "japanese_symbol_for_beginner",
-  "\ud83d\udd31": "trident_emblem",
-  "\ud83d\udd32": "black_square_button",
-  "\ud83d\udd33": "white_square_button",
-  "\ud83d\udd34": "red_circle",
-  "\ud83d\udd35": "blue_circle",
-  "\ud83d\udd36": "large_orange_diamond",
-  "\ud83d\udd37": "large_blue_diamond",
-  "\ud83d\udd38": "small_orange_diamond",
-  "\ud83d\udd39": "small_blue_diamond",
-  "\ud83d\udd3a": "red_triangle_pointed_up",
-  "\ud83d\udd3b": "red_triangle_pointed_down",
-  "\ud83d\udd3c": "upwards_button",
-  "\ud83d\udd3d": "downwards_button",
-  "\ud83d\udd49": "om",
-  "\ud83d\udd49\ufe0f": "om",
-  "\ud83d\udd4a": "dove",
-  "\ud83d\udd4a\ufe0f": "dove",
-  "\ud83d\udd4b": "kaaba",
-  "\ud83d\udd4c": "mosque",
-  "\ud83d\udd4d": "synagogue",
-  "\ud83d\udd4e": "menorah",
-  "\ud83d\udd50": "one_o\u2019clock",
-  "\ud83d\udd51": "two_o\u2019clock",
-  "\ud83d\udd52": "three_o\u2019clock",
-  "\ud83d\udd53": "four_o\u2019clock",
-  "\ud83d\udd54": "five_o\u2019clock",
-  "\ud83d\udd55": "six_o\u2019clock",
-  "\ud83d\udd56": "seven_o\u2019clock",
-  "\ud83d\udd57": "eight_o\u2019clock",
-  "\ud83d\udd58": "nine_o\u2019clock",
-  "\ud83d\udd59": "ten_o\u2019clock",
-  "\ud83d\udd5a": "eleven_o\u2019clock",
-  "\ud83d\udd5b": "twelve_o\u2019clock",
-  "\ud83d\udd5c": "one-thirty",
-  "\ud83d\udd5d": "two-thirty",
-  "\ud83d\udd5e": "three-thirty",
-  "\ud83d\udd5f": "four-thirty",
-  "\ud83d\udd60": "five-thirty",
-  "\ud83d\udd61": "six-thirty",
-  "\ud83d\udd62": "seven-thirty",
-  "\ud83d\udd63": "eight-thirty",
-  "\ud83d\udd64": "nine-thirty",
-  "\ud83d\udd65": "ten-thirty",
-  "\ud83d\udd66": "eleven-thirty",
-  "\ud83d\udd67": "twelve-thirty",
-  "\ud83d\udd6f": "candle",
-  "\ud83d\udd6f\ufe0f": "candle",
-  "\ud83d\udd70": "mantelpiece_clock",
-  "\ud83d\udd70\ufe0f": "mantelpiece_clock",
-  "\ud83d\udd73": "hole",
-  "\ud83d\udd73\ufe0f": "hole",
-  "\ud83d\udd74": "person_in_suit_levitating",
-  "\ud83d\udd74\ufe0f": "person_in_suit_levitating",
-  "\ud83d\udd74\ud83c\udffb": "person_in_suit_levitating_light_skin_tone",
-  "\ud83d\udd74\ud83c\udffc": "person_in_suit_levitating_medium-light_skin_tone",
-  "\ud83d\udd74\ud83c\udffd": "person_in_suit_levitating_medium_skin_tone",
-  "\ud83d\udd74\ud83c\udffe": "person_in_suit_levitating_medium-dark_skin_tone",
-  "\ud83d\udd74\ud83c\udfff": "person_in_suit_levitating_dark_skin_tone",
-  "\ud83d\udd75": "detective",
-  "\ud83d\udd75\u200d\u2640": "woman_detective",
-  "\ud83d\udd75\u200d\u2640\ufe0f": "woman_detective",
-  "\ud83d\udd75\u200d\u2642": "man_detective",
-  "\ud83d\udd75\u200d\u2642\ufe0f": "man_detective",
-  "\ud83d\udd75\ufe0f": "detective",
-  "\ud83d\udd75\ufe0f\u200d\u2640": "woman_detective",
-  "\ud83d\udd75\ufe0f\u200d\u2640\ufe0f": "woman_detective",
-  "\ud83d\udd75\ufe0f\u200d\u2642": "man_detective",
-  "\ud83d\udd75\ufe0f\u200d\u2642\ufe0f": "man_detective",
-  "\ud83d\udd75\ud83c\udffb": "detective_light_skin_tone",
-  "\ud83d\udd75\ud83c\udffb\u200d\u2640": "woman_detective_light_skin_tone",
-  "\ud83d\udd75\ud83c\udffb\u200d\u2640\ufe0f": "woman_detective_light_skin_tone",
-  "\ud83d\udd75\ud83c\udffb\u200d\u2642": "man_detective_light_skin_tone",
-  "\ud83d\udd75\ud83c\udffb\u200d\u2642\ufe0f": "man_detective_light_skin_tone",
-  "\ud83d\udd75\ud83c\udffc": "detective_medium-light_skin_tone",
-  "\ud83d\udd75\ud83c\udffc\u200d\u2640": "woman_detective_medium-light_skin_tone",
-  "\ud83d\udd75\ud83c\udffc\u200d\u2640\ufe0f": "woman_detective_medium-light_skin_tone",
-  "\ud83d\udd75\ud83c\udffc\u200d\u2642": "man_detective_medium-light_skin_tone",
-  "\ud83d\udd75\ud83c\udffc\u200d\u2642\ufe0f": "man_detective_medium-light_skin_tone",
-  "\ud83d\udd75\ud83c\udffd": "detective_medium_skin_tone",
-  "\ud83d\udd75\ud83c\udffd\u200d\u2640": "woman_detective_medium_skin_tone",
-  "\ud83d\udd75\ud83c\udffd\u200d\u2640\ufe0f": "woman_detective_medium_skin_tone",
-  "\ud83d\udd75\ud83c\udffd\u200d\u2642": "man_detective_medium_skin_tone",
-  "\ud83d\udd75\ud83c\udffd\u200d\u2642\ufe0f": "man_detective_medium_skin_tone",
-  "\ud83d\udd75\ud83c\udffe": "detective_medium-dark_skin_tone",
-  "\ud83d\udd75\ud83c\udffe\u200d\u2640": "woman_detective_medium-dark_skin_tone",
-  "\ud83d\udd75\ud83c\udffe\u200d\u2640\ufe0f": "woman_detective_medium-dark_skin_tone",
-  "\ud83d\udd75\ud83c\udffe\u200d\u2642": "man_detective_medium-dark_skin_tone",
-  "\ud83d\udd75\ud83c\udffe\u200d\u2642\ufe0f": "man_detective_medium-dark_skin_tone",
-  "\ud83d\udd75\ud83c\udfff": "detective_dark_skin_tone",
-  "\ud83d\udd75\ud83c\udfff\u200d\u2640": "woman_detective_dark_skin_tone",
-  "\ud83d\udd75\ud83c\udfff\u200d\u2640\ufe0f": "woman_detective_dark_skin_tone",
-  "\ud83d\udd75\ud83c\udfff\u200d\u2642": "man_detective_dark_skin_tone",
-  "\ud83d\udd75\ud83c\udfff\u200d\u2642\ufe0f": "man_detective_dark_skin_tone",
-  "\ud83d\udd76": "sunglasses",
-  "\ud83d\udd76\ufe0f": "sunglasses",
-  "\ud83d\udd77": "spider",
-  "\ud83d\udd77\ufe0f": "spider",
-  "\ud83d\udd78": "spider_web",
-  "\ud83d\udd78\ufe0f": "spider_web",
-  "\ud83d\udd79": "joystick",
-  "\ud83d\udd79\ufe0f": "joystick",
-  "\ud83d\udd7a": "man_dancing",
-  "\ud83d\udd7a\ud83c\udffb": "man_dancing_light_skin_tone",
-  "\ud83d\udd7a\ud83c\udffc": "man_dancing_medium-light_skin_tone",
-  "\ud83d\udd7a\ud83c\udffd": "man_dancing_medium_skin_tone",
-  "\ud83d\udd7a\ud83c\udffe": "man_dancing_medium-dark_skin_tone",
-  "\ud83d\udd7a\ud83c\udfff": "man_dancing_dark_skin_tone",
-  "\ud83d\udd87": "linked_paperclips",
-  "\ud83d\udd87\ufe0f": "linked_paperclips",
-  "\ud83d\udd8a": "pen",
-  "\ud83d\udd8a\ufe0f": "pen",
-  "\ud83d\udd8b": "fountain_pen",
-  "\ud83d\udd8b\ufe0f": "fountain_pen",
-  "\ud83d\udd8c": "paintbrush",
-  "\ud83d\udd8c\ufe0f": "paintbrush",
-  "\ud83d\udd8d": "crayon",
-  "\ud83d\udd8d\ufe0f": "crayon",
-  "\ud83d\udd90": "hand_with_fingers_splayed",
-  "\ud83d\udd90\ufe0f": "hand_with_fingers_splayed",
-  "\ud83d\udd90\ud83c\udffb": "hand_with_fingers_splayed_light_skin_tone",
-  "\ud83d\udd90\ud83c\udffc": "hand_with_fingers_splayed_medium-light_skin_tone",
-  "\ud83d\udd90\ud83c\udffd": "hand_with_fingers_splayed_medium_skin_tone",
-  "\ud83d\udd90\ud83c\udffe": "hand_with_fingers_splayed_medium-dark_skin_tone",
-  "\ud83d\udd90\ud83c\udfff": "hand_with_fingers_splayed_dark_skin_tone",
-  "\ud83d\udd95": "middle_finger",
-  "\ud83d\udd95\ud83c\udffb": "middle_finger_light_skin_tone",
-  "\ud83d\udd95\ud83c\udffc": "middle_finger_medium-light_skin_tone",
-  "\ud83d\udd95\ud83c\udffd": "middle_finger_medium_skin_tone",
-  "\ud83d\udd95\ud83c\udffe": "middle_finger_medium-dark_skin_tone",
-  "\ud83d\udd95\ud83c\udfff": "middle_finger_dark_skin_tone",
-  "\ud83d\udd96": "vulcan_salute",
-  "\ud83d\udd96\ud83c\udffb": "vulcan_salute_light_skin_tone",
-  "\ud83d\udd96\ud83c\udffc": "vulcan_salute_medium-light_skin_tone",
-  "\ud83d\udd96\ud83c\udffd": "vulcan_salute_medium_skin_tone",
-  "\ud83d\udd96\ud83c\udffe": "vulcan_salute_medium-dark_skin_tone",
-  "\ud83d\udd96\ud83c\udfff": "vulcan_salute_dark_skin_tone",
-  "\ud83d\udda4": "black_heart",
-  "\ud83d\udda5": "desktop_computer",
-  "\ud83d\udda5\ufe0f": "desktop_computer",
-  "\ud83d\udda8": "printer",
-  "\ud83d\udda8\ufe0f": "printer",
-  "\ud83d\uddb1": "computer_mouse",
-  "\ud83d\uddb1\ufe0f": "computer_mouse",
-  "\ud83d\uddb2": "trackball",
-  "\ud83d\uddb2\ufe0f": "trackball",
-  "\ud83d\uddbc": "framed_picture",
-  "\ud83d\uddbc\ufe0f": "framed_picture",
-  "\ud83d\uddc2": "card_index_dividers",
-  "\ud83d\uddc2\ufe0f": "card_index_dividers",
-  "\ud83d\uddc3": "card_file_box",
-  "\ud83d\uddc3\ufe0f": "card_file_box",
-  "\ud83d\uddc4": "file_cabinet",
-  "\ud83d\uddc4\ufe0f": "file_cabinet",
-  "\ud83d\uddd1": "wastebasket",
-  "\ud83d\uddd1\ufe0f": "wastebasket",
-  "\ud83d\uddd2": "spiral_notepad",
-  "\ud83d\uddd2\ufe0f": "spiral_notepad",
-  "\ud83d\uddd3": "spiral_calendar",
-  "\ud83d\uddd3\ufe0f": "spiral_calendar",
-  "\ud83d\udddc": "clamp",
-  "\ud83d\udddc\ufe0f": "clamp",
-  "\ud83d\udddd": "old_key",
-  "\ud83d\udddd\ufe0f": "old_key",
-  "\ud83d\uddde": "rolled-up_newspaper",
-  "\ud83d\uddde\ufe0f": "rolled-up_newspaper",
-  "\ud83d\udde1": "dagger",
-  "\ud83d\udde1\ufe0f": "dagger",
-  "\ud83d\udde3": "speaking_head",
-  "\ud83d\udde3\ufe0f": "speaking_head",
-  "\ud83d\udde8": "left_speech_bubble",
-  "\ud83d\udde8\ufe0f": "left_speech_bubble",
-  "\ud83d\uddef": "right_anger_bubble",
-  "\ud83d\uddef\ufe0f": "right_anger_bubble",
-  "\ud83d\uddf3": "ballot_box_with_ballot",
-  "\ud83d\uddf3\ufe0f": "ballot_box_with_ballot",
-  "\ud83d\uddfa": "world_map",
-  "\ud83d\uddfa\ufe0f": "world_map",
-  "\ud83d\uddfb": "mount_fuji",
-  "\ud83d\uddfc": "tokyo_tower",
-  "\ud83d\uddfd": "statue_of_liberty",
-  "\ud83d\uddfe": "map_of_japan",
-  "\ud83d\uddff": "moai",
-  "\ud83d\ude00": "grinning_face",
-  "\ud83d\ude01": "beaming_face_with_smiling_eyes",
-  "\ud83d\ude02": "face_with_tears_of_joy",
-  "\ud83d\ude03": "grinning_face_with_big_eyes",
-  "\ud83d\ude04": "grinning_face_with_smiling_eyes",
-  "\ud83d\ude05": "grinning_face_with_sweat",
-  "\ud83d\ude06": "grinning_squinting_face",
-  "\ud83d\ude07": "smiling_face_with_halo",
-  "\ud83d\ude08": "smiling_face_with_horns",
-  "\ud83d\ude09": "winking_face",
-  "\ud83d\ude0a": "smiling_face_with_smiling_eyes",
-  "\ud83d\ude0b": "face_savoring_food",
-  "\ud83d\ude0c": "relieved_face",
-  "\ud83d\ude0d": "smiling_face_with_heart-eyes",
-  "\ud83d\ude0e": "smiling_face_with_sunglasses",
-  "\ud83d\ude0f": "smirking_face",
-  "\ud83d\ude10": "neutral_face",
-  "\ud83d\ude11": "expressionless_face",
-  "\ud83d\ude12": "unamused_face",
-  "\ud83d\ude13": "downcast_face_with_sweat",
-  "\ud83d\ude14": "pensive_face",
-  "\ud83d\ude15": "confused_face",
-  "\ud83d\ude16": "confounded_face",
-  "\ud83d\ude17": "kissing_face",
-  "\ud83d\ude18": "face_blowing_a_kiss",
-  "\ud83d\ude19": "kissing_face_with_smiling_eyes",
-  "\ud83d\ude1a": "kissing_face_with_closed_eyes",
-  "\ud83d\ude1b": "face_with_tongue",
-  "\ud83d\ude1c": "winking_face_with_tongue",
-  "\ud83d\ude1d": "squinting_face_with_tongue",
-  "\ud83d\ude1e": "disappointed_face",
-  "\ud83d\ude1f": "worried_face",
-  "\ud83d\ude20": "angry_face",
-  "\ud83d\ude21": "enraged_face",
-  "\ud83d\ude22": "crying_face",
-  "\ud83d\ude23": "persevering_face",
-  "\ud83d\ude24": "face_with_steam_from_nose",
-  "\ud83d\ude25": "sad_but_relieved_face",
-  "\ud83d\ude26": "frowning_face_with_open_mouth",
-  "\ud83d\ude27": "anguished_face",
-  "\ud83d\ude28": "fearful_face",
-  "\ud83d\ude29": "weary_face",
-  "\ud83d\ude2a": "sleepy_face",
-  "\ud83d\ude2b": "tired_face",
-  "\ud83d\ude2c": "grimacing_face",
-  "\ud83d\ude2d": "loudly_crying_face",
-  "\ud83d\ude2e": "face_with_open_mouth",
-  "\ud83d\ude2e\u200d\ud83d\udca8": "face_exhaling",
-  "\ud83d\ude2f": "hushed_face",
-  "\ud83d\ude30": "anxious_face_with_sweat",
-  "\ud83d\ude31": "face_screaming_in_fear",
-  "\ud83d\ude32": "astonished_face",
-  "\ud83d\ude33": "flushed_face",
-  "\ud83d\ude34": "sleeping_face",
-  "\ud83d\ude35": "face_with_crossed-out_eyes",
-  "\ud83d\ude35\u200d\ud83d\udcab": "face_with_spiral_eyes",
-  "\ud83d\ude36": "face_without_mouth",
-  "\ud83d\ude36\u200d\ud83c\udf2b": "face_in_clouds",
-  "\ud83d\ude36\u200d\ud83c\udf2b\ufe0f": "face_in_clouds",
-  "\ud83d\ude37": "face_with_medical_mask",
-  "\ud83d\ude38": "grinning_cat_with_smiling_eyes",
-  "\ud83d\ude39": "cat_with_tears_of_joy",
-  "\ud83d\ude3a": "grinning_cat",
-  "\ud83d\ude3b": "smiling_cat_with_heart-eyes",
-  "\ud83d\ude3c": "cat_with_wry_smile",
-  "\ud83d\ude3d": "kissing_cat",
-  "\ud83d\ude3e": "pouting_cat",
-  "\ud83d\ude3f": "crying_cat",
-  "\ud83d\ude40": "weary_cat",
-  "\ud83d\ude41": "slightly_frowning_face",
-  "\ud83d\ude42": "slightly_smiling_face",
-  "\ud83d\ude42\u200d\u2194": "head_shaking_horizontally",
-  "\ud83d\ude42\u200d\u2194\ufe0f": "head_shaking_horizontally",
-  "\ud83d\ude42\u200d\u2195": "head_shaking_vertically",
-  "\ud83d\ude42\u200d\u2195\ufe0f": "head_shaking_vertically",
-  "\ud83d\ude43": "upside-down_face",
-  "\ud83d\ude44": "face_with_rolling_eyes",
-  "\ud83d\ude45": "person_gesturing_no",
-  "\ud83d\ude45\u200d\u2640": "woman_gesturing_no",
-  "\ud83d\ude45\u200d\u2640\ufe0f": "woman_gesturing_no",
-  "\ud83d\ude45\u200d\u2642": "man_gesturing_no",
-  "\ud83d\ude45\u200d\u2642\ufe0f": "man_gesturing_no",
-  "\ud83d\ude45\ud83c\udffb": "person_gesturing_no_light_skin_tone",
-  "\ud83d\ude45\ud83c\udffb\u200d\u2640": "woman_gesturing_no_light_skin_tone",
-  "\ud83d\ude45\ud83c\udffb\u200d\u2640\ufe0f": "woman_gesturing_no_light_skin_tone",
-  "\ud83d\ude45\ud83c\udffb\u200d\u2642": "man_gesturing_no_light_skin_tone",
-  "\ud83d\ude45\ud83c\udffb\u200d\u2642\ufe0f": "man_gesturing_no_light_skin_tone",
-  "\ud83d\ude45\ud83c\udffc": "person_gesturing_no_medium-light_skin_tone",
-  "\ud83d\ude45\ud83c\udffc\u200d\u2640": "woman_gesturing_no_medium-light_skin_tone",
-  "\ud83d\ude45\ud83c\udffc\u200d\u2640\ufe0f": "woman_gesturing_no_medium-light_skin_tone",
-  "\ud83d\ude45\ud83c\udffc\u200d\u2642": "man_gesturing_no_medium-light_skin_tone",
-  "\ud83d\ude45\ud83c\udffc\u200d\u2642\ufe0f": "man_gesturing_no_medium-light_skin_tone",
-  "\ud83d\ude45\ud83c\udffd": "person_gesturing_no_medium_skin_tone",
-  "\ud83d\ude45\ud83c\udffd\u200d\u2640": "woman_gesturing_no_medium_skin_tone",
-  "\ud83d\ude45\ud83c\udffd\u200d\u2640\ufe0f": "woman_gesturing_no_medium_skin_tone",
-  "\ud83d\ude45\ud83c\udffd\u200d\u2642": "man_gesturing_no_medium_skin_tone",
-  "\ud83d\ude45\ud83c\udffd\u200d\u2642\ufe0f": "man_gesturing_no_medium_skin_tone",
-  "\ud83d\ude45\ud83c\udffe": "person_gesturing_no_medium-dark_skin_tone",
-  "\ud83d\ude45\ud83c\udffe\u200d\u2640": "woman_gesturing_no_medium-dark_skin_tone",
-  "\ud83d\ude45\ud83c\udffe\u200d\u2640\ufe0f": "woman_gesturing_no_medium-dark_skin_tone",
-  "\ud83d\ude45\ud83c\udffe\u200d\u2642": "man_gesturing_no_medium-dark_skin_tone",
-  "\ud83d\ude45\ud83c\udffe\u200d\u2642\ufe0f": "man_gesturing_no_medium-dark_skin_tone",
-  "\ud83d\ude45\ud83c\udfff": "person_gesturing_no_dark_skin_tone",
-  "\ud83d\ude45\ud83c\udfff\u200d\u2640": "woman_gesturing_no_dark_skin_tone",
-  "\ud83d\ude45\ud83c\udfff\u200d\u2640\ufe0f": "woman_gesturing_no_dark_skin_tone",
-  "\ud83d\ude45\ud83c\udfff\u200d\u2642": "man_gesturing_no_dark_skin_tone",
-  "\ud83d\ude45\ud83c\udfff\u200d\u2642\ufe0f": "man_gesturing_no_dark_skin_tone",
-  "\ud83d\ude46": "person_gesturing_ok",
-  "\ud83d\ude46\u200d\u2640": "woman_gesturing_ok",
-  "\ud83d\ude46\u200d\u2640\ufe0f": "woman_gesturing_ok",
-  "\ud83d\ude46\u200d\u2642": "man_gesturing_ok",
-  "\ud83d\ude46\u200d\u2642\ufe0f": "man_gesturing_ok",
-  "\ud83d\ude46\ud83c\udffb": "person_gesturing_ok_light_skin_tone",
-  "\ud83d\ude46\ud83c\udffb\u200d\u2640": "woman_gesturing_ok_light_skin_tone",
-  "\ud83d\ude46\ud83c\udffb\u200d\u2640\ufe0f": "woman_gesturing_ok_light_skin_tone",
-  "\ud83d\ude46\ud83c\udffb\u200d\u2642": "man_gesturing_ok_light_skin_tone",
-  "\ud83d\ude46\ud83c\udffb\u200d\u2642\ufe0f": "man_gesturing_ok_light_skin_tone",
-  "\ud83d\ude46\ud83c\udffc": "person_gesturing_ok_medium-light_skin_tone",
-  "\ud83d\ude46\ud83c\udffc\u200d\u2640": "woman_gesturing_ok_medium-light_skin_tone",
-  "\ud83d\ude46\ud83c\udffc\u200d\u2640\ufe0f": "woman_gesturing_ok_medium-light_skin_tone",
-  "\ud83d\ude46\ud83c\udffc\u200d\u2642": "man_gesturing_ok_medium-light_skin_tone",
-  "\ud83d\ude46\ud83c\udffc\u200d\u2642\ufe0f": "man_gesturing_ok_medium-light_skin_tone",
-  "\ud83d\ude46\ud83c\udffd": "person_gesturing_ok_medium_skin_tone",
-  "\ud83d\ude46\ud83c\udffd\u200d\u2640": "woman_gesturing_ok_medium_skin_tone",
-  "\ud83d\ude46\ud83c\udffd\u200d\u2640\ufe0f": "woman_gesturing_ok_medium_skin_tone",
-  "\ud83d\ude46\ud83c\udffd\u200d\u2642": "man_gesturing_ok_medium_skin_tone",
-  "\ud83d\ude46\ud83c\udffd\u200d\u2642\ufe0f": "man_gesturing_ok_medium_skin_tone",
-  "\ud83d\ude46\ud83c\udffe": "person_gesturing_ok_medium-dark_skin_tone",
-  "\ud83d\ude46\ud83c\udffe\u200d\u2640": "woman_gesturing_ok_medium-dark_skin_tone",
-  "\ud83d\ude46\ud83c\udffe\u200d\u2640\ufe0f": "woman_gesturing_ok_medium-dark_skin_tone",
-  "\ud83d\ude46\ud83c\udffe\u200d\u2642": "man_gesturing_ok_medium-dark_skin_tone",
-  "\ud83d\ude46\ud83c\udffe\u200d\u2642\ufe0f": "man_gesturing_ok_medium-dark_skin_tone",
-  "\ud83d\ude46\ud83c\udfff": "person_gesturing_ok_dark_skin_tone",
-  "\ud83d\ude46\ud83c\udfff\u200d\u2640": "woman_gesturing_ok_dark_skin_tone",
-  "\ud83d\ude46\ud83c\udfff\u200d\u2640\ufe0f": "woman_gesturing_ok_dark_skin_tone",
-  "\ud83d\ude46\ud83c\udfff\u200d\u2642": "man_gesturing_ok_dark_skin_tone",
-  "\ud83d\ude46\ud83c\udfff\u200d\u2642\ufe0f": "man_gesturing_ok_dark_skin_tone",
-  "\ud83d\ude47": "person_bowing",
-  "\ud83d\ude47\u200d\u2640": "woman_bowing",
-  "\ud83d\ude47\u200d\u2640\ufe0f": "woman_bowing",
-  "\ud83d\ude47\u200d\u2642": "man_bowing",
-  "\ud83d\ude47\u200d\u2642\ufe0f": "man_bowing",
-  "\ud83d\ude47\ud83c\udffb": "person_bowing_light_skin_tone",
-  "\ud83d\ude47\ud83c\udffb\u200d\u2640": "woman_bowing_light_skin_tone",
-  "\ud83d\ude47\ud83c\udffb\u200d\u2640\ufe0f": "woman_bowing_light_skin_tone",
-  "\ud83d\ude47\ud83c\udffb\u200d\u2642": "man_bowing_light_skin_tone",
-  "\ud83d\ude47\ud83c\udffb\u200d\u2642\ufe0f": "man_bowing_light_skin_tone",
-  "\ud83d\ude47\ud83c\udffc": "person_bowing_medium-light_skin_tone",
-  "\ud83d\ude47\ud83c\udffc\u200d\u2640": "woman_bowing_medium-light_skin_tone",
-  "\ud83d\ude47\ud83c\udffc\u200d\u2640\ufe0f": "woman_bowing_medium-light_skin_tone",
-  "\ud83d\ude47\ud83c\udffc\u200d\u2642": "man_bowing_medium-light_skin_tone",
-  "\ud83d\ude47\ud83c\udffc\u200d\u2642\ufe0f": "man_bowing_medium-light_skin_tone",
-  "\ud83d\ude47\ud83c\udffd": "person_bowing_medium_skin_tone",
-  "\ud83d\ude47\ud83c\udffd\u200d\u2640": "woman_bowing_medium_skin_tone",
-  "\ud83d\ude47\ud83c\udffd\u200d\u2640\ufe0f": "woman_bowing_medium_skin_tone",
-  "\ud83d\ude47\ud83c\udffd\u200d\u2642": "man_bowing_medium_skin_tone",
-  "\ud83d\ude47\ud83c\udffd\u200d\u2642\ufe0f": "man_bowing_medium_skin_tone",
-  "\ud83d\ude47\ud83c\udffe": "person_bowing_medium-dark_skin_tone",
-  "\ud83d\ude47\ud83c\udffe\u200d\u2640": "woman_bowing_medium-dark_skin_tone",
-  "\ud83d\ude47\ud83c\udffe\u200d\u2640\ufe0f": "woman_bowing_medium-dark_skin_tone",
-  "\ud83d\ude47\ud83c\udffe\u200d\u2642": "man_bowing_medium-dark_skin_tone",
-  "\ud83d\ude47\ud83c\udffe\u200d\u2642\ufe0f": "man_bowing_medium-dark_skin_tone",
-  "\ud83d\ude47\ud83c\udfff": "person_bowing_dark_skin_tone",
-  "\ud83d\ude47\ud83c\udfff\u200d\u2640": "woman_bowing_dark_skin_tone",
-  "\ud83d\ude47\ud83c\udfff\u200d\u2640\ufe0f": "woman_bowing_dark_skin_tone",
-  "\ud83d\ude47\ud83c\udfff\u200d\u2642": "man_bowing_dark_skin_tone",
-  "\ud83d\ude47\ud83c\udfff\u200d\u2642\ufe0f": "man_bowing_dark_skin_tone",
-  "\ud83d\ude48": "see-no-evil_monkey",
-  "\ud83d\ude49": "hear-no-evil_monkey",
-  "\ud83d\ude4a": "speak-no-evil_monkey",
-  "\ud83d\ude4b": "person_raising_hand",
-  "\ud83d\ude4b\u200d\u2640": "woman_raising_hand",
-  "\ud83d\ude4b\u200d\u2640\ufe0f": "woman_raising_hand",
-  "\ud83d\ude4b\u200d\u2642": "man_raising_hand",
-  "\ud83d\ude4b\u200d\u2642\ufe0f": "man_raising_hand",
-  "\ud83d\ude4b\ud83c\udffb": "person_raising_hand_light_skin_tone",
-  "\ud83d\ude4b\ud83c\udffb\u200d\u2640": "woman_raising_hand_light_skin_tone",
-  "\ud83d\ude4b\ud83c\udffb\u200d\u2640\ufe0f": "woman_raising_hand_light_skin_tone",
-  "\ud83d\ude4b\ud83c\udffb\u200d\u2642": "man_raising_hand_light_skin_tone",
-  "\ud83d\ude4b\ud83c\udffb\u200d\u2642\ufe0f": "man_raising_hand_light_skin_tone",
-  "\ud83d\ude4b\ud83c\udffc": "person_raising_hand_medium-light_skin_tone",
-  "\ud83d\ude4b\ud83c\udffc\u200d\u2640": "woman_raising_hand_medium-light_skin_tone",
-  "\ud83d\ude4b\ud83c\udffc\u200d\u2640\ufe0f": "woman_raising_hand_medium-light_skin_tone",
-  "\ud83d\ude4b\ud83c\udffc\u200d\u2642": "man_raising_hand_medium-light_skin_tone",
-  "\ud83d\ude4b\ud83c\udffc\u200d\u2642\ufe0f": "man_raising_hand_medium-light_skin_tone",
-  "\ud83d\ude4b\ud83c\udffd": "person_raising_hand_medium_skin_tone",
-  "\ud83d\ude4b\ud83c\udffd\u200d\u2640": "woman_raising_hand_medium_skin_tone",
-  "\ud83d\ude4b\ud83c\udffd\u200d\u2640\ufe0f": "woman_raising_hand_medium_skin_tone",
-  "\ud83d\ude4b\ud83c\udffd\u200d\u2642": "man_raising_hand_medium_skin_tone",
-  "\ud83d\ude4b\ud83c\udffd\u200d\u2642\ufe0f": "man_raising_hand_medium_skin_tone",
-  "\ud83d\ude4b\ud83c\udffe": "person_raising_hand_medium-dark_skin_tone",
-  "\ud83d\ude4b\ud83c\udffe\u200d\u2640": "woman_raising_hand_medium-dark_skin_tone",
-  "\ud83d\ude4b\ud83c\udffe\u200d\u2640\ufe0f": "woman_raising_hand_medium-dark_skin_tone",
-  "\ud83d\ude4b\ud83c\udffe\u200d\u2642": "man_raising_hand_medium-dark_skin_tone",
-  "\ud83d\ude4b\ud83c\udffe\u200d\u2642\ufe0f": "man_raising_hand_medium-dark_skin_tone",
-  "\ud83d\ude4b\ud83c\udfff": "person_raising_hand_dark_skin_tone",
-  "\ud83d\ude4b\ud83c\udfff\u200d\u2640": "woman_raising_hand_dark_skin_tone",
-  "\ud83d\ude4b\ud83c\udfff\u200d\u2640\ufe0f": "woman_raising_hand_dark_skin_tone",
-  "\ud83d\ude4b\ud83c\udfff\u200d\u2642": "man_raising_hand_dark_skin_tone",
-  "\ud83d\ude4b\ud83c\udfff\u200d\u2642\ufe0f": "man_raising_hand_dark_skin_tone",
-  "\ud83d\ude4c": "raising_hands",
-  "\ud83d\ude4c\ud83c\udffb": "raising_hands_light_skin_tone",
-  "\ud83d\ude4c\ud83c\udffc": "raising_hands_medium-light_skin_tone",
-  "\ud83d\ude4c\ud83c\udffd": "raising_hands_medium_skin_tone",
-  "\ud83d\ude4c\ud83c\udffe": "raising_hands_medium-dark_skin_tone",
-  "\ud83d\ude4c\ud83c\udfff": "raising_hands_dark_skin_tone",
-  "\ud83d\ude4d": "person_frowning",
-  "\ud83d\ude4d\u200d\u2640": "woman_frowning",
-  "\ud83d\ude4d\u200d\u2640\ufe0f": "woman_frowning",
-  "\ud83d\ude4d\u200d\u2642": "man_frowning",
-  "\ud83d\ude4d\u200d\u2642\ufe0f": "man_frowning",
-  "\ud83d\ude4d\ud83c\udffb": "person_frowning_light_skin_tone",
-  "\ud83d\ude4d\ud83c\udffb\u200d\u2640": "woman_frowning_light_skin_tone",
-  "\ud83d\ude4d\ud83c\udffb\u200d\u2640\ufe0f": "woman_frowning_light_skin_tone",
-  "\ud83d\ude4d\ud83c\udffb\u200d\u2642": "man_frowning_light_skin_tone",
-  "\ud83d\ude4d\ud83c\udffb\u200d\u2642\ufe0f": "man_frowning_light_skin_tone",
-  "\ud83d\ude4d\ud83c\udffc": "person_frowning_medium-light_skin_tone",
-  "\ud83d\ude4d\ud83c\udffc\u200d\u2640": "woman_frowning_medium-light_skin_tone",
-  "\ud83d\ude4d\ud83c\udffc\u200d\u2640\ufe0f": "woman_frowning_medium-light_skin_tone",
-  "\ud83d\ude4d\ud83c\udffc\u200d\u2642": "man_frowning_medium-light_skin_tone",
-  "\ud83d\ude4d\ud83c\udffc\u200d\u2642\ufe0f": "man_frowning_medium-light_skin_tone",
-  "\ud83d\ude4d\ud83c\udffd": "person_frowning_medium_skin_tone",
-  "\ud83d\ude4d\ud83c\udffd\u200d\u2640": "woman_frowning_medium_skin_tone",
-  "\ud83d\ude4d\ud83c\udffd\u200d\u2640\ufe0f": "woman_frowning_medium_skin_tone",
-  "\ud83d\ude4d\ud83c\udffd\u200d\u2642": "man_frowning_medium_skin_tone",
-  "\ud83d\ude4d\ud83c\udffd\u200d\u2642\ufe0f": "man_frowning_medium_skin_tone",
-  "\ud83d\ude4d\ud83c\udffe": "person_frowning_medium-dark_skin_tone",
-  "\ud83d\ude4d\ud83c\udffe\u200d\u2640": "woman_frowning_medium-dark_skin_tone",
-  "\ud83d\ude4d\ud83c\udffe\u200d\u2640\ufe0f": "woman_frowning_medium-dark_skin_tone",
-  "\ud83d\ude4d\ud83c\udffe\u200d\u2642": "man_frowning_medium-dark_skin_tone",
-  "\ud83d\ude4d\ud83c\udffe\u200d\u2642\ufe0f": "man_frowning_medium-dark_skin_tone",
-  "\ud83d\ude4d\ud83c\udfff": "person_frowning_dark_skin_tone",
-  "\ud83d\ude4d\ud83c\udfff\u200d\u2640": "woman_frowning_dark_skin_tone",
-  "\ud83d\ude4d\ud83c\udfff\u200d\u2640\ufe0f": "woman_frowning_dark_skin_tone",
-  "\ud83d\ude4d\ud83c\udfff\u200d\u2642": "man_frowning_dark_skin_tone",
-  "\ud83d\ude4d\ud83c\udfff\u200d\u2642\ufe0f": "man_frowning_dark_skin_tone",
-  "\ud83d\ude4e": "person_pouting",
-  "\ud83d\ude4e\u200d\u2640": "woman_pouting",
-  "\ud83d\ude4e\u200d\u2640\ufe0f": "woman_pouting",
-  "\ud83d\ude4e\u200d\u2642": "man_pouting",
-  "\ud83d\ude4e\u200d\u2642\ufe0f": "man_pouting",
-  "\ud83d\ude4e\ud83c\udffb": "person_pouting_light_skin_tone",
-  "\ud83d\ude4e\ud83c\udffb\u200d\u2640": "woman_pouting_light_skin_tone",
-  "\ud83d\ude4e\ud83c\udffb\u200d\u2640\ufe0f": "woman_pouting_light_skin_tone",
-  "\ud83d\ude4e\ud83c\udffb\u200d\u2642": "man_pouting_light_skin_tone",
-  "\ud83d\ude4e\ud83c\udffb\u200d\u2642\ufe0f": "man_pouting_light_skin_tone",
-  "\ud83d\ude4e\ud83c\udffc": "person_pouting_medium-light_skin_tone",
-  "\ud83d\ude4e\ud83c\udffc\u200d\u2640": "woman_pouting_medium-light_skin_tone",
-  "\ud83d\ude4e\ud83c\udffc\u200d\u2640\ufe0f": "woman_pouting_medium-light_skin_tone",
-  "\ud83d\ude4e\ud83c\udffc\u200d\u2642": "man_pouting_medium-light_skin_tone",
-  "\ud83d\ude4e\ud83c\udffc\u200d\u2642\ufe0f": "man_pouting_medium-light_skin_tone",
-  "\ud83d\ude4e\ud83c\udffd": "person_pouting_medium_skin_tone",
-  "\ud83d\ude4e\ud83c\udffd\u200d\u2640": "woman_pouting_medium_skin_tone",
-  "\ud83d\ude4e\ud83c\udffd\u200d\u2640\ufe0f": "woman_pouting_medium_skin_tone",
-  "\ud83d\ude4e\ud83c\udffd\u200d\u2642": "man_pouting_medium_skin_tone",
-  "\ud83d\ude4e\ud83c\udffd\u200d\u2642\ufe0f": "man_pouting_medium_skin_tone",
-  "\ud83d\ude4e\ud83c\udffe": "person_pouting_medium-dark_skin_tone",
-  "\ud83d\ude4e\ud83c\udffe\u200d\u2640": "woman_pouting_medium-dark_skin_tone",
-  "\ud83d\ude4e\ud83c\udffe\u200d\u2640\ufe0f": "woman_pouting_medium-dark_skin_tone",
-  "\ud83d\ude4e\ud83c\udffe\u200d\u2642": "man_pouting_medium-dark_skin_tone",
-  "\ud83d\ude4e\ud83c\udffe\u200d\u2642\ufe0f": "man_pouting_medium-dark_skin_tone",
-  "\ud83d\ude4e\ud83c\udfff": "person_pouting_dark_skin_tone",
-  "\ud83d\ude4e\ud83c\udfff\u200d\u2640": "woman_pouting_dark_skin_tone",
-  "\ud83d\ude4e\ud83c\udfff\u200d\u2640\ufe0f": "woman_pouting_dark_skin_tone",
-  "\ud83d\ude4e\ud83c\udfff\u200d\u2642": "man_pouting_dark_skin_tone",
-  "\ud83d\ude4e\ud83c\udfff\u200d\u2642\ufe0f": "man_pouting_dark_skin_tone",
-  "\ud83d\ude4f": "folded_hands",
-  "\ud83d\ude4f\ud83c\udffb": "folded_hands_light_skin_tone",
-  "\ud83d\ude4f\ud83c\udffc": "folded_hands_medium-light_skin_tone",
-  "\ud83d\ude4f\ud83c\udffd": "folded_hands_medium_skin_tone",
-  "\ud83d\ude4f\ud83c\udffe": "folded_hands_medium-dark_skin_tone",
-  "\ud83d\ude4f\ud83c\udfff": "folded_hands_dark_skin_tone",
-  "\ud83d\ude80": "rocket",
-  "\ud83d\ude81": "helicopter",
-  "\ud83d\ude82": "locomotive",
-  "\ud83d\ude83": "railway_car",
-  "\ud83d\ude84": "high-speed_train",
-  "\ud83d\ude85": "bullet_train",
-  "\ud83d\ude86": "train",
-  "\ud83d\ude87": "metro",
-  "\ud83d\ude88": "light_rail",
-  "\ud83d\ude89": "station",
-  "\ud83d\ude8a": "tram",
-  "\ud83d\ude8b": "tram_car",
-  "\ud83d\ude8c": "bus",
-  "\ud83d\ude8d": "oncoming_bus",
-  "\ud83d\ude8e": "trolleybus",
-  "\ud83d\ude8f": "bus_stop",
-  "\ud83d\ude90": "minibus",
-  "\ud83d\ude91": "ambulance",
-  "\ud83d\ude92": "fire_engine",
-  "\ud83d\ude93": "police_car",
-  "\ud83d\ude94": "oncoming_police_car",
-  "\ud83d\ude95": "taxi",
-  "\ud83d\ude96": "oncoming_taxi",
-  "\ud83d\ude97": "automobile",
-  "\ud83d\ude98": "oncoming_automobile",
-  "\ud83d\ude99": "sport_utility_vehicle",
-  "\ud83d\ude9a": "delivery_truck",
-  "\ud83d\ude9b": "articulated_lorry",
-  "\ud83d\ude9c": "tractor",
-  "\ud83d\ude9d": "monorail",
-  "\ud83d\ude9e": "mountain_railway",
-  "\ud83d\ude9f": "suspension_railway",
-  "\ud83d\udea0": "mountain_cableway",
-  "\ud83d\udea1": "aerial_tramway",
-  "\ud83d\udea2": "ship",
-  "\ud83d\udea3": "person_rowing_boat",
-  "\ud83d\udea3\u200d\u2640": "woman_rowing_boat",
-  "\ud83d\udea3\u200d\u2640\ufe0f": "woman_rowing_boat",
-  "\ud83d\udea3\u200d\u2642": "man_rowing_boat",
-  "\ud83d\udea3\u200d\u2642\ufe0f": "man_rowing_boat",
-  "\ud83d\udea3\ud83c\udffb": "person_rowing_boat_light_skin_tone",
-  "\ud83d\udea3\ud83c\udffb\u200d\u2640": "woman_rowing_boat_light_skin_tone",
-  "\ud83d\udea3\ud83c\udffb\u200d\u2640\ufe0f": "woman_rowing_boat_light_skin_tone",
-  "\ud83d\udea3\ud83c\udffb\u200d\u2642": "man_rowing_boat_light_skin_tone",
-  "\ud83d\udea3\ud83c\udffb\u200d\u2642\ufe0f": "man_rowing_boat_light_skin_tone",
-  "\ud83d\udea3\ud83c\udffc": "person_rowing_boat_medium-light_skin_tone",
-  "\ud83d\udea3\ud83c\udffc\u200d\u2640": "woman_rowing_boat_medium-light_skin_tone",
-  "\ud83d\udea3\ud83c\udffc\u200d\u2640\ufe0f": "woman_rowing_boat_medium-light_skin_tone",
-  "\ud83d\udea3\ud83c\udffc\u200d\u2642": "man_rowing_boat_medium-light_skin_tone",
-  "\ud83d\udea3\ud83c\udffc\u200d\u2642\ufe0f": "man_rowing_boat_medium-light_skin_tone",
-  "\ud83d\udea3\ud83c\udffd": "person_rowing_boat_medium_skin_tone",
-  "\ud83d\udea3\ud83c\udffd\u200d\u2640": "woman_rowing_boat_medium_skin_tone",
-  "\ud83d\udea3\ud83c\udffd\u200d\u2640\ufe0f": "woman_rowing_boat_medium_skin_tone",
-  "\ud83d\udea3\ud83c\udffd\u200d\u2642": "man_rowing_boat_medium_skin_tone",
-  "\ud83d\udea3\ud83c\udffd\u200d\u2642\ufe0f": "man_rowing_boat_medium_skin_tone",
-  "\ud83d\udea3\ud83c\udffe": "person_rowing_boat_medium-dark_skin_tone",
-  "\ud83d\udea3\ud83c\udffe\u200d\u2640": "woman_rowing_boat_medium-dark_skin_tone",
-  "\ud83d\udea3\ud83c\udffe\u200d\u2640\ufe0f": "woman_rowing_boat_medium-dark_skin_tone",
-  "\ud83d\udea3\ud83c\udffe\u200d\u2642": "man_rowing_boat_medium-dark_skin_tone",
-  "\ud83d\udea3\ud83c\udffe\u200d\u2642\ufe0f": "man_rowing_boat_medium-dark_skin_tone",
-  "\ud83d\udea3\ud83c\udfff": "person_rowing_boat_dark_skin_tone",
-  "\ud83d\udea3\ud83c\udfff\u200d\u2640": "woman_rowing_boat_dark_skin_tone",
-  "\ud83d\udea3\ud83c\udfff\u200d\u2640\ufe0f": "woman_rowing_boat_dark_skin_tone",
-  "\ud83d\udea3\ud83c\udfff\u200d\u2642": "man_rowing_boat_dark_skin_tone",
-  "\ud83d\udea3\ud83c\udfff\u200d\u2642\ufe0f": "man_rowing_boat_dark_skin_tone",
-  "\ud83d\udea4": "speedboat",
-  "\ud83d\udea5": "horizontal_traffic_light",
-  "\ud83d\udea6": "vertical_traffic_light",
-  "\ud83d\udea7": "construction",
-  "\ud83d\udea8": "police_car_light",
-  "\ud83d\udea9": "triangular_flag",
-  "\ud83d\udeaa": "door",
-  "\ud83d\udeab": "prohibited",
-  "\ud83d\udeac": "cigarette",
-  "\ud83d\udead": "no_smoking",
-  "\ud83d\udeae": "litter_in_bin_sign",
-  "\ud83d\udeaf": "no_littering",
-  "\ud83d\udeb0": "potable_water",
-  "\ud83d\udeb1": "non-potable_water",
-  "\ud83d\udeb2": "bicycle",
-  "\ud83d\udeb3": "no_bicycles",
-  "\ud83d\udeb4": "person_biking",
-  "\ud83d\udeb4\u200d\u2640": "woman_biking",
-  "\ud83d\udeb4\u200d\u2640\ufe0f": "woman_biking",
-  "\ud83d\udeb4\u200d\u2642": "man_biking",
-  "\ud83d\udeb4\u200d\u2642\ufe0f": "man_biking",
-  "\ud83d\udeb4\ud83c\udffb": "person_biking_light_skin_tone",
-  "\ud83d\udeb4\ud83c\udffb\u200d\u2640": "woman_biking_light_skin_tone",
-  "\ud83d\udeb4\ud83c\udffb\u200d\u2640\ufe0f": "woman_biking_light_skin_tone",
-  "\ud83d\udeb4\ud83c\udffb\u200d\u2642": "man_biking_light_skin_tone",
-  "\ud83d\udeb4\ud83c\udffb\u200d\u2642\ufe0f": "man_biking_light_skin_tone",
-  "\ud83d\udeb4\ud83c\udffc": "person_biking_medium-light_skin_tone",
-  "\ud83d\udeb4\ud83c\udffc\u200d\u2640": "woman_biking_medium-light_skin_tone",
-  "\ud83d\udeb4\ud83c\udffc\u200d\u2640\ufe0f": "woman_biking_medium-light_skin_tone",
-  "\ud83d\udeb4\ud83c\udffc\u200d\u2642": "man_biking_medium-light_skin_tone",
-  "\ud83d\udeb4\ud83c\udffc\u200d\u2642\ufe0f": "man_biking_medium-light_skin_tone",
-  "\ud83d\udeb4\ud83c\udffd": "person_biking_medium_skin_tone",
-  "\ud83d\udeb4\ud83c\udffd\u200d\u2640": "woman_biking_medium_skin_tone",
-  "\ud83d\udeb4\ud83c\udffd\u200d\u2640\ufe0f": "woman_biking_medium_skin_tone",
-  "\ud83d\udeb4\ud83c\udffd\u200d\u2642": "man_biking_medium_skin_tone",
-  "\ud83d\udeb4\ud83c\udffd\u200d\u2642\ufe0f": "man_biking_medium_skin_tone",
-  "\ud83d\udeb4\ud83c\udffe": "person_biking_medium-dark_skin_tone",
-  "\ud83d\udeb4\ud83c\udffe\u200d\u2640": "woman_biking_medium-dark_skin_tone",
-  "\ud83d\udeb4\ud83c\udffe\u200d\u2640\ufe0f": "woman_biking_medium-dark_skin_tone",
-  "\ud83d\udeb4\ud83c\udffe\u200d\u2642": "man_biking_medium-dark_skin_tone",
-  "\ud83d\udeb4\ud83c\udffe\u200d\u2642\ufe0f": "man_biking_medium-dark_skin_tone",
-  "\ud83d\udeb4\ud83c\udfff": "person_biking_dark_skin_tone",
-  "\ud83d\udeb4\ud83c\udfff\u200d\u2640": "woman_biking_dark_skin_tone",
-  "\ud83d\udeb4\ud83c\udfff\u200d\u2640\ufe0f": "woman_biking_dark_skin_tone",
-  "\ud83d\udeb4\ud83c\udfff\u200d\u2642": "man_biking_dark_skin_tone",
-  "\ud83d\udeb4\ud83c\udfff\u200d\u2642\ufe0f": "man_biking_dark_skin_tone",
-  "\ud83d\udeb5": "person_mountain_biking",
-  "\ud83d\udeb5\u200d\u2640": "woman_mountain_biking",
-  "\ud83d\udeb5\u200d\u2640\ufe0f": "woman_mountain_biking",
-  "\ud83d\udeb5\u200d\u2642": "man_mountain_biking",
-  "\ud83d\udeb5\u200d\u2642\ufe0f": "man_mountain_biking",
-  "\ud83d\udeb5\ud83c\udffb": "person_mountain_biking_light_skin_tone",
-  "\ud83d\udeb5\ud83c\udffb\u200d\u2640": "woman_mountain_biking_light_skin_tone",
-  "\ud83d\udeb5\ud83c\udffb\u200d\u2640\ufe0f": "woman_mountain_biking_light_skin_tone",
-  "\ud83d\udeb5\ud83c\udffb\u200d\u2642": "man_mountain_biking_light_skin_tone",
-  "\ud83d\udeb5\ud83c\udffb\u200d\u2642\ufe0f": "man_mountain_biking_light_skin_tone",
-  "\ud83d\udeb5\ud83c\udffc": "person_mountain_biking_medium-light_skin_tone",
-  "\ud83d\udeb5\ud83c\udffc\u200d\u2640": "woman_mountain_biking_medium-light_skin_tone",
-  "\ud83d\udeb5\ud83c\udffc\u200d\u2640\ufe0f": "woman_mountain_biking_medium-light_skin_tone",
-  "\ud83d\udeb5\ud83c\udffc\u200d\u2642": "man_mountain_biking_medium-light_skin_tone",
-  "\ud83d\udeb5\ud83c\udffc\u200d\u2642\ufe0f": "man_mountain_biking_medium-light_skin_tone",
-  "\ud83d\udeb5\ud83c\udffd": "person_mountain_biking_medium_skin_tone",
-  "\ud83d\udeb5\ud83c\udffd\u200d\u2640": "woman_mountain_biking_medium_skin_tone",
-  "\ud83d\udeb5\ud83c\udffd\u200d\u2640\ufe0f": "woman_mountain_biking_medium_skin_tone",
-  "\ud83d\udeb5\ud83c\udffd\u200d\u2642": "man_mountain_biking_medium_skin_tone",
-  "\ud83d\udeb5\ud83c\udffd\u200d\u2642\ufe0f": "man_mountain_biking_medium_skin_tone",
-  "\ud83d\udeb5\ud83c\udffe": "person_mountain_biking_medium-dark_skin_tone",
-  "\ud83d\udeb5\ud83c\udffe\u200d\u2640": "woman_mountain_biking_medium-dark_skin_tone",
-  "\ud83d\udeb5\ud83c\udffe\u200d\u2640\ufe0f": "woman_mountain_biking_medium-dark_skin_tone",
-  "\ud83d\udeb5\ud83c\udffe\u200d\u2642": "man_mountain_biking_medium-dark_skin_tone",
-  "\ud83d\udeb5\ud83c\udffe\u200d\u2642\ufe0f": "man_mountain_biking_medium-dark_skin_tone",
-  "\ud83d\udeb5\ud83c\udfff": "person_mountain_biking_dark_skin_tone",
-  "\ud83d\udeb5\ud83c\udfff\u200d\u2640": "woman_mountain_biking_dark_skin_tone",
-  "\ud83d\udeb5\ud83c\udfff\u200d\u2640\ufe0f": "woman_mountain_biking_dark_skin_tone",
-  "\ud83d\udeb5\ud83c\udfff\u200d\u2642": "man_mountain_biking_dark_skin_tone",
-  "\ud83d\udeb5\ud83c\udfff\u200d\u2642\ufe0f": "man_mountain_biking_dark_skin_tone",
-  "\ud83d\udeb6": "person_walking",
-  "\ud83d\udeb6\u200d\u2640": "woman_walking",
-  "\ud83d\udeb6\u200d\u2640\u200d\u27a1": "woman_walking_facing_right",
-  "\ud83d\udeb6\u200d\u2640\u200d\u27a1\ufe0f": "woman_walking_facing_right",
-  "\ud83d\udeb6\u200d\u2640\ufe0f": "woman_walking",
-  "\ud83d\udeb6\u200d\u2640\ufe0f\u200d\u27a1": "woman_walking_facing_right",
-  "\ud83d\udeb6\u200d\u2640\ufe0f\u200d\u27a1\ufe0f": "woman_walking_facing_right",
-  "\ud83d\udeb6\u200d\u2642": "man_walking",
-  "\ud83d\udeb6\u200d\u2642\u200d\u27a1": "man_walking_facing_right",
-  "\ud83d\udeb6\u200d\u2642\u200d\u27a1\ufe0f": "man_walking_facing_right",
-  "\ud83d\udeb6\u200d\u2642\ufe0f": "man_walking",
-  "\ud83d\udeb6\u200d\u2642\ufe0f\u200d\u27a1": "man_walking_facing_right",
-  "\ud83d\udeb6\u200d\u2642\ufe0f\u200d\u27a1\ufe0f": "man_walking_facing_right",
-  "\ud83d\udeb6\u200d\u27a1": "person_walking_facing_right",
-  "\ud83d\udeb6\u200d\u27a1\ufe0f": "person_walking_facing_right",
-  "\ud83d\udeb6\ud83c\udffb": "person_walking_light_skin_tone",
-  "\ud83d\udeb6\ud83c\udffb\u200d\u2640": "woman_walking_light_skin_tone",
-  "\ud83d\udeb6\ud83c\udffb\u200d\u2640\u200d\u27a1": "woman_walking_facing_right_light_skin_tone",
-  "\ud83d\udeb6\ud83c\udffb\u200d\u2640\u200d\u27a1\ufe0f": "woman_walking_facing_right_light_skin_tone",
-  "\ud83d\udeb6\ud83c\udffb\u200d\u2640\ufe0f": "woman_walking_light_skin_tone",
-  "\ud83d\udeb6\ud83c\udffb\u200d\u2640\ufe0f\u200d\u27a1": "woman_walking_facing_right_light_skin_tone",
-  "\ud83d\udeb6\ud83c\udffb\u200d\u2640\ufe0f\u200d\u27a1\ufe0f": "woman_walking_facing_right_light_skin_tone",
-  "\ud83d\udeb6\ud83c\udffb\u200d\u2642": "man_walking_light_skin_tone",
-  "\ud83d\udeb6\ud83c\udffb\u200d\u2642\u200d\u27a1": "man_walking_facing_right_light_skin_tone",
-  "\ud83d\udeb6\ud83c\udffb\u200d\u2642\u200d\u27a1\ufe0f": "man_walking_facing_right_light_skin_tone",
-  "\ud83d\udeb6\ud83c\udffb\u200d\u2642\ufe0f": "man_walking_light_skin_tone",
-  "\ud83d\udeb6\ud83c\udffb\u200d\u2642\ufe0f\u200d\u27a1": "man_walking_facing_right_light_skin_tone",
-  "\ud83d\udeb6\ud83c\udffb\u200d\u2642\ufe0f\u200d\u27a1\ufe0f": "man_walking_facing_right_light_skin_tone",
-  "\ud83d\udeb6\ud83c\udffb\u200d\u27a1": "person_walking_facing_right_light_skin_tone",
-  "\ud83d\udeb6\ud83c\udffb\u200d\u27a1\ufe0f": "person_walking_facing_right_light_skin_tone",
-  "\ud83d\udeb6\ud83c\udffc": "person_walking_medium-light_skin_tone",
-  "\ud83d\udeb6\ud83c\udffc\u200d\u2640": "woman_walking_medium-light_skin_tone",
-  "\ud83d\udeb6\ud83c\udffc\u200d\u2640\u200d\u27a1": "woman_walking_facing_right_medium-light_skin_tone",
-  "\ud83d\udeb6\ud83c\udffc\u200d\u2640\u200d\u27a1\ufe0f": "woman_walking_facing_right_medium-light_skin_tone",
-  "\ud83d\udeb6\ud83c\udffc\u200d\u2640\ufe0f": "woman_walking_medium-light_skin_tone",
-  "\ud83d\udeb6\ud83c\udffc\u200d\u2640\ufe0f\u200d\u27a1": "woman_walking_facing_right_medium-light_skin_tone",
-  "\ud83d\udeb6\ud83c\udffc\u200d\u2640\ufe0f\u200d\u27a1\ufe0f": "woman_walking_facing_right_medium-light_skin_tone",
-  "\ud83d\udeb6\ud83c\udffc\u200d\u2642": "man_walking_medium-light_skin_tone",
-  "\ud83d\udeb6\ud83c\udffc\u200d\u2642\u200d\u27a1": "man_walking_facing_right_medium-light_skin_tone",
-  "\ud83d\udeb6\ud83c\udffc\u200d\u2642\u200d\u27a1\ufe0f": "man_walking_facing_right_medium-light_skin_tone",
-  "\ud83d\udeb6\ud83c\udffc\u200d\u2642\ufe0f": "man_walking_medium-light_skin_tone",
-  "\ud83d\udeb6\ud83c\udffc\u200d\u2642\ufe0f\u200d\u27a1": "man_walking_facing_right_medium-light_skin_tone",
-  "\ud83d\udeb6\ud83c\udffc\u200d\u2642\ufe0f\u200d\u27a1\ufe0f": "man_walking_facing_right_medium-light_skin_tone",
-  "\ud83d\udeb6\ud83c\udffc\u200d\u27a1": "person_walking_facing_right_medium-light_skin_tone",
-  "\ud83d\udeb6\ud83c\udffc\u200d\u27a1\ufe0f": "person_walking_facing_right_medium-light_skin_tone",
-  "\ud83d\udeb6\ud83c\udffd": "person_walking_medium_skin_tone",
-  "\ud83d\udeb6\ud83c\udffd\u200d\u2640": "woman_walking_medium_skin_tone",
-  "\ud83d\udeb6\ud83c\udffd\u200d\u2640\u200d\u27a1": "woman_walking_facing_right_medium_skin_tone",
-  "\ud83d\udeb6\ud83c\udffd\u200d\u2640\u200d\u27a1\ufe0f": "woman_walking_facing_right_medium_skin_tone",
-  "\ud83d\udeb6\ud83c\udffd\u200d\u2640\ufe0f": "woman_walking_medium_skin_tone",
-  "\ud83d\udeb6\ud83c\udffd\u200d\u2640\ufe0f\u200d\u27a1": "woman_walking_facing_right_medium_skin_tone",
-  "\ud83d\udeb6\ud83c\udffd\u200d\u2640\ufe0f\u200d\u27a1\ufe0f": "woman_walking_facing_right_medium_skin_tone",
-  "\ud83d\udeb6\ud83c\udffd\u200d\u2642": "man_walking_medium_skin_tone",
-  "\ud83d\udeb6\ud83c\udffd\u200d\u2642\u200d\u27a1": "man_walking_facing_right_medium_skin_tone",
-  "\ud83d\udeb6\ud83c\udffd\u200d\u2642\u200d\u27a1\ufe0f": "man_walking_facing_right_medium_skin_tone",
-  "\ud83d\udeb6\ud83c\udffd\u200d\u2642\ufe0f": "man_walking_medium_skin_tone",
-  "\ud83d\udeb6\ud83c\udffd\u200d\u2642\ufe0f\u200d\u27a1": "man_walking_facing_right_medium_skin_tone",
-  "\ud83d\udeb6\ud83c\udffd\u200d\u2642\ufe0f\u200d\u27a1\ufe0f": "man_walking_facing_right_medium_skin_tone",
-  "\ud83d\udeb6\ud83c\udffd\u200d\u27a1": "person_walking_facing_right_medium_skin_tone",
-  "\ud83d\udeb6\ud83c\udffd\u200d\u27a1\ufe0f": "person_walking_facing_right_medium_skin_tone",
-  "\ud83d\udeb6\ud83c\udffe": "person_walking_medium-dark_skin_tone",
-  "\ud83d\udeb6\ud83c\udffe\u200d\u2640": "woman_walking_medium-dark_skin_tone",
-  "\ud83d\udeb6\ud83c\udffe\u200d\u2640\u200d\u27a1": "woman_walking_facing_right_medium-dark_skin_tone",
-  "\ud83d\udeb6\ud83c\udffe\u200d\u2640\u200d\u27a1\ufe0f": "woman_walking_facing_right_medium-dark_skin_tone",
-  "\ud83d\udeb6\ud83c\udffe\u200d\u2640\ufe0f": "woman_walking_medium-dark_skin_tone",
-  "\ud83d\udeb6\ud83c\udffe\u200d\u2640\ufe0f\u200d\u27a1": "woman_walking_facing_right_medium-dark_skin_tone",
-  "\ud83d\udeb6\ud83c\udffe\u200d\u2640\ufe0f\u200d\u27a1\ufe0f": "woman_walking_facing_right_medium-dark_skin_tone",
-  "\ud83d\udeb6\ud83c\udffe\u200d\u2642": "man_walking_medium-dark_skin_tone",
-  "\ud83d\udeb6\ud83c\udffe\u200d\u2642\u200d\u27a1": "man_walking_facing_right_medium-dark_skin_tone",
-  "\ud83d\udeb6\ud83c\udffe\u200d\u2642\u200d\u27a1\ufe0f": "man_walking_facing_right_medium-dark_skin_tone",
-  "\ud83d\udeb6\ud83c\udffe\u200d\u2642\ufe0f": "man_walking_medium-dark_skin_tone",
-  "\ud83d\udeb6\ud83c\udffe\u200d\u2642\ufe0f\u200d\u27a1": "man_walking_facing_right_medium-dark_skin_tone",
-  "\ud83d\udeb6\ud83c\udffe\u200d\u2642\ufe0f\u200d\u27a1\ufe0f": "man_walking_facing_right_medium-dark_skin_tone",
-  "\ud83d\udeb6\ud83c\udffe\u200d\u27a1": "person_walking_facing_right_medium-dark_skin_tone",
-  "\ud83d\udeb6\ud83c\udffe\u200d\u27a1\ufe0f": "person_walking_facing_right_medium-dark_skin_tone",
-  "\ud83d\udeb6\ud83c\udfff": "person_walking_dark_skin_tone",
-  "\ud83d\udeb6\ud83c\udfff\u200d\u2640": "woman_walking_dark_skin_tone",
-  "\ud83d\udeb6\ud83c\udfff\u200d\u2640\u200d\u27a1": "woman_walking_facing_right_dark_skin_tone",
-  "\ud83d\udeb6\ud83c\udfff\u200d\u2640\u200d\u27a1\ufe0f": "woman_walking_facing_right_dark_skin_tone",
-  "\ud83d\udeb6\ud83c\udfff\u200d\u2640\ufe0f": "woman_walking_dark_skin_tone",
-  "\ud83d\udeb6\ud83c\udfff\u200d\u2640\ufe0f\u200d\u27a1": "woman_walking_facing_right_dark_skin_tone",
-  "\ud83d\udeb6\ud83c\udfff\u200d\u2640\ufe0f\u200d\u27a1\ufe0f": "woman_walking_facing_right_dark_skin_tone",
-  "\ud83d\udeb6\ud83c\udfff\u200d\u2642": "man_walking_dark_skin_tone",
-  "\ud83d\udeb6\ud83c\udfff\u200d\u2642\u200d\u27a1": "man_walking_facing_right_dark_skin_tone",
-  "\ud83d\udeb6\ud83c\udfff\u200d\u2642\u200d\u27a1\ufe0f": "man_walking_facing_right_dark_skin_tone",
-  "\ud83d\udeb6\ud83c\udfff\u200d\u2642\ufe0f": "man_walking_dark_skin_tone",
-  "\ud83d\udeb6\ud83c\udfff\u200d\u2642\ufe0f\u200d\u27a1": "man_walking_facing_right_dark_skin_tone",
-  "\ud83d\udeb6\ud83c\udfff\u200d\u2642\ufe0f\u200d\u27a1\ufe0f": "man_walking_facing_right_dark_skin_tone",
-  "\ud83d\udeb6\ud83c\udfff\u200d\u27a1": "person_walking_facing_right_dark_skin_tone",
-  "\ud83d\udeb6\ud83c\udfff\u200d\u27a1\ufe0f": "person_walking_facing_right_dark_skin_tone",
-  "\ud83d\udeb7": "no_pedestrians",
-  "\ud83d\udeb8": "children_crossing",
-  "\ud83d\udeb9": "men\u2019s_room",
-  "\ud83d\udeba": "women\u2019s_room",
-  "\ud83d\udebb": "restroom",
-  "\ud83d\udebc": "baby_symbol",
-  "\ud83d\udebd": "toilet",
-  "\ud83d\udebe": "water_closet",
-  "\ud83d\udebf": "shower",
-  "\ud83d\udec0": "person_taking_bath",
-  "\ud83d\udec0\ud83c\udffb": "person_taking_bath_light_skin_tone",
-  "\ud83d\udec0\ud83c\udffc": "person_taking_bath_medium-light_skin_tone",
-  "\ud83d\udec0\ud83c\udffd": "person_taking_bath_medium_skin_tone",
-  "\ud83d\udec0\ud83c\udffe": "person_taking_bath_medium-dark_skin_tone",
-  "\ud83d\udec0\ud83c\udfff": "person_taking_bath_dark_skin_tone",
-  "\ud83d\udec1": "bathtub",
-  "\ud83d\udec2": "passport_control",
-  "\ud83d\udec3": "customs",
-  "\ud83d\udec4": "baggage_claim",
-  "\ud83d\udec5": "left_luggage",
-  "\ud83d\udecb": "couch_and_lamp",
-  "\ud83d\udecb\ufe0f": "couch_and_lamp",
-  "\ud83d\udecc": "person_in_bed",
-  "\ud83d\udecc\ud83c\udffb": "person_in_bed_light_skin_tone",
-  "\ud83d\udecc\ud83c\udffc": "person_in_bed_medium-light_skin_tone",
-  "\ud83d\udecc\ud83c\udffd": "person_in_bed_medium_skin_tone",
-  "\ud83d\udecc\ud83c\udffe": "person_in_bed_medium-dark_skin_tone",
-  "\ud83d\udecc\ud83c\udfff": "person_in_bed_dark_skin_tone",
-  "\ud83d\udecd": "shopping_bags",
-  "\ud83d\udecd\ufe0f": "shopping_bags",
-  "\ud83d\udece": "bellhop_bell",
-  "\ud83d\udece\ufe0f": "bellhop_bell",
-  "\ud83d\udecf": "bed",
-  "\ud83d\udecf\ufe0f": "bed",
-  "\ud83d\uded0": "place_of_worship",
-  "\ud83d\uded1": "stop_sign",
-  "\ud83d\uded2": "shopping_cart",
-  "\ud83d\uded5": "hindu_temple",
-  "\ud83d\uded6": "hut",
-  "\ud83d\uded7": "elevator",
-  "\ud83d\udedc": "wireless",
-  "\ud83d\udedd": "playground_slide",
-  "\ud83d\udede": "wheel",
-  "\ud83d\udedf": "ring_buoy",
-  "\ud83d\udee0": "hammer_and_wrench",
-  "\ud83d\udee0\ufe0f": "hammer_and_wrench",
-  "\ud83d\udee1": "shield",
-  "\ud83d\udee1\ufe0f": "shield",
-  "\ud83d\udee2": "oil_drum",
-  "\ud83d\udee2\ufe0f": "oil_drum",
-  "\ud83d\udee3": "motorway",
-  "\ud83d\udee3\ufe0f": "motorway",
-  "\ud83d\udee4": "railway_track",
-  "\ud83d\udee4\ufe0f": "railway_track",
-  "\ud83d\udee5": "motor_boat",
-  "\ud83d\udee5\ufe0f": "motor_boat",
-  "\ud83d\udee9": "small_airplane",
-  "\ud83d\udee9\ufe0f": "small_airplane",
-  "\ud83d\udeeb": "airplane_departure",
-  "\ud83d\udeec": "airplane_arrival",
-  "\ud83d\udef0": "satellite",
-  "\ud83d\udef0\ufe0f": "satellite",
-  "\ud83d\udef3": "passenger_ship",
-  "\ud83d\udef3\ufe0f": "passenger_ship",
-  "\ud83d\udef4": "kick_scooter",
-  "\ud83d\udef5": "motor_scooter",
-  "\ud83d\udef6": "canoe",
-  "\ud83d\udef7": "sled",
-  "\ud83d\udef8": "flying_saucer",
-  "\ud83d\udef9": "skateboard",
-  "\ud83d\udefa": "auto_rickshaw",
-  "\ud83d\udefb": "pickup_truck",
-  "\ud83d\udefc": "roller_skate",
-  "\ud83d\udfe0": "orange_circle",
-  "\ud83d\udfe1": "yellow_circle",
-  "\ud83d\udfe2": "green_circle",
-  "\ud83d\udfe3": "purple_circle",
-  "\ud83d\udfe4": "brown_circle",
-  "\ud83d\udfe5": "red_square",
-  "\ud83d\udfe6": "blue_square",
-  "\ud83d\udfe7": "orange_square",
-  "\ud83d\udfe8": "yellow_square",
-  "\ud83d\udfe9": "green_square",
-  "\ud83d\udfea": "purple_square",
-  "\ud83d\udfeb": "brown_square",
-  "\ud83d\udff0": "heavy_equals_sign",
-  "\ud83e\udd0c": "pinched_fingers",
-  "\ud83e\udd0c\ud83c\udffb": "pinched_fingers_light_skin_tone",
-  "\ud83e\udd0c\ud83c\udffc": "pinched_fingers_medium-light_skin_tone",
-  "\ud83e\udd0c\ud83c\udffd": "pinched_fingers_medium_skin_tone",
-  "\ud83e\udd0c\ud83c\udffe": "pinched_fingers_medium-dark_skin_tone",
-  "\ud83e\udd0c\ud83c\udfff": "pinched_fingers_dark_skin_tone",
-  "\ud83e\udd0d": "white_heart",
-  "\ud83e\udd0e": "brown_heart",
-  "\ud83e\udd0f": "pinching_hand",
-  "\ud83e\udd0f\ud83c\udffb": "pinching_hand_light_skin_tone",
-  "\ud83e\udd0f\ud83c\udffc": "pinching_hand_medium-light_skin_tone",
-  "\ud83e\udd0f\ud83c\udffd": "pinching_hand_medium_skin_tone",
-  "\ud83e\udd0f\ud83c\udffe": "pinching_hand_medium-dark_skin_tone",
-  "\ud83e\udd0f\ud83c\udfff": "pinching_hand_dark_skin_tone",
-  "\ud83e\udd10": "zipper-mouth_face",
-  "\ud83e\udd11": "money-mouth_face",
-  "\ud83e\udd12": "face_with_thermometer",
-  "\ud83e\udd13": "nerd_face",
-  "\ud83e\udd14": "thinking_face",
-  "\ud83e\udd15": "face_with_head-bandage",
-  "\ud83e\udd16": "robot",
-  "\ud83e\udd17": "smiling_face_with_open_hands",
-  "\ud83e\udd18": "sign_of_the_horns",
-  "\ud83e\udd18\ud83c\udffb": "sign_of_the_horns_light_skin_tone",
-  "\ud83e\udd18\ud83c\udffc": "sign_of_the_horns_medium-light_skin_tone",
-  "\ud83e\udd18\ud83c\udffd": "sign_of_the_horns_medium_skin_tone",
-  "\ud83e\udd18\ud83c\udffe": "sign_of_the_horns_medium-dark_skin_tone",
-  "\ud83e\udd18\ud83c\udfff": "sign_of_the_horns_dark_skin_tone",
-  "\ud83e\udd19": "call_me_hand",
-  "\ud83e\udd19\ud83c\udffb": "call_me_hand_light_skin_tone",
-  "\ud83e\udd19\ud83c\udffc": "call_me_hand_medium-light_skin_tone",
-  "\ud83e\udd19\ud83c\udffd": "call_me_hand_medium_skin_tone",
-  "\ud83e\udd19\ud83c\udffe": "call_me_hand_medium-dark_skin_tone",
-  "\ud83e\udd19\ud83c\udfff": "call_me_hand_dark_skin_tone",
-  "\ud83e\udd1a": "raised_back_of_hand",
-  "\ud83e\udd1a\ud83c\udffb": "raised_back_of_hand_light_skin_tone",
-  "\ud83e\udd1a\ud83c\udffc": "raised_back_of_hand_medium-light_skin_tone",
-  "\ud83e\udd1a\ud83c\udffd": "raised_back_of_hand_medium_skin_tone",
-  "\ud83e\udd1a\ud83c\udffe": "raised_back_of_hand_medium-dark_skin_tone",
-  "\ud83e\udd1a\ud83c\udfff": "raised_back_of_hand_dark_skin_tone",
-  "\ud83e\udd1b": "left-facing_fist",
-  "\ud83e\udd1b\ud83c\udffb": "left-facing_fist_light_skin_tone",
-  "\ud83e\udd1b\ud83c\udffc": "left-facing_fist_medium-light_skin_tone",
-  "\ud83e\udd1b\ud83c\udffd": "left-facing_fist_medium_skin_tone",
-  "\ud83e\udd1b\ud83c\udffe": "left-facing_fist_medium-dark_skin_tone",
-  "\ud83e\udd1b\ud83c\udfff": "left-facing_fist_dark_skin_tone",
-  "\ud83e\udd1c": "right-facing_fist",
-  "\ud83e\udd1c\ud83c\udffb": "right-facing_fist_light_skin_tone",
-  "\ud83e\udd1c\ud83c\udffc": "right-facing_fist_medium-light_skin_tone",
-  "\ud83e\udd1c\ud83c\udffd": "right-facing_fist_medium_skin_tone",
-  "\ud83e\udd1c\ud83c\udffe": "right-facing_fist_medium-dark_skin_tone",
-  "\ud83e\udd1c\ud83c\udfff": "right-facing_fist_dark_skin_tone",
-  "\ud83e\udd1d": "handshake",
-  "\ud83e\udd1d\ud83c\udffb": "handshake_light_skin_tone",
-  "\ud83e\udd1d\ud83c\udffc": "handshake_medium-light_skin_tone",
-  "\ud83e\udd1d\ud83c\udffd": "handshake_medium_skin_tone",
-  "\ud83e\udd1d\ud83c\udffe": "handshake_medium-dark_skin_tone",
-  "\ud83e\udd1d\ud83c\udfff": "handshake_dark_skin_tone",
-  "\ud83e\udd1e": "crossed_fingers",
-  "\ud83e\udd1e\ud83c\udffb": "crossed_fingers_light_skin_tone",
-  "\ud83e\udd1e\ud83c\udffc": "crossed_fingers_medium-light_skin_tone",
-  "\ud83e\udd1e\ud83c\udffd": "crossed_fingers_medium_skin_tone",
-  "\ud83e\udd1e\ud83c\udffe": "crossed_fingers_medium-dark_skin_tone",
-  "\ud83e\udd1e\ud83c\udfff": "crossed_fingers_dark_skin_tone",
-  "\ud83e\udd1f": "love-you_gesture",
-  "\ud83e\udd1f\ud83c\udffb": "love-you_gesture_light_skin_tone",
-  "\ud83e\udd1f\ud83c\udffc": "love-you_gesture_medium-light_skin_tone",
-  "\ud83e\udd1f\ud83c\udffd": "love-you_gesture_medium_skin_tone",
-  "\ud83e\udd1f\ud83c\udffe": "love-you_gesture_medium-dark_skin_tone",
-  "\ud83e\udd1f\ud83c\udfff": "love-you_gesture_dark_skin_tone",
-  "\ud83e\udd20": "cowboy_hat_face",
-  "\ud83e\udd21": "clown_face",
-  "\ud83e\udd22": "nauseated_face",
-  "\ud83e\udd23": "rolling_on_the_floor_laughing",
-  "\ud83e\udd24": "drooling_face",
-  "\ud83e\udd25": "lying_face",
-  "\ud83e\udd26": "person_facepalming",
-  "\ud83e\udd26\u200d\u2640": "woman_facepalming",
-  "\ud83e\udd26\u200d\u2640\ufe0f": "woman_facepalming",
-  "\ud83e\udd26\u200d\u2642": "man_facepalming",
-  "\ud83e\udd26\u200d\u2642\ufe0f": "man_facepalming",
-  "\ud83e\udd26\ud83c\udffb": "person_facepalming_light_skin_tone",
-  "\ud83e\udd26\ud83c\udffb\u200d\u2640": "woman_facepalming_light_skin_tone",
-  "\ud83e\udd26\ud83c\udffb\u200d\u2640\ufe0f": "woman_facepalming_light_skin_tone",
-  "\ud83e\udd26\ud83c\udffb\u200d\u2642": "man_facepalming_light_skin_tone",
-  "\ud83e\udd26\ud83c\udffb\u200d\u2642\ufe0f": "man_facepalming_light_skin_tone",
-  "\ud83e\udd26\ud83c\udffc": "person_facepalming_medium-light_skin_tone",
-  "\ud83e\udd26\ud83c\udffc\u200d\u2640": "woman_facepalming_medium-light_skin_tone",
-  "\ud83e\udd26\ud83c\udffc\u200d\u2640\ufe0f": "woman_facepalming_medium-light_skin_tone",
-  "\ud83e\udd26\ud83c\udffc\u200d\u2642": "man_facepalming_medium-light_skin_tone",
-  "\ud83e\udd26\ud83c\udffc\u200d\u2642\ufe0f": "man_facepalming_medium-light_skin_tone",
-  "\ud83e\udd26\ud83c\udffd": "person_facepalming_medium_skin_tone",
-  "\ud83e\udd26\ud83c\udffd\u200d\u2640": "woman_facepalming_medium_skin_tone",
-  "\ud83e\udd26\ud83c\udffd\u200d\u2640\ufe0f": "woman_facepalming_medium_skin_tone",
-  "\ud83e\udd26\ud83c\udffd\u200d\u2642": "man_facepalming_medium_skin_tone",
-  "\ud83e\udd26\ud83c\udffd\u200d\u2642\ufe0f": "man_facepalming_medium_skin_tone",
-  "\ud83e\udd26\ud83c\udffe": "person_facepalming_medium-dark_skin_tone",
-  "\ud83e\udd26\ud83c\udffe\u200d\u2640": "woman_facepalming_medium-dark_skin_tone",
-  "\ud83e\udd26\ud83c\udffe\u200d\u2640\ufe0f": "woman_facepalming_medium-dark_skin_tone",
-  "\ud83e\udd26\ud83c\udffe\u200d\u2642": "man_facepalming_medium-dark_skin_tone",
-  "\ud83e\udd26\ud83c\udffe\u200d\u2642\ufe0f": "man_facepalming_medium-dark_skin_tone",
-  "\ud83e\udd26\ud83c\udfff": "person_facepalming_dark_skin_tone",
-  "\ud83e\udd26\ud83c\udfff\u200d\u2640": "woman_facepalming_dark_skin_tone",
-  "\ud83e\udd26\ud83c\udfff\u200d\u2640\ufe0f": "woman_facepalming_dark_skin_tone",
-  "\ud83e\udd26\ud83c\udfff\u200d\u2642": "man_facepalming_dark_skin_tone",
-  "\ud83e\udd26\ud83c\udfff\u200d\u2642\ufe0f": "man_facepalming_dark_skin_tone",
-  "\ud83e\udd27": "sneezing_face",
-  "\ud83e\udd28": "face_with_raised_eyebrow",
-  "\ud83e\udd29": "star-struck",
-  "\ud83e\udd2a": "zany_face",
-  "\ud83e\udd2b": "shushing_face",
-  "\ud83e\udd2c": "face_with_symbols_on_mouth",
-  "\ud83e\udd2d": "face_with_hand_over_mouth",
-  "\ud83e\udd2e": "face_vomiting",
-  "\ud83e\udd2f": "exploding_head",
-  "\ud83e\udd30": "pregnant_woman",
-  "\ud83e\udd30\ud83c\udffb": "pregnant_woman_light_skin_tone",
-  "\ud83e\udd30\ud83c\udffc": "pregnant_woman_medium-light_skin_tone",
-  "\ud83e\udd30\ud83c\udffd": "pregnant_woman_medium_skin_tone",
-  "\ud83e\udd30\ud83c\udffe": "pregnant_woman_medium-dark_skin_tone",
-  "\ud83e\udd30\ud83c\udfff": "pregnant_woman_dark_skin_tone",
-  "\ud83e\udd31": "breast-feeding",
-  "\ud83e\udd31\ud83c\udffb": "breast-feeding_light_skin_tone",
-  "\ud83e\udd31\ud83c\udffc": "breast-feeding_medium-light_skin_tone",
-  "\ud83e\udd31\ud83c\udffd": "breast-feeding_medium_skin_tone",
-  "\ud83e\udd31\ud83c\udffe": "breast-feeding_medium-dark_skin_tone",
-  "\ud83e\udd31\ud83c\udfff": "breast-feeding_dark_skin_tone",
-  "\ud83e\udd32": "palms_up_together",
-  "\ud83e\udd32\ud83c\udffb": "palms_up_together_light_skin_tone",
-  "\ud83e\udd32\ud83c\udffc": "palms_up_together_medium-light_skin_tone",
-  "\ud83e\udd32\ud83c\udffd": "palms_up_together_medium_skin_tone",
-  "\ud83e\udd32\ud83c\udffe": "palms_up_together_medium-dark_skin_tone",
-  "\ud83e\udd32\ud83c\udfff": "palms_up_together_dark_skin_tone",
-  "\ud83e\udd33": "selfie",
-  "\ud83e\udd33\ud83c\udffb": "selfie_light_skin_tone",
-  "\ud83e\udd33\ud83c\udffc": "selfie_medium-light_skin_tone",
-  "\ud83e\udd33\ud83c\udffd": "selfie_medium_skin_tone",
-  "\ud83e\udd33\ud83c\udffe": "selfie_medium-dark_skin_tone",
-  "\ud83e\udd33\ud83c\udfff": "selfie_dark_skin_tone",
-  "\ud83e\udd34": "prince",
-  "\ud83e\udd34\ud83c\udffb": "prince_light_skin_tone",
-  "\ud83e\udd34\ud83c\udffc": "prince_medium-light_skin_tone",
-  "\ud83e\udd34\ud83c\udffd": "prince_medium_skin_tone",
-  "\ud83e\udd34\ud83c\udffe": "prince_medium-dark_skin_tone",
-  "\ud83e\udd34\ud83c\udfff": "prince_dark_skin_tone",
-  "\ud83e\udd35": "person_in_tuxedo",
-  "\ud83e\udd35\u200d\u2640": "woman_in_tuxedo",
-  "\ud83e\udd35\u200d\u2640\ufe0f": "woman_in_tuxedo",
-  "\ud83e\udd35\u200d\u2642": "man_in_tuxedo",
-  "\ud83e\udd35\u200d\u2642\ufe0f": "man_in_tuxedo",
-  "\ud83e\udd35\ud83c\udffb": "person_in_tuxedo_light_skin_tone",
-  "\ud83e\udd35\ud83c\udffb\u200d\u2640": "woman_in_tuxedo_light_skin_tone",
-  "\ud83e\udd35\ud83c\udffb\u200d\u2640\ufe0f": "woman_in_tuxedo_light_skin_tone",
-  "\ud83e\udd35\ud83c\udffb\u200d\u2642": "man_in_tuxedo_light_skin_tone",
-  "\ud83e\udd35\ud83c\udffb\u200d\u2642\ufe0f": "man_in_tuxedo_light_skin_tone",
-  "\ud83e\udd35\ud83c\udffc": "person_in_tuxedo_medium-light_skin_tone",
-  "\ud83e\udd35\ud83c\udffc\u200d\u2640": "woman_in_tuxedo_medium-light_skin_tone",
-  "\ud83e\udd35\ud83c\udffc\u200d\u2640\ufe0f": "woman_in_tuxedo_medium-light_skin_tone",
-  "\ud83e\udd35\ud83c\udffc\u200d\u2642": "man_in_tuxedo_medium-light_skin_tone",
-  "\ud83e\udd35\ud83c\udffc\u200d\u2642\ufe0f": "man_in_tuxedo_medium-light_skin_tone",
-  "\ud83e\udd35\ud83c\udffd": "person_in_tuxedo_medium_skin_tone",
-  "\ud83e\udd35\ud83c\udffd\u200d\u2640": "woman_in_tuxedo_medium_skin_tone",
-  "\ud83e\udd35\ud83c\udffd\u200d\u2640\ufe0f": "woman_in_tuxedo_medium_skin_tone",
-  "\ud83e\udd35\ud83c\udffd\u200d\u2642": "man_in_tuxedo_medium_skin_tone",
-  "\ud83e\udd35\ud83c\udffd\u200d\u2642\ufe0f": "man_in_tuxedo_medium_skin_tone",
-  "\ud83e\udd35\ud83c\udffe": "person_in_tuxedo_medium-dark_skin_tone",
-  "\ud83e\udd35\ud83c\udffe\u200d\u2640": "woman_in_tuxedo_medium-dark_skin_tone",
-  "\ud83e\udd35\ud83c\udffe\u200d\u2640\ufe0f": "woman_in_tuxedo_medium-dark_skin_tone",
-  "\ud83e\udd35\ud83c\udffe\u200d\u2642": "man_in_tuxedo_medium-dark_skin_tone",
-  "\ud83e\udd35\ud83c\udffe\u200d\u2642\ufe0f": "man_in_tuxedo_medium-dark_skin_tone",
-  "\ud83e\udd35\ud83c\udfff": "person_in_tuxedo_dark_skin_tone",
-  "\ud83e\udd35\ud83c\udfff\u200d\u2640": "woman_in_tuxedo_dark_skin_tone",
-  "\ud83e\udd35\ud83c\udfff\u200d\u2640\ufe0f": "woman_in_tuxedo_dark_skin_tone",
-  "\ud83e\udd35\ud83c\udfff\u200d\u2642": "man_in_tuxedo_dark_skin_tone",
-  "\ud83e\udd35\ud83c\udfff\u200d\u2642\ufe0f": "man_in_tuxedo_dark_skin_tone",
-  "\ud83e\udd36": "mrs._claus",
-  "\ud83e\udd36\ud83c\udffb": "mrs._claus_light_skin_tone",
-  "\ud83e\udd36\ud83c\udffc": "mrs._claus_medium-light_skin_tone",
-  "\ud83e\udd36\ud83c\udffd": "mrs._claus_medium_skin_tone",
-  "\ud83e\udd36\ud83c\udffe": "mrs._claus_medium-dark_skin_tone",
-  "\ud83e\udd36\ud83c\udfff": "mrs._claus_dark_skin_tone",
-  "\ud83e\udd37": "person_shrugging",
-  "\ud83e\udd37\u200d\u2640": "woman_shrugging",
-  "\ud83e\udd37\u200d\u2640\ufe0f": "woman_shrugging",
-  "\ud83e\udd37\u200d\u2642": "man_shrugging",
-  "\ud83e\udd37\u200d\u2642\ufe0f": "man_shrugging",
-  "\ud83e\udd37\ud83c\udffb": "person_shrugging_light_skin_tone",
-  "\ud83e\udd37\ud83c\udffb\u200d\u2640": "woman_shrugging_light_skin_tone",
-  "\ud83e\udd37\ud83c\udffb\u200d\u2640\ufe0f": "woman_shrugging_light_skin_tone",
-  "\ud83e\udd37\ud83c\udffb\u200d\u2642": "man_shrugging_light_skin_tone",
-  "\ud83e\udd37\ud83c\udffb\u200d\u2642\ufe0f": "man_shrugging_light_skin_tone",
-  "\ud83e\udd37\ud83c\udffc": "person_shrugging_medium-light_skin_tone",
-  "\ud83e\udd37\ud83c\udffc\u200d\u2640": "woman_shrugging_medium-light_skin_tone",
-  "\ud83e\udd37\ud83c\udffc\u200d\u2640\ufe0f": "woman_shrugging_medium-light_skin_tone",
-  "\ud83e\udd37\ud83c\udffc\u200d\u2642": "man_shrugging_medium-light_skin_tone",
-  "\ud83e\udd37\ud83c\udffc\u200d\u2642\ufe0f": "man_shrugging_medium-light_skin_tone",
-  "\ud83e\udd37\ud83c\udffd": "person_shrugging_medium_skin_tone",
-  "\ud83e\udd37\ud83c\udffd\u200d\u2640": "woman_shrugging_medium_skin_tone",
-  "\ud83e\udd37\ud83c\udffd\u200d\u2640\ufe0f": "woman_shrugging_medium_skin_tone",
-  "\ud83e\udd37\ud83c\udffd\u200d\u2642": "man_shrugging_medium_skin_tone",
-  "\ud83e\udd37\ud83c\udffd\u200d\u2642\ufe0f": "man_shrugging_medium_skin_tone",
-  "\ud83e\udd37\ud83c\udffe": "person_shrugging_medium-dark_skin_tone",
-  "\ud83e\udd37\ud83c\udffe\u200d\u2640": "woman_shrugging_medium-dark_skin_tone",
-  "\ud83e\udd37\ud83c\udffe\u200d\u2640\ufe0f": "woman_shrugging_medium-dark_skin_tone",
-  "\ud83e\udd37\ud83c\udffe\u200d\u2642": "man_shrugging_medium-dark_skin_tone",
-  "\ud83e\udd37\ud83c\udffe\u200d\u2642\ufe0f": "man_shrugging_medium-dark_skin_tone",
-  "\ud83e\udd37\ud83c\udfff": "person_shrugging_dark_skin_tone",
-  "\ud83e\udd37\ud83c\udfff\u200d\u2640": "woman_shrugging_dark_skin_tone",
-  "\ud83e\udd37\ud83c\udfff\u200d\u2640\ufe0f": "woman_shrugging_dark_skin_tone",
-  "\ud83e\udd37\ud83c\udfff\u200d\u2642": "man_shrugging_dark_skin_tone",
-  "\ud83e\udd37\ud83c\udfff\u200d\u2642\ufe0f": "man_shrugging_dark_skin_tone",
-  "\ud83e\udd38": "person_cartwheeling",
-  "\ud83e\udd38\u200d\u2640": "woman_cartwheeling",
-  "\ud83e\udd38\u200d\u2640\ufe0f": "woman_cartwheeling",
-  "\ud83e\udd38\u200d\u2642": "man_cartwheeling",
-  "\ud83e\udd38\u200d\u2642\ufe0f": "man_cartwheeling",
-  "\ud83e\udd38\ud83c\udffb": "person_cartwheeling_light_skin_tone",
-  "\ud83e\udd38\ud83c\udffb\u200d\u2640": "woman_cartwheeling_light_skin_tone",
-  "\ud83e\udd38\ud83c\udffb\u200d\u2640\ufe0f": "woman_cartwheeling_light_skin_tone",
-  "\ud83e\udd38\ud83c\udffb\u200d\u2642": "man_cartwheeling_light_skin_tone",
-  "\ud83e\udd38\ud83c\udffb\u200d\u2642\ufe0f": "man_cartwheeling_light_skin_tone",
-  "\ud83e\udd38\ud83c\udffc": "person_cartwheeling_medium-light_skin_tone",
-  "\ud83e\udd38\ud83c\udffc\u200d\u2640": "woman_cartwheeling_medium-light_skin_tone",
-  "\ud83e\udd38\ud83c\udffc\u200d\u2640\ufe0f": "woman_cartwheeling_medium-light_skin_tone",
-  "\ud83e\udd38\ud83c\udffc\u200d\u2642": "man_cartwheeling_medium-light_skin_tone",
-  "\ud83e\udd38\ud83c\udffc\u200d\u2642\ufe0f": "man_cartwheeling_medium-light_skin_tone",
-  "\ud83e\udd38\ud83c\udffd": "person_cartwheeling_medium_skin_tone",
-  "\ud83e\udd38\ud83c\udffd\u200d\u2640": "woman_cartwheeling_medium_skin_tone",
-  "\ud83e\udd38\ud83c\udffd\u200d\u2640\ufe0f": "woman_cartwheeling_medium_skin_tone",
-  "\ud83e\udd38\ud83c\udffd\u200d\u2642": "man_cartwheeling_medium_skin_tone",
-  "\ud83e\udd38\ud83c\udffd\u200d\u2642\ufe0f": "man_cartwheeling_medium_skin_tone",
-  "\ud83e\udd38\ud83c\udffe": "person_cartwheeling_medium-dark_skin_tone",
-  "\ud83e\udd38\ud83c\udffe\u200d\u2640": "woman_cartwheeling_medium-dark_skin_tone",
-  "\ud83e\udd38\ud83c\udffe\u200d\u2640\ufe0f": "woman_cartwheeling_medium-dark_skin_tone",
-  "\ud83e\udd38\ud83c\udffe\u200d\u2642": "man_cartwheeling_medium-dark_skin_tone",
-  "\ud83e\udd38\ud83c\udffe\u200d\u2642\ufe0f": "man_cartwheeling_medium-dark_skin_tone",
-  "\ud83e\udd38\ud83c\udfff": "person_cartwheeling_dark_skin_tone",
-  "\ud83e\udd38\ud83c\udfff\u200d\u2640": "woman_cartwheeling_dark_skin_tone",
-  "\ud83e\udd38\ud83c\udfff\u200d\u2640\ufe0f": "woman_cartwheeling_dark_skin_tone",
-  "\ud83e\udd38\ud83c\udfff\u200d\u2642": "man_cartwheeling_dark_skin_tone",
-  "\ud83e\udd38\ud83c\udfff\u200d\u2642\ufe0f": "man_cartwheeling_dark_skin_tone",
-  "\ud83e\udd39": "person_juggling",
-  "\ud83e\udd39\u200d\u2640": "woman_juggling",
-  "\ud83e\udd39\u200d\u2640\ufe0f": "woman_juggling",
-  "\ud83e\udd39\u200d\u2642": "man_juggling",
-  "\ud83e\udd39\u200d\u2642\ufe0f": "man_juggling",
-  "\ud83e\udd39\ud83c\udffb": "person_juggling_light_skin_tone",
-  "\ud83e\udd39\ud83c\udffb\u200d\u2640": "woman_juggling_light_skin_tone",
-  "\ud83e\udd39\ud83c\udffb\u200d\u2640\ufe0f": "woman_juggling_light_skin_tone",
-  "\ud83e\udd39\ud83c\udffb\u200d\u2642": "man_juggling_light_skin_tone",
-  "\ud83e\udd39\ud83c\udffb\u200d\u2642\ufe0f": "man_juggling_light_skin_tone",
-  "\ud83e\udd39\ud83c\udffc": "person_juggling_medium-light_skin_tone",
-  "\ud83e\udd39\ud83c\udffc\u200d\u2640": "woman_juggling_medium-light_skin_tone",
-  "\ud83e\udd39\ud83c\udffc\u200d\u2640\ufe0f": "woman_juggling_medium-light_skin_tone",
-  "\ud83e\udd39\ud83c\udffc\u200d\u2642": "man_juggling_medium-light_skin_tone",
-  "\ud83e\udd39\ud83c\udffc\u200d\u2642\ufe0f": "man_juggling_medium-light_skin_tone",
-  "\ud83e\udd39\ud83c\udffd": "person_juggling_medium_skin_tone",
-  "\ud83e\udd39\ud83c\udffd\u200d\u2640": "woman_juggling_medium_skin_tone",
-  "\ud83e\udd39\ud83c\udffd\u200d\u2640\ufe0f": "woman_juggling_medium_skin_tone",
-  "\ud83e\udd39\ud83c\udffd\u200d\u2642": "man_juggling_medium_skin_tone",
-  "\ud83e\udd39\ud83c\udffd\u200d\u2642\ufe0f": "man_juggling_medium_skin_tone",
-  "\ud83e\udd39\ud83c\udffe": "person_juggling_medium-dark_skin_tone",
-  "\ud83e\udd39\ud83c\udffe\u200d\u2640": "woman_juggling_medium-dark_skin_tone",
-  "\ud83e\udd39\ud83c\udffe\u200d\u2640\ufe0f": "woman_juggling_medium-dark_skin_tone",
-  "\ud83e\udd39\ud83c\udffe\u200d\u2642": "man_juggling_medium-dark_skin_tone",
-  "\ud83e\udd39\ud83c\udffe\u200d\u2642\ufe0f": "man_juggling_medium-dark_skin_tone",
-  "\ud83e\udd39\ud83c\udfff": "person_juggling_dark_skin_tone",
-  "\ud83e\udd39\ud83c\udfff\u200d\u2640": "woman_juggling_dark_skin_tone",
-  "\ud83e\udd39\ud83c\udfff\u200d\u2640\ufe0f": "woman_juggling_dark_skin_tone",
-  "\ud83e\udd39\ud83c\udfff\u200d\u2642": "man_juggling_dark_skin_tone",
-  "\ud83e\udd39\ud83c\udfff\u200d\u2642\ufe0f": "man_juggling_dark_skin_tone",
-  "\ud83e\udd3a": "person_fencing",
-  "\ud83e\udd3c": "people_wrestling",
-  "\ud83e\udd3c\u200d\u2640": "women_wrestling",
-  "\ud83e\udd3c\u200d\u2640\ufe0f": "women_wrestling",
-  "\ud83e\udd3c\u200d\u2642": "men_wrestling",
-  "\ud83e\udd3c\u200d\u2642\ufe0f": "men_wrestling",
-  "\ud83e\udd3d": "person_playing_water_polo",
-  "\ud83e\udd3d\u200d\u2640": "woman_playing_water_polo",
-  "\ud83e\udd3d\u200d\u2640\ufe0f": "woman_playing_water_polo",
-  "\ud83e\udd3d\u200d\u2642": "man_playing_water_polo",
-  "\ud83e\udd3d\u200d\u2642\ufe0f": "man_playing_water_polo",
-  "\ud83e\udd3d\ud83c\udffb": "person_playing_water_polo_light_skin_tone",
-  "\ud83e\udd3d\ud83c\udffb\u200d\u2640": "woman_playing_water_polo_light_skin_tone",
-  "\ud83e\udd3d\ud83c\udffb\u200d\u2640\ufe0f": "woman_playing_water_polo_light_skin_tone",
-  "\ud83e\udd3d\ud83c\udffb\u200d\u2642": "man_playing_water_polo_light_skin_tone",
-  "\ud83e\udd3d\ud83c\udffb\u200d\u2642\ufe0f": "man_playing_water_polo_light_skin_tone",
-  "\ud83e\udd3d\ud83c\udffc": "person_playing_water_polo_medium-light_skin_tone",
-  "\ud83e\udd3d\ud83c\udffc\u200d\u2640": "woman_playing_water_polo_medium-light_skin_tone",
-  "\ud83e\udd3d\ud83c\udffc\u200d\u2640\ufe0f": "woman_playing_water_polo_medium-light_skin_tone",
-  "\ud83e\udd3d\ud83c\udffc\u200d\u2642": "man_playing_water_polo_medium-light_skin_tone",
-  "\ud83e\udd3d\ud83c\udffc\u200d\u2642\ufe0f": "man_playing_water_polo_medium-light_skin_tone",
-  "\ud83e\udd3d\ud83c\udffd": "person_playing_water_polo_medium_skin_tone",
-  "\ud83e\udd3d\ud83c\udffd\u200d\u2640": "woman_playing_water_polo_medium_skin_tone",
-  "\ud83e\udd3d\ud83c\udffd\u200d\u2640\ufe0f": "woman_playing_water_polo_medium_skin_tone",
-  "\ud83e\udd3d\ud83c\udffd\u200d\u2642": "man_playing_water_polo_medium_skin_tone",
-  "\ud83e\udd3d\ud83c\udffd\u200d\u2642\ufe0f": "man_playing_water_polo_medium_skin_tone",
-  "\ud83e\udd3d\ud83c\udffe": "person_playing_water_polo_medium-dark_skin_tone",
-  "\ud83e\udd3d\ud83c\udffe\u200d\u2640": "woman_playing_water_polo_medium-dark_skin_tone",
-  "\ud83e\udd3d\ud83c\udffe\u200d\u2640\ufe0f": "woman_playing_water_polo_medium-dark_skin_tone",
-  "\ud83e\udd3d\ud83c\udffe\u200d\u2642": "man_playing_water_polo_medium-dark_skin_tone",
-  "\ud83e\udd3d\ud83c\udffe\u200d\u2642\ufe0f": "man_playing_water_polo_medium-dark_skin_tone",
-  "\ud83e\udd3d\ud83c\udfff": "person_playing_water_polo_dark_skin_tone",
-  "\ud83e\udd3d\ud83c\udfff\u200d\u2640": "woman_playing_water_polo_dark_skin_tone",
-  "\ud83e\udd3d\ud83c\udfff\u200d\u2640\ufe0f": "woman_playing_water_polo_dark_skin_tone",
-  "\ud83e\udd3d\ud83c\udfff\u200d\u2642": "man_playing_water_polo_dark_skin_tone",
-  "\ud83e\udd3d\ud83c\udfff\u200d\u2642\ufe0f": "man_playing_water_polo_dark_skin_tone",
-  "\ud83e\udd3e": "person_playing_handball",
-  "\ud83e\udd3e\u200d\u2640": "woman_playing_handball",
-  "\ud83e\udd3e\u200d\u2640\ufe0f": "woman_playing_handball",
-  "\ud83e\udd3e\u200d\u2642": "man_playing_handball",
-  "\ud83e\udd3e\u200d\u2642\ufe0f": "man_playing_handball",
-  "\ud83e\udd3e\ud83c\udffb": "person_playing_handball_light_skin_tone",
-  "\ud83e\udd3e\ud83c\udffb\u200d\u2640": "woman_playing_handball_light_skin_tone",
-  "\ud83e\udd3e\ud83c\udffb\u200d\u2640\ufe0f": "woman_playing_handball_light_skin_tone",
-  "\ud83e\udd3e\ud83c\udffb\u200d\u2642": "man_playing_handball_light_skin_tone",
-  "\ud83e\udd3e\ud83c\udffb\u200d\u2642\ufe0f": "man_playing_handball_light_skin_tone",
-  "\ud83e\udd3e\ud83c\udffc": "person_playing_handball_medium-light_skin_tone",
-  "\ud83e\udd3e\ud83c\udffc\u200d\u2640": "woman_playing_handball_medium-light_skin_tone",
-  "\ud83e\udd3e\ud83c\udffc\u200d\u2640\ufe0f": "woman_playing_handball_medium-light_skin_tone",
-  "\ud83e\udd3e\ud83c\udffc\u200d\u2642": "man_playing_handball_medium-light_skin_tone",
-  "\ud83e\udd3e\ud83c\udffc\u200d\u2642\ufe0f": "man_playing_handball_medium-light_skin_tone",
-  "\ud83e\udd3e\ud83c\udffd": "person_playing_handball_medium_skin_tone",
-  "\ud83e\udd3e\ud83c\udffd\u200d\u2640": "woman_playing_handball_medium_skin_tone",
-  "\ud83e\udd3e\ud83c\udffd\u200d\u2640\ufe0f": "woman_playing_handball_medium_skin_tone",
-  "\ud83e\udd3e\ud83c\udffd\u200d\u2642": "man_playing_handball_medium_skin_tone",
-  "\ud83e\udd3e\ud83c\udffd\u200d\u2642\ufe0f": "man_playing_handball_medium_skin_tone",
-  "\ud83e\udd3e\ud83c\udffe": "person_playing_handball_medium-dark_skin_tone",
-  "\ud83e\udd3e\ud83c\udffe\u200d\u2640": "woman_playing_handball_medium-dark_skin_tone",
-  "\ud83e\udd3e\ud83c\udffe\u200d\u2640\ufe0f": "woman_playing_handball_medium-dark_skin_tone",
-  "\ud83e\udd3e\ud83c\udffe\u200d\u2642": "man_playing_handball_medium-dark_skin_tone",
-  "\ud83e\udd3e\ud83c\udffe\u200d\u2642\ufe0f": "man_playing_handball_medium-dark_skin_tone",
-  "\ud83e\udd3e\ud83c\udfff": "person_playing_handball_dark_skin_tone",
-  "\ud83e\udd3e\ud83c\udfff\u200d\u2640": "woman_playing_handball_dark_skin_tone",
-  "\ud83e\udd3e\ud83c\udfff\u200d\u2640\ufe0f": "woman_playing_handball_dark_skin_tone",
-  "\ud83e\udd3e\ud83c\udfff\u200d\u2642": "man_playing_handball_dark_skin_tone",
-  "\ud83e\udd3e\ud83c\udfff\u200d\u2642\ufe0f": "man_playing_handball_dark_skin_tone",
-  "\ud83e\udd3f": "diving_mask",
-  "\ud83e\udd40": "wilted_flower",
-  "\ud83e\udd41": "drum",
-  "\ud83e\udd42": "clinking_glasses",
-  "\ud83e\udd43": "tumbler_glass",
-  "\ud83e\udd44": "spoon",
-  "\ud83e\udd45": "goal_net",
-  "\ud83e\udd47": "1st_place_medal",
-  "\ud83e\udd48": "2nd_place_medal",
-  "\ud83e\udd49": "3rd_place_medal",
-  "\ud83e\udd4a": "boxing_glove",
-  "\ud83e\udd4b": "martial_arts_uniform",
-  "\ud83e\udd4c": "curling_stone",
-  "\ud83e\udd4d": "lacrosse",
-  "\ud83e\udd4e": "softball",
-  "\ud83e\udd4f": "flying_disc",
-  "\ud83e\udd50": "croissant",
-  "\ud83e\udd51": "avocado",
-  "\ud83e\udd52": "cucumber",
-  "\ud83e\udd53": "bacon",
-  "\ud83e\udd54": "potato",
-  "\ud83e\udd55": "carrot",
-  "\ud83e\udd56": "baguette_bread",
-  "\ud83e\udd57": "green_salad",
-  "\ud83e\udd58": "shallow_pan_of_food",
-  "\ud83e\udd59": "stuffed_flatbread",
-  "\ud83e\udd5a": "egg",
-  "\ud83e\udd5b": "glass_of_milk",
-  "\ud83e\udd5c": "peanuts",
-  "\ud83e\udd5d": "kiwi_fruit",
-  "\ud83e\udd5e": "pancakes",
-  "\ud83e\udd5f": "dumpling",
-  "\ud83e\udd60": "fortune_cookie",
-  "\ud83e\udd61": "takeout_box",
-  "\ud83e\udd62": "chopsticks",
-  "\ud83e\udd63": "bowl_with_spoon",
-  "\ud83e\udd64": "cup_with_straw",
-  "\ud83e\udd65": "coconut",
-  "\ud83e\udd66": "broccoli",
-  "\ud83e\udd67": "pie",
-  "\ud83e\udd68": "pretzel",
-  "\ud83e\udd69": "cut_of_meat",
-  "\ud83e\udd6a": "sandwich",
-  "\ud83e\udd6b": "canned_food",
-  "\ud83e\udd6c": "leafy_green",
-  "\ud83e\udd6d": "mango",
-  "\ud83e\udd6e": "moon_cake",
-  "\ud83e\udd6f": "bagel",
-  "\ud83e\udd70": "smiling_face_with_hearts",
-  "\ud83e\udd71": "yawning_face",
-  "\ud83e\udd72": "smiling_face_with_tear",
-  "\ud83e\udd73": "partying_face",
-  "\ud83e\udd74": "woozy_face",
-  "\ud83e\udd75": "hot_face",
-  "\ud83e\udd76": "cold_face",
-  "\ud83e\udd77": "ninja",
-  "\ud83e\udd77\ud83c\udffb": "ninja_light_skin_tone",
-  "\ud83e\udd77\ud83c\udffc": "ninja_medium-light_skin_tone",
-  "\ud83e\udd77\ud83c\udffd": "ninja_medium_skin_tone",
-  "\ud83e\udd77\ud83c\udffe": "ninja_medium-dark_skin_tone",
-  "\ud83e\udd77\ud83c\udfff": "ninja_dark_skin_tone",
-  "\ud83e\udd78": "disguised_face",
-  "\ud83e\udd79": "face_holding_back_tears",
-  "\ud83e\udd7a": "pleading_face",
-  "\ud83e\udd7b": "sari",
-  "\ud83e\udd7c": "lab_coat",
-  "\ud83e\udd7d": "goggles",
-  "\ud83e\udd7e": "hiking_boot",
-  "\ud83e\udd7f": "flat_shoe",
-  "\ud83e\udd80": "crab",
-  "\ud83e\udd81": "lion",
-  "\ud83e\udd82": "scorpion",
-  "\ud83e\udd83": "turkey",
-  "\ud83e\udd84": "unicorn",
-  "\ud83e\udd85": "eagle",
-  "\ud83e\udd86": "duck",
-  "\ud83e\udd87": "bat",
-  "\ud83e\udd88": "shark",
-  "\ud83e\udd89": "owl",
-  "\ud83e\udd8a": "fox",
-  "\ud83e\udd8b": "butterfly",
-  "\ud83e\udd8c": "deer",
-  "\ud83e\udd8d": "gorilla",
-  "\ud83e\udd8e": "lizard",
-  "\ud83e\udd8f": "rhinoceros",
-  "\ud83e\udd90": "shrimp",
-  "\ud83e\udd91": "squid",
-  "\ud83e\udd92": "giraffe",
-  "\ud83e\udd93": "zebra",
-  "\ud83e\udd94": "hedgehog",
-  "\ud83e\udd95": "sauropod",
-  "\ud83e\udd96": "t-rex",
-  "\ud83e\udd97": "cricket",
-  "\ud83e\udd98": "kangaroo",
-  "\ud83e\udd99": "llama",
-  "\ud83e\udd9a": "peacock",
-  "\ud83e\udd9b": "hippopotamus",
-  "\ud83e\udd9c": "parrot",
-  "\ud83e\udd9d": "raccoon",
-  "\ud83e\udd9e": "lobster",
-  "\ud83e\udd9f": "mosquito",
-  "\ud83e\udda0": "microbe",
-  "\ud83e\udda1": "badger",
-  "\ud83e\udda2": "swan",
-  "\ud83e\udda3": "mammoth",
-  "\ud83e\udda4": "dodo",
-  "\ud83e\udda5": "sloth",
-  "\ud83e\udda6": "otter",
-  "\ud83e\udda7": "orangutan",
-  "\ud83e\udda8": "skunk",
-  "\ud83e\udda9": "flamingo",
-  "\ud83e\uddaa": "oyster",
-  "\ud83e\uddab": "beaver",
-  "\ud83e\uddac": "bison",
-  "\ud83e\uddad": "seal",
-  "\ud83e\uddae": "guide_dog",
-  "\ud83e\uddaf": "white_cane",
-  "\ud83e\uddb0": "red_hair",
-  "\ud83e\uddb1": "curly_hair",
-  "\ud83e\uddb2": "bald",
-  "\ud83e\uddb3": "white_hair",
-  "\ud83e\uddb4": "bone",
-  "\ud83e\uddb5": "leg",
-  "\ud83e\uddb5\ud83c\udffb": "leg_light_skin_tone",
-  "\ud83e\uddb5\ud83c\udffc": "leg_medium-light_skin_tone",
-  "\ud83e\uddb5\ud83c\udffd": "leg_medium_skin_tone",
-  "\ud83e\uddb5\ud83c\udffe": "leg_medium-dark_skin_tone",
-  "\ud83e\uddb5\ud83c\udfff": "leg_dark_skin_tone",
-  "\ud83e\uddb6": "foot",
-  "\ud83e\uddb6\ud83c\udffb": "foot_light_skin_tone",
-  "\ud83e\uddb6\ud83c\udffc": "foot_medium-light_skin_tone",
-  "\ud83e\uddb6\ud83c\udffd": "foot_medium_skin_tone",
-  "\ud83e\uddb6\ud83c\udffe": "foot_medium-dark_skin_tone",
-  "\ud83e\uddb6\ud83c\udfff": "foot_dark_skin_tone",
-  "\ud83e\uddb7": "tooth",
-  "\ud83e\uddb8": "superhero",
-  "\ud83e\uddb8\u200d\u2640": "woman_superhero",
-  "\ud83e\uddb8\u200d\u2640\ufe0f": "woman_superhero",
-  "\ud83e\uddb8\u200d\u2642": "man_superhero",
-  "\ud83e\uddb8\u200d\u2642\ufe0f": "man_superhero",
-  "\ud83e\uddb8\ud83c\udffb": "superhero_light_skin_tone",
-  "\ud83e\uddb8\ud83c\udffb\u200d\u2640": "woman_superhero_light_skin_tone",
-  "\ud83e\uddb8\ud83c\udffb\u200d\u2640\ufe0f": "woman_superhero_light_skin_tone",
-  "\ud83e\uddb8\ud83c\udffb\u200d\u2642": "man_superhero_light_skin_tone",
-  "\ud83e\uddb8\ud83c\udffb\u200d\u2642\ufe0f": "man_superhero_light_skin_tone",
-  "\ud83e\uddb8\ud83c\udffc": "superhero_medium-light_skin_tone",
-  "\ud83e\uddb8\ud83c\udffc\u200d\u2640": "woman_superhero_medium-light_skin_tone",
-  "\ud83e\uddb8\ud83c\udffc\u200d\u2640\ufe0f": "woman_superhero_medium-light_skin_tone",
-  "\ud83e\uddb8\ud83c\udffc\u200d\u2642": "man_superhero_medium-light_skin_tone",
-  "\ud83e\uddb8\ud83c\udffc\u200d\u2642\ufe0f": "man_superhero_medium-light_skin_tone",
-  "\ud83e\uddb8\ud83c\udffd": "superhero_medium_skin_tone",
-  "\ud83e\uddb8\ud83c\udffd\u200d\u2640": "woman_superhero_medium_skin_tone",
-  "\ud83e\uddb8\ud83c\udffd\u200d\u2640\ufe0f": "woman_superhero_medium_skin_tone",
-  "\ud83e\uddb8\ud83c\udffd\u200d\u2642": "man_superhero_medium_skin_tone",
-  "\ud83e\uddb8\ud83c\udffd\u200d\u2642\ufe0f": "man_superhero_medium_skin_tone",
-  "\ud83e\uddb8\ud83c\udffe": "superhero_medium-dark_skin_tone",
-  "\ud83e\uddb8\ud83c\udffe\u200d\u2640": "woman_superhero_medium-dark_skin_tone",
-  "\ud83e\uddb8\ud83c\udffe\u200d\u2640\ufe0f": "woman_superhero_medium-dark_skin_tone",
-  "\ud83e\uddb8\ud83c\udffe\u200d\u2642": "man_superhero_medium-dark_skin_tone",
-  "\ud83e\uddb8\ud83c\udffe\u200d\u2642\ufe0f": "man_superhero_medium-dark_skin_tone",
-  "\ud83e\uddb8\ud83c\udfff": "superhero_dark_skin_tone",
-  "\ud83e\uddb8\ud83c\udfff\u200d\u2640": "woman_superhero_dark_skin_tone",
-  "\ud83e\uddb8\ud83c\udfff\u200d\u2640\ufe0f": "woman_superhero_dark_skin_tone",
-  "\ud83e\uddb8\ud83c\udfff\u200d\u2642": "man_superhero_dark_skin_tone",
-  "\ud83e\uddb8\ud83c\udfff\u200d\u2642\ufe0f": "man_superhero_dark_skin_tone",
-  "\ud83e\uddb9": "supervillain",
-  "\ud83e\uddb9\u200d\u2640": "woman_supervillain",
-  "\ud83e\uddb9\u200d\u2640\ufe0f": "woman_supervillain",
-  "\ud83e\uddb9\u200d\u2642": "man_supervillain",
-  "\ud83e\uddb9\u200d\u2642\ufe0f": "man_supervillain",
-  "\ud83e\uddb9\ud83c\udffb": "supervillain_light_skin_tone",
-  "\ud83e\uddb9\ud83c\udffb\u200d\u2640": "woman_supervillain_light_skin_tone",
-  "\ud83e\uddb9\ud83c\udffb\u200d\u2640\ufe0f": "woman_supervillain_light_skin_tone",
-  "\ud83e\uddb9\ud83c\udffb\u200d\u2642": "man_supervillain_light_skin_tone",
-  "\ud83e\uddb9\ud83c\udffb\u200d\u2642\ufe0f": "man_supervillain_light_skin_tone",
-  "\ud83e\uddb9\ud83c\udffc": "supervillain_medium-light_skin_tone",
-  "\ud83e\uddb9\ud83c\udffc\u200d\u2640": "woman_supervillain_medium-light_skin_tone",
-  "\ud83e\uddb9\ud83c\udffc\u200d\u2640\ufe0f": "woman_supervillain_medium-light_skin_tone",
-  "\ud83e\uddb9\ud83c\udffc\u200d\u2642": "man_supervillain_medium-light_skin_tone",
-  "\ud83e\uddb9\ud83c\udffc\u200d\u2642\ufe0f": "man_supervillain_medium-light_skin_tone",
-  "\ud83e\uddb9\ud83c\udffd": "supervillain_medium_skin_tone",
-  "\ud83e\uddb9\ud83c\udffd\u200d\u2640": "woman_supervillain_medium_skin_tone",
-  "\ud83e\uddb9\ud83c\udffd\u200d\u2640\ufe0f": "woman_supervillain_medium_skin_tone",
-  "\ud83e\uddb9\ud83c\udffd\u200d\u2642": "man_supervillain_medium_skin_tone",
-  "\ud83e\uddb9\ud83c\udffd\u200d\u2642\ufe0f": "man_supervillain_medium_skin_tone",
-  "\ud83e\uddb9\ud83c\udffe": "supervillain_medium-dark_skin_tone",
-  "\ud83e\uddb9\ud83c\udffe\u200d\u2640": "woman_supervillain_medium-dark_skin_tone",
-  "\ud83e\uddb9\ud83c\udffe\u200d\u2640\ufe0f": "woman_supervillain_medium-dark_skin_tone",
-  "\ud83e\uddb9\ud83c\udffe\u200d\u2642": "man_supervillain_medium-dark_skin_tone",
-  "\ud83e\uddb9\ud83c\udffe\u200d\u2642\ufe0f": "man_supervillain_medium-dark_skin_tone",
-  "\ud83e\uddb9\ud83c\udfff": "supervillain_dark_skin_tone",
-  "\ud83e\uddb9\ud83c\udfff\u200d\u2640": "woman_supervillain_dark_skin_tone",
-  "\ud83e\uddb9\ud83c\udfff\u200d\u2640\ufe0f": "woman_supervillain_dark_skin_tone",
-  "\ud83e\uddb9\ud83c\udfff\u200d\u2642": "man_supervillain_dark_skin_tone",
-  "\ud83e\uddb9\ud83c\udfff\u200d\u2642\ufe0f": "man_supervillain_dark_skin_tone",
-  "\ud83e\uddba": "safety_vest",
-  "\ud83e\uddbb": "ear_with_hearing_aid",
-  "\ud83e\uddbb\ud83c\udffb": "ear_with_hearing_aid_light_skin_tone",
-  "\ud83e\uddbb\ud83c\udffc": "ear_with_hearing_aid_medium-light_skin_tone",
-  "\ud83e\uddbb\ud83c\udffd": "ear_with_hearing_aid_medium_skin_tone",
-  "\ud83e\uddbb\ud83c\udffe": "ear_with_hearing_aid_medium-dark_skin_tone",
-  "\ud83e\uddbb\ud83c\udfff": "ear_with_hearing_aid_dark_skin_tone",
-  "\ud83e\uddbc": "motorized_wheelchair",
-  "\ud83e\uddbd": "manual_wheelchair",
-  "\ud83e\uddbe": "mechanical_arm",
-  "\ud83e\uddbf": "mechanical_leg",
-  "\ud83e\uddc0": "cheese_wedge",
-  "\ud83e\uddc1": "cupcake",
-  "\ud83e\uddc2": "salt",
-  "\ud83e\uddc3": "beverage_box",
-  "\ud83e\uddc4": "garlic",
-  "\ud83e\uddc5": "onion",
-  "\ud83e\uddc6": "falafel",
-  "\ud83e\uddc7": "waffle",
-  "\ud83e\uddc8": "butter",
-  "\ud83e\uddc9": "mate",
-  "\ud83e\uddca": "ice",
-  "\ud83e\uddcb": "bubble_tea",
-  "\ud83e\uddcc": "troll",
-  "\ud83e\uddcd": "person_standing",
-  "\ud83e\uddcd\u200d\u2640": "woman_standing",
-  "\ud83e\uddcd\u200d\u2640\ufe0f": "woman_standing",
-  "\ud83e\uddcd\u200d\u2642": "man_standing",
-  "\ud83e\uddcd\u200d\u2642\ufe0f": "man_standing",
-  "\ud83e\uddcd\ud83c\udffb": "person_standing_light_skin_tone",
-  "\ud83e\uddcd\ud83c\udffb\u200d\u2640": "woman_standing_light_skin_tone",
-  "\ud83e\uddcd\ud83c\udffb\u200d\u2640\ufe0f": "woman_standing_light_skin_tone",
-  "\ud83e\uddcd\ud83c\udffb\u200d\u2642": "man_standing_light_skin_tone",
-  "\ud83e\uddcd\ud83c\udffb\u200d\u2642\ufe0f": "man_standing_light_skin_tone",
-  "\ud83e\uddcd\ud83c\udffc": "person_standing_medium-light_skin_tone",
-  "\ud83e\uddcd\ud83c\udffc\u200d\u2640": "woman_standing_medium-light_skin_tone",
-  "\ud83e\uddcd\ud83c\udffc\u200d\u2640\ufe0f": "woman_standing_medium-light_skin_tone",
-  "\ud83e\uddcd\ud83c\udffc\u200d\u2642": "man_standing_medium-light_skin_tone",
-  "\ud83e\uddcd\ud83c\udffc\u200d\u2642\ufe0f": "man_standing_medium-light_skin_tone",
-  "\ud83e\uddcd\ud83c\udffd": "person_standing_medium_skin_tone",
-  "\ud83e\uddcd\ud83c\udffd\u200d\u2640": "woman_standing_medium_skin_tone",
-  "\ud83e\uddcd\ud83c\udffd\u200d\u2640\ufe0f": "woman_standing_medium_skin_tone",
-  "\ud83e\uddcd\ud83c\udffd\u200d\u2642": "man_standing_medium_skin_tone",
-  "\ud83e\uddcd\ud83c\udffd\u200d\u2642\ufe0f": "man_standing_medium_skin_tone",
-  "\ud83e\uddcd\ud83c\udffe": "person_standing_medium-dark_skin_tone",
-  "\ud83e\uddcd\ud83c\udffe\u200d\u2640": "woman_standing_medium-dark_skin_tone",
-  "\ud83e\uddcd\ud83c\udffe\u200d\u2640\ufe0f": "woman_standing_medium-dark_skin_tone",
-  "\ud83e\uddcd\ud83c\udffe\u200d\u2642": "man_standing_medium-dark_skin_tone",
-  "\ud83e\uddcd\ud83c\udffe\u200d\u2642\ufe0f": "man_standing_medium-dark_skin_tone",
-  "\ud83e\uddcd\ud83c\udfff": "person_standing_dark_skin_tone",
-  "\ud83e\uddcd\ud83c\udfff\u200d\u2640": "woman_standing_dark_skin_tone",
-  "\ud83e\uddcd\ud83c\udfff\u200d\u2640\ufe0f": "woman_standing_dark_skin_tone",
-  "\ud83e\uddcd\ud83c\udfff\u200d\u2642": "man_standing_dark_skin_tone",
-  "\ud83e\uddcd\ud83c\udfff\u200d\u2642\ufe0f": "man_standing_dark_skin_tone",
-  "\ud83e\uddce": "person_kneeling",
-  "\ud83e\uddce\u200d\u2640": "woman_kneeling",
-  "\ud83e\uddce\u200d\u2640\u200d\u27a1": "woman_kneeling_facing_right",
-  "\ud83e\uddce\u200d\u2640\u200d\u27a1\ufe0f": "woman_kneeling_facing_right",
-  "\ud83e\uddce\u200d\u2640\ufe0f": "woman_kneeling",
-  "\ud83e\uddce\u200d\u2640\ufe0f\u200d\u27a1": "woman_kneeling_facing_right",
-  "\ud83e\uddce\u200d\u2640\ufe0f\u200d\u27a1\ufe0f": "woman_kneeling_facing_right",
-  "\ud83e\uddce\u200d\u2642": "man_kneeling",
-  "\ud83e\uddce\u200d\u2642\u200d\u27a1": "man_kneeling_facing_right",
-  "\ud83e\uddce\u200d\u2642\u200d\u27a1\ufe0f": "man_kneeling_facing_right",
-  "\ud83e\uddce\u200d\u2642\ufe0f": "man_kneeling",
-  "\ud83e\uddce\u200d\u2642\ufe0f\u200d\u27a1": "man_kneeling_facing_right",
-  "\ud83e\uddce\u200d\u2642\ufe0f\u200d\u27a1\ufe0f": "man_kneeling_facing_right",
-  "\ud83e\uddce\u200d\u27a1": "person_kneeling_facing_right",
-  "\ud83e\uddce\u200d\u27a1\ufe0f": "person_kneeling_facing_right",
-  "\ud83e\uddce\ud83c\udffb": "person_kneeling_light_skin_tone",
-  "\ud83e\uddce\ud83c\udffb\u200d\u2640": "woman_kneeling_light_skin_tone",
-  "\ud83e\uddce\ud83c\udffb\u200d\u2640\u200d\u27a1": "woman_kneeling_facing_right_light_skin_tone",
-  "\ud83e\uddce\ud83c\udffb\u200d\u2640\u200d\u27a1\ufe0f": "woman_kneeling_facing_right_light_skin_tone",
-  "\ud83e\uddce\ud83c\udffb\u200d\u2640\ufe0f": "woman_kneeling_light_skin_tone",
-  "\ud83e\uddce\ud83c\udffb\u200d\u2640\ufe0f\u200d\u27a1": "woman_kneeling_facing_right_light_skin_tone",
-  "\ud83e\uddce\ud83c\udffb\u200d\u2640\ufe0f\u200d\u27a1\ufe0f": "woman_kneeling_facing_right_light_skin_tone",
-  "\ud83e\uddce\ud83c\udffb\u200d\u2642": "man_kneeling_light_skin_tone",
-  "\ud83e\uddce\ud83c\udffb\u200d\u2642\u200d\u27a1": "man_kneeling_facing_right_light_skin_tone",
-  "\ud83e\uddce\ud83c\udffb\u200d\u2642\u200d\u27a1\ufe0f": "man_kneeling_facing_right_light_skin_tone",
-  "\ud83e\uddce\ud83c\udffb\u200d\u2642\ufe0f": "man_kneeling_light_skin_tone",
-  "\ud83e\uddce\ud83c\udffb\u200d\u2642\ufe0f\u200d\u27a1": "man_kneeling_facing_right_light_skin_tone",
-  "\ud83e\uddce\ud83c\udffb\u200d\u2642\ufe0f\u200d\u27a1\ufe0f": "man_kneeling_facing_right_light_skin_tone",
-  "\ud83e\uddce\ud83c\udffb\u200d\u27a1": "person_kneeling_facing_right_light_skin_tone",
-  "\ud83e\uddce\ud83c\udffb\u200d\u27a1\ufe0f": "person_kneeling_facing_right_light_skin_tone",
-  "\ud83e\uddce\ud83c\udffc": "person_kneeling_medium-light_skin_tone",
-  "\ud83e\uddce\ud83c\udffc\u200d\u2640": "woman_kneeling_medium-light_skin_tone",
-  "\ud83e\uddce\ud83c\udffc\u200d\u2640\u200d\u27a1": "woman_kneeling_facing_right_medium-light_skin_tone",
-  "\ud83e\uddce\ud83c\udffc\u200d\u2640\u200d\u27a1\ufe0f": "woman_kneeling_facing_right_medium-light_skin_tone",
-  "\ud83e\uddce\ud83c\udffc\u200d\u2640\ufe0f": "woman_kneeling_medium-light_skin_tone",
-  "\ud83e\uddce\ud83c\udffc\u200d\u2640\ufe0f\u200d\u27a1": "woman_kneeling_facing_right_medium-light_skin_tone",
-  "\ud83e\uddce\ud83c\udffc\u200d\u2640\ufe0f\u200d\u27a1\ufe0f": "woman_kneeling_facing_right_medium-light_skin_tone",
-  "\ud83e\uddce\ud83c\udffc\u200d\u2642": "man_kneeling_medium-light_skin_tone",
-  "\ud83e\uddce\ud83c\udffc\u200d\u2642\u200d\u27a1": "man_kneeling_facing_right_medium-light_skin_tone",
-  "\ud83e\uddce\ud83c\udffc\u200d\u2642\u200d\u27a1\ufe0f": "man_kneeling_facing_right_medium-light_skin_tone",
-  "\ud83e\uddce\ud83c\udffc\u200d\u2642\ufe0f": "man_kneeling_medium-light_skin_tone",
-  "\ud83e\uddce\ud83c\udffc\u200d\u2642\ufe0f\u200d\u27a1": "man_kneeling_facing_right_medium-light_skin_tone",
-  "\ud83e\uddce\ud83c\udffc\u200d\u2642\ufe0f\u200d\u27a1\ufe0f": "man_kneeling_facing_right_medium-light_skin_tone",
-  "\ud83e\uddce\ud83c\udffc\u200d\u27a1": "person_kneeling_facing_right_medium-light_skin_tone",
-  "\ud83e\uddce\ud83c\udffc\u200d\u27a1\ufe0f": "person_kneeling_facing_right_medium-light_skin_tone",
-  "\ud83e\uddce\ud83c\udffd": "person_kneeling_medium_skin_tone",
-  "\ud83e\uddce\ud83c\udffd\u200d\u2640": "woman_kneeling_medium_skin_tone",
-  "\ud83e\uddce\ud83c\udffd\u200d\u2640\u200d\u27a1": "woman_kneeling_facing_right_medium_skin_tone",
-  "\ud83e\uddce\ud83c\udffd\u200d\u2640\u200d\u27a1\ufe0f": "woman_kneeling_facing_right_medium_skin_tone",
-  "\ud83e\uddce\ud83c\udffd\u200d\u2640\ufe0f": "woman_kneeling_medium_skin_tone",
-  "\ud83e\uddce\ud83c\udffd\u200d\u2640\ufe0f\u200d\u27a1": "woman_kneeling_facing_right_medium_skin_tone",
-  "\ud83e\uddce\ud83c\udffd\u200d\u2640\ufe0f\u200d\u27a1\ufe0f": "woman_kneeling_facing_right_medium_skin_tone",
-  "\ud83e\uddce\ud83c\udffd\u200d\u2642": "man_kneeling_medium_skin_tone",
-  "\ud83e\uddce\ud83c\udffd\u200d\u2642\u200d\u27a1": "man_kneeling_facing_right_medium_skin_tone",
-  "\ud83e\uddce\ud83c\udffd\u200d\u2642\u200d\u27a1\ufe0f": "man_kneeling_facing_right_medium_skin_tone",
-  "\ud83e\uddce\ud83c\udffd\u200d\u2642\ufe0f": "man_kneeling_medium_skin_tone",
-  "\ud83e\uddce\ud83c\udffd\u200d\u2642\ufe0f\u200d\u27a1": "man_kneeling_facing_right_medium_skin_tone",
-  "\ud83e\uddce\ud83c\udffd\u200d\u2642\ufe0f\u200d\u27a1\ufe0f": "man_kneeling_facing_right_medium_skin_tone",
-  "\ud83e\uddce\ud83c\udffd\u200d\u27a1": "person_kneeling_facing_right_medium_skin_tone",
-  "\ud83e\uddce\ud83c\udffd\u200d\u27a1\ufe0f": "person_kneeling_facing_right_medium_skin_tone",
-  "\ud83e\uddce\ud83c\udffe": "person_kneeling_medium-dark_skin_tone",
-  "\ud83e\uddce\ud83c\udffe\u200d\u2640": "woman_kneeling_medium-dark_skin_tone",
-  "\ud83e\uddce\ud83c\udffe\u200d\u2640\u200d\u27a1": "woman_kneeling_facing_right_medium-dark_skin_tone",
-  "\ud83e\uddce\ud83c\udffe\u200d\u2640\u200d\u27a1\ufe0f": "woman_kneeling_facing_right_medium-dark_skin_tone",
-  "\ud83e\uddce\ud83c\udffe\u200d\u2640\ufe0f": "woman_kneeling_medium-dark_skin_tone",
-  "\ud83e\uddce\ud83c\udffe\u200d\u2640\ufe0f\u200d\u27a1": "woman_kneeling_facing_right_medium-dark_skin_tone",
-  "\ud83e\uddce\ud83c\udffe\u200d\u2640\ufe0f\u200d\u27a1\ufe0f": "woman_kneeling_facing_right_medium-dark_skin_tone",
-  "\ud83e\uddce\ud83c\udffe\u200d\u2642": "man_kneeling_medium-dark_skin_tone",
-  "\ud83e\uddce\ud83c\udffe\u200d\u2642\u200d\u27a1": "man_kneeling_facing_right_medium-dark_skin_tone",
-  "\ud83e\uddce\ud83c\udffe\u200d\u2642\u200d\u27a1\ufe0f": "man_kneeling_facing_right_medium-dark_skin_tone",
-  "\ud83e\uddce\ud83c\udffe\u200d\u2642\ufe0f": "man_kneeling_medium-dark_skin_tone",
-  "\ud83e\uddce\ud83c\udffe\u200d\u2642\ufe0f\u200d\u27a1": "man_kneeling_facing_right_medium-dark_skin_tone",
-  "\ud83e\uddce\ud83c\udffe\u200d\u2642\ufe0f\u200d\u27a1\ufe0f": "man_kneeling_facing_right_medium-dark_skin_tone",
-  "\ud83e\uddce\ud83c\udffe\u200d\u27a1": "person_kneeling_facing_right_medium-dark_skin_tone",
-  "\ud83e\uddce\ud83c\udffe\u200d\u27a1\ufe0f": "person_kneeling_facing_right_medium-dark_skin_tone",
-  "\ud83e\uddce\ud83c\udfff": "person_kneeling_dark_skin_tone",
-  "\ud83e\uddce\ud83c\udfff\u200d\u2640": "woman_kneeling_dark_skin_tone",
-  "\ud83e\uddce\ud83c\udfff\u200d\u2640\u200d\u27a1": "woman_kneeling_facing_right_dark_skin_tone",
-  "\ud83e\uddce\ud83c\udfff\u200d\u2640\u200d\u27a1\ufe0f": "woman_kneeling_facing_right_dark_skin_tone",
-  "\ud83e\uddce\ud83c\udfff\u200d\u2640\ufe0f": "woman_kneeling_dark_skin_tone",
-  "\ud83e\uddce\ud83c\udfff\u200d\u2640\ufe0f\u200d\u27a1": "woman_kneeling_facing_right_dark_skin_tone",
-  "\ud83e\uddce\ud83c\udfff\u200d\u2640\ufe0f\u200d\u27a1\ufe0f": "woman_kneeling_facing_right_dark_skin_tone",
-  "\ud83e\uddce\ud83c\udfff\u200d\u2642": "man_kneeling_dark_skin_tone",
-  "\ud83e\uddce\ud83c\udfff\u200d\u2642\u200d\u27a1": "man_kneeling_facing_right_dark_skin_tone",
-  "\ud83e\uddce\ud83c\udfff\u200d\u2642\u200d\u27a1\ufe0f": "man_kneeling_facing_right_dark_skin_tone",
-  "\ud83e\uddce\ud83c\udfff\u200d\u2642\ufe0f": "man_kneeling_dark_skin_tone",
-  "\ud83e\uddce\ud83c\udfff\u200d\u2642\ufe0f\u200d\u27a1": "man_kneeling_facing_right_dark_skin_tone",
-  "\ud83e\uddce\ud83c\udfff\u200d\u2642\ufe0f\u200d\u27a1\ufe0f": "man_kneeling_facing_right_dark_skin_tone",
-  "\ud83e\uddce\ud83c\udfff\u200d\u27a1": "person_kneeling_facing_right_dark_skin_tone",
-  "\ud83e\uddce\ud83c\udfff\u200d\u27a1\ufe0f": "person_kneeling_facing_right_dark_skin_tone",
-  "\ud83e\uddcf": "deaf_person",
-  "\ud83e\uddcf\u200d\u2640": "deaf_woman",
-  "\ud83e\uddcf\u200d\u2640\ufe0f": "deaf_woman",
-  "\ud83e\uddcf\u200d\u2642": "deaf_man",
-  "\ud83e\uddcf\u200d\u2642\ufe0f": "deaf_man",
-  "\ud83e\uddcf\ud83c\udffb": "deaf_person_light_skin_tone",
-  "\ud83e\uddcf\ud83c\udffb\u200d\u2640": "deaf_woman_light_skin_tone",
-  "\ud83e\uddcf\ud83c\udffb\u200d\u2640\ufe0f": "deaf_woman_light_skin_tone",
-  "\ud83e\uddcf\ud83c\udffb\u200d\u2642": "deaf_man_light_skin_tone",
-  "\ud83e\uddcf\ud83c\udffb\u200d\u2642\ufe0f": "deaf_man_light_skin_tone",
-  "\ud83e\uddcf\ud83c\udffc": "deaf_person_medium-light_skin_tone",
-  "\ud83e\uddcf\ud83c\udffc\u200d\u2640": "deaf_woman_medium-light_skin_tone",
-  "\ud83e\uddcf\ud83c\udffc\u200d\u2640\ufe0f": "deaf_woman_medium-light_skin_tone",
-  "\ud83e\uddcf\ud83c\udffc\u200d\u2642": "deaf_man_medium-light_skin_tone",
-  "\ud83e\uddcf\ud83c\udffc\u200d\u2642\ufe0f": "deaf_man_medium-light_skin_tone",
-  "\ud83e\uddcf\ud83c\udffd": "deaf_person_medium_skin_tone",
-  "\ud83e\uddcf\ud83c\udffd\u200d\u2640": "deaf_woman_medium_skin_tone",
-  "\ud83e\uddcf\ud83c\udffd\u200d\u2640\ufe0f": "deaf_woman_medium_skin_tone",
-  "\ud83e\uddcf\ud83c\udffd\u200d\u2642": "deaf_man_medium_skin_tone",
-  "\ud83e\uddcf\ud83c\udffd\u200d\u2642\ufe0f": "deaf_man_medium_skin_tone",
-  "\ud83e\uddcf\ud83c\udffe": "deaf_person_medium-dark_skin_tone",
-  "\ud83e\uddcf\ud83c\udffe\u200d\u2640": "deaf_woman_medium-dark_skin_tone",
-  "\ud83e\uddcf\ud83c\udffe\u200d\u2640\ufe0f": "deaf_woman_medium-dark_skin_tone",
-  "\ud83e\uddcf\ud83c\udffe\u200d\u2642": "deaf_man_medium-dark_skin_tone",
-  "\ud83e\uddcf\ud83c\udffe\u200d\u2642\ufe0f": "deaf_man_medium-dark_skin_tone",
-  "\ud83e\uddcf\ud83c\udfff": "deaf_person_dark_skin_tone",
-  "\ud83e\uddcf\ud83c\udfff\u200d\u2640": "deaf_woman_dark_skin_tone",
-  "\ud83e\uddcf\ud83c\udfff\u200d\u2640\ufe0f": "deaf_woman_dark_skin_tone",
-  "\ud83e\uddcf\ud83c\udfff\u200d\u2642": "deaf_man_dark_skin_tone",
-  "\ud83e\uddcf\ud83c\udfff\u200d\u2642\ufe0f": "deaf_man_dark_skin_tone",
-  "\ud83e\uddd0": "face_with_monocle",
-  "\ud83e\uddd1": "person",
-  "\ud83e\uddd1\u200d\u2695": "health_worker",
-  "\ud83e\uddd1\u200d\u2695\ufe0f": "health_worker",
-  "\ud83e\uddd1\u200d\u2696": "judge",
-  "\ud83e\uddd1\u200d\u2696\ufe0f": "judge",
-  "\ud83e\uddd1\u200d\u2708": "pilot",
-  "\ud83e\uddd1\u200d\u2708\ufe0f": "pilot",
-  "\ud83e\uddd1\u200d\ud83c\udf3e": "farmer",
-  "\ud83e\uddd1\u200d\ud83c\udf73": "cook",
-  "\ud83e\uddd1\u200d\ud83c\udf7c": "person_feeding_baby",
-  "\ud83e\uddd1\u200d\ud83c\udf84": "mx_claus",
-  "\ud83e\uddd1\u200d\ud83c\udf93": "student",
-  "\ud83e\uddd1\u200d\ud83c\udfa4": "singer",
-  "\ud83e\uddd1\u200d\ud83c\udfa8": "artist",
-  "\ud83e\uddd1\u200d\ud83c\udfeb": "teacher",
-  "\ud83e\uddd1\u200d\ud83c\udfed": "factory_worker",
-  "\ud83e\uddd1\u200d\ud83d\udcbb": "technologist",
-  "\ud83e\uddd1\u200d\ud83d\udcbc": "office_worker",
-  "\ud83e\uddd1\u200d\ud83d\udd27": "mechanic",
-  "\ud83e\uddd1\u200d\ud83d\udd2c": "scientist",
-  "\ud83e\uddd1\u200d\ud83d\ude80": "astronaut",
-  "\ud83e\uddd1\u200d\ud83d\ude92": "firefighter",
-  "\ud83e\uddd1\u200d\ud83e\udd1d\u200d\ud83e\uddd1": "people_holding_hands",
-  "\ud83e\uddd1\u200d\ud83e\uddaf": "person_with_white_cane",
-  "\ud83e\uddd1\u200d\ud83e\uddaf\u200d\u27a1": "person_with_white_cane_facing_right",
-  "\ud83e\uddd1\u200d\ud83e\uddaf\u200d\u27a1\ufe0f": "person_with_white_cane_facing_right",
-  "\ud83e\uddd1\u200d\ud83e\uddb0": "person_red_hair",
-  "\ud83e\uddd1\u200d\ud83e\uddb1": "person_curly_hair",
-  "\ud83e\uddd1\u200d\ud83e\uddb2": "person_bald",
-  "\ud83e\uddd1\u200d\ud83e\uddb3": "person_white_hair",
-  "\ud83e\uddd1\u200d\ud83e\uddbc": "person_in_motorized_wheelchair",
-  "\ud83e\uddd1\u200d\ud83e\uddbc\u200d\u27a1": "person_in_motorized_wheelchair_facing_right",
-  "\ud83e\uddd1\u200d\ud83e\uddbc\u200d\u27a1\ufe0f": "person_in_motorized_wheelchair_facing_right",
-  "\ud83e\uddd1\u200d\ud83e\uddbd": "person_in_manual_wheelchair",
-  "\ud83e\uddd1\u200d\ud83e\uddbd\u200d\u27a1": "person_in_manual_wheelchair_facing_right",
-  "\ud83e\uddd1\u200d\ud83e\uddbd\u200d\u27a1\ufe0f": "person_in_manual_wheelchair_facing_right",
-  "\ud83e\uddd1\u200d\ud83e\uddd1\u200d\ud83e\uddd2": "family_adult_adult_child",
-  "\ud83e\uddd1\u200d\ud83e\uddd1\u200d\ud83e\uddd2\u200d\ud83e\uddd2": "family_adult_adult_child_child",
-  "\ud83e\uddd1\u200d\ud83e\uddd2": "family_adult_child",
-  "\ud83e\uddd1\u200d\ud83e\uddd2\u200d\ud83e\uddd2": "family_adult_child_child",
-  "\ud83e\uddd1\ud83c\udffb": "person_light_skin_tone",
-  "\ud83e\uddd1\ud83c\udffb\u200d\u2695": "health_worker_light_skin_tone",
-  "\ud83e\uddd1\ud83c\udffb\u200d\u2695\ufe0f": "health_worker_light_skin_tone",
-  "\ud83e\uddd1\ud83c\udffb\u200d\u2696": "judge_light_skin_tone",
-  "\ud83e\uddd1\ud83c\udffb\u200d\u2696\ufe0f": "judge_light_skin_tone",
-  "\ud83e\uddd1\ud83c\udffb\u200d\u2708": "pilot_light_skin_tone",
-  "\ud83e\uddd1\ud83c\udffb\u200d\u2708\ufe0f": "pilot_light_skin_tone",
-  "\ud83e\uddd1\ud83c\udffb\u200d\u2764\u200d\ud83d\udc8b\u200d\ud83e\uddd1\ud83c\udffc": "kiss_person_person_light_skin_tone_medium-light_skin_tone",
-  "\ud83e\uddd1\ud83c\udffb\u200d\u2764\u200d\ud83d\udc8b\u200d\ud83e\uddd1\ud83c\udffd": "kiss_person_person_light_skin_tone_medium_skin_tone",
-  "\ud83e\uddd1\ud83c\udffb\u200d\u2764\u200d\ud83d\udc8b\u200d\ud83e\uddd1\ud83c\udffe": "kiss_person_person_light_skin_tone_medium-dark_skin_tone",
-  "\ud83e\uddd1\ud83c\udffb\u200d\u2764\u200d\ud83d\udc8b\u200d\ud83e\uddd1\ud83c\udfff": "kiss_person_person_light_skin_tone_dark_skin_tone",
-  "\ud83e\uddd1\ud83c\udffb\u200d\u2764\u200d\ud83e\uddd1\ud83c\udffc": "couple_with_heart_person_person_light_skin_tone_medium-light_skin_tone",
-  "\ud83e\uddd1\ud83c\udffb\u200d\u2764\u200d\ud83e\uddd1\ud83c\udffd": "couple_with_heart_person_person_light_skin_tone_medium_skin_tone",
-  "\ud83e\uddd1\ud83c\udffb\u200d\u2764\u200d\ud83e\uddd1\ud83c\udffe": "couple_with_heart_person_person_light_skin_tone_medium-dark_skin_tone",
-  "\ud83e\uddd1\ud83c\udffb\u200d\u2764\u200d\ud83e\uddd1\ud83c\udfff": "couple_with_heart_person_person_light_skin_tone_dark_skin_tone",
-  "\ud83e\uddd1\ud83c\udffb\u200d\u2764\ufe0f\u200d\ud83d\udc8b\u200d\ud83e\uddd1\ud83c\udffc": "kiss_person_person_light_skin_tone_medium-light_skin_tone",
-  "\ud83e\uddd1\ud83c\udffb\u200d\u2764\ufe0f\u200d\ud83d\udc8b\u200d\ud83e\uddd1\ud83c\udffd": "kiss_person_person_light_skin_tone_medium_skin_tone",
-  "\ud83e\uddd1\ud83c\udffb\u200d\u2764\ufe0f\u200d\ud83d\udc8b\u200d\ud83e\uddd1\ud83c\udffe": "kiss_person_person_light_skin_tone_medium-dark_skin_tone",
-  "\ud83e\uddd1\ud83c\udffb\u200d\u2764\ufe0f\u200d\ud83d\udc8b\u200d\ud83e\uddd1\ud83c\udfff": "kiss_person_person_light_skin_tone_dark_skin_tone",
-  "\ud83e\uddd1\ud83c\udffb\u200d\u2764\ufe0f\u200d\ud83e\uddd1\ud83c\udffc": "couple_with_heart_person_person_light_skin_tone_medium-light_skin_tone",
-  "\ud83e\uddd1\ud83c\udffb\u200d\u2764\ufe0f\u200d\ud83e\uddd1\ud83c\udffd": "couple_with_heart_person_person_light_skin_tone_medium_skin_tone",
-  "\ud83e\uddd1\ud83c\udffb\u200d\u2764\ufe0f\u200d\ud83e\uddd1\ud83c\udffe": "couple_with_heart_person_person_light_skin_tone_medium-dark_skin_tone",
-  "\ud83e\uddd1\ud83c\udffb\u200d\u2764\ufe0f\u200d\ud83e\uddd1\ud83c\udfff": "couple_with_heart_person_person_light_skin_tone_dark_skin_tone",
-  "\ud83e\uddd1\ud83c\udffb\u200d\ud83c\udf3e": "farmer_light_skin_tone",
-  "\ud83e\uddd1\ud83c\udffb\u200d\ud83c\udf73": "cook_light_skin_tone",
-  "\ud83e\uddd1\ud83c\udffb\u200d\ud83c\udf7c": "person_feeding_baby_light_skin_tone",
-  "\ud83e\uddd1\ud83c\udffb\u200d\ud83c\udf84": "mx_claus_light_skin_tone",
-  "\ud83e\uddd1\ud83c\udffb\u200d\ud83c\udf93": "student_light_skin_tone",
-  "\ud83e\uddd1\ud83c\udffb\u200d\ud83c\udfa4": "singer_light_skin_tone",
-  "\ud83e\uddd1\ud83c\udffb\u200d\ud83c\udfa8": "artist_light_skin_tone",
-  "\ud83e\uddd1\ud83c\udffb\u200d\ud83c\udfeb": "teacher_light_skin_tone",
-  "\ud83e\uddd1\ud83c\udffb\u200d\ud83c\udfed": "factory_worker_light_skin_tone",
-  "\ud83e\uddd1\ud83c\udffb\u200d\ud83d\udcbb": "technologist_light_skin_tone",
-  "\ud83e\uddd1\ud83c\udffb\u200d\ud83d\udcbc": "office_worker_light_skin_tone",
-  "\ud83e\uddd1\ud83c\udffb\u200d\ud83d\udd27": "mechanic_light_skin_tone",
-  "\ud83e\uddd1\ud83c\udffb\u200d\ud83d\udd2c": "scientist_light_skin_tone",
-  "\ud83e\uddd1\ud83c\udffb\u200d\ud83d\ude80": "astronaut_light_skin_tone",
-  "\ud83e\uddd1\ud83c\udffb\u200d\ud83d\ude92": "firefighter_light_skin_tone",
-  "\ud83e\uddd1\ud83c\udffb\u200d\ud83e\udd1d\u200d\ud83e\uddd1\ud83c\udffb": "people_holding_hands_light_skin_tone",
-  "\ud83e\uddd1\ud83c\udffb\u200d\ud83e\udd1d\u200d\ud83e\uddd1\ud83c\udffc": "people_holding_hands_light_skin_tone_medium-light_skin_tone",
-  "\ud83e\uddd1\ud83c\udffb\u200d\ud83e\udd1d\u200d\ud83e\uddd1\ud83c\udffd": "people_holding_hands_light_skin_tone_medium_skin_tone",
-  "\ud83e\uddd1\ud83c\udffb\u200d\ud83e\udd1d\u200d\ud83e\uddd1\ud83c\udffe": "people_holding_hands_light_skin_tone_medium-dark_skin_tone",
-  "\ud83e\uddd1\ud83c\udffb\u200d\ud83e\udd1d\u200d\ud83e\uddd1\ud83c\udfff": "people_holding_hands_light_skin_tone_dark_skin_tone",
-  "\ud83e\uddd1\ud83c\udffb\u200d\ud83e\uddaf": "person_with_white_cane_light_skin_tone",
-  "\ud83e\uddd1\ud83c\udffb\u200d\ud83e\uddaf\u200d\u27a1": "person_with_white_cane_facing_right_light_skin_tone",
-  "\ud83e\uddd1\ud83c\udffb\u200d\ud83e\uddaf\u200d\u27a1\ufe0f": "person_with_white_cane_facing_right_light_skin_tone",
-  "\ud83e\uddd1\ud83c\udffb\u200d\ud83e\uddb0": "person_light_skin_tone_red_hair",
-  "\ud83e\uddd1\ud83c\udffb\u200d\ud83e\uddb1": "person_light_skin_tone_curly_hair",
-  "\ud83e\uddd1\ud83c\udffb\u200d\ud83e\uddb2": "person_light_skin_tone_bald",
-  "\ud83e\uddd1\ud83c\udffb\u200d\ud83e\uddb3": "person_light_skin_tone_white_hair",
-  "\ud83e\uddd1\ud83c\udffb\u200d\ud83e\uddbc": "person_in_motorized_wheelchair_light_skin_tone",
-  "\ud83e\uddd1\ud83c\udffb\u200d\ud83e\uddbc\u200d\u27a1": "person_in_motorized_wheelchair_facing_right_light_skin_tone",
-  "\ud83e\uddd1\ud83c\udffb\u200d\ud83e\uddbc\u200d\u27a1\ufe0f": "person_in_motorized_wheelchair_facing_right_light_skin_tone",
-  "\ud83e\uddd1\ud83c\udffb\u200d\ud83e\uddbd": "person_in_manual_wheelchair_light_skin_tone",
-  "\ud83e\uddd1\ud83c\udffb\u200d\ud83e\uddbd\u200d\u27a1": "person_in_manual_wheelchair_facing_right_light_skin_tone",
-  "\ud83e\uddd1\ud83c\udffb\u200d\ud83e\uddbd\u200d\u27a1\ufe0f": "person_in_manual_wheelchair_facing_right_light_skin_tone",
-  "\ud83e\uddd1\ud83c\udffc": "person_medium-light_skin_tone",
-  "\ud83e\uddd1\ud83c\udffc\u200d\u2695": "health_worker_medium-light_skin_tone",
-  "\ud83e\uddd1\ud83c\udffc\u200d\u2695\ufe0f": "health_worker_medium-light_skin_tone",
-  "\ud83e\uddd1\ud83c\udffc\u200d\u2696": "judge_medium-light_skin_tone",
-  "\ud83e\uddd1\ud83c\udffc\u200d\u2696\ufe0f": "judge_medium-light_skin_tone",
-  "\ud83e\uddd1\ud83c\udffc\u200d\u2708": "pilot_medium-light_skin_tone",
-  "\ud83e\uddd1\ud83c\udffc\u200d\u2708\ufe0f": "pilot_medium-light_skin_tone",
-  "\ud83e\uddd1\ud83c\udffc\u200d\u2764\u200d\ud83d\udc8b\u200d\ud83e\uddd1\ud83c\udffb": "kiss_person_person_medium-light_skin_tone_light_skin_tone",
-  "\ud83e\uddd1\ud83c\udffc\u200d\u2764\u200d\ud83d\udc8b\u200d\ud83e\uddd1\ud83c\udffd": "kiss_person_person_medium-light_skin_tone_medium_skin_tone",
-  "\ud83e\uddd1\ud83c\udffc\u200d\u2764\u200d\ud83d\udc8b\u200d\ud83e\uddd1\ud83c\udffe": "kiss_person_person_medium-light_skin_tone_medium-dark_skin_tone",
-  "\ud83e\uddd1\ud83c\udffc\u200d\u2764\u200d\ud83d\udc8b\u200d\ud83e\uddd1\ud83c\udfff": "kiss_person_person_medium-light_skin_tone_dark_skin_tone",
-  "\ud83e\uddd1\ud83c\udffc\u200d\u2764\u200d\ud83e\uddd1\ud83c\udffb": "couple_with_heart_person_person_medium-light_skin_tone_light_skin_tone",
-  "\ud83e\uddd1\ud83c\udffc\u200d\u2764\u200d\ud83e\uddd1\ud83c\udffd": "couple_with_heart_person_person_medium-light_skin_tone_medium_skin_tone",
-  "\ud83e\uddd1\ud83c\udffc\u200d\u2764\u200d\ud83e\uddd1\ud83c\udffe": "couple_with_heart_person_person_medium-light_skin_tone_medium-dark_skin_tone",
-  "\ud83e\uddd1\ud83c\udffc\u200d\u2764\u200d\ud83e\uddd1\ud83c\udfff": "couple_with_heart_person_person_medium-light_skin_tone_dark_skin_tone",
-  "\ud83e\uddd1\ud83c\udffc\u200d\u2764\ufe0f\u200d\ud83d\udc8b\u200d\ud83e\uddd1\ud83c\udffb": "kiss_person_person_medium-light_skin_tone_light_skin_tone",
-  "\ud83e\uddd1\ud83c\udffc\u200d\u2764\ufe0f\u200d\ud83d\udc8b\u200d\ud83e\uddd1\ud83c\udffd": "kiss_person_person_medium-light_skin_tone_medium_skin_tone",
-  "\ud83e\uddd1\ud83c\udffc\u200d\u2764\ufe0f\u200d\ud83d\udc8b\u200d\ud83e\uddd1\ud83c\udffe": "kiss_person_person_medium-light_skin_tone_medium-dark_skin_tone",
-  "\ud83e\uddd1\ud83c\udffc\u200d\u2764\ufe0f\u200d\ud83d\udc8b\u200d\ud83e\uddd1\ud83c\udfff": "kiss_person_person_medium-light_skin_tone_dark_skin_tone",
-  "\ud83e\uddd1\ud83c\udffc\u200d\u2764\ufe0f\u200d\ud83e\uddd1\ud83c\udffb": "couple_with_heart_person_person_medium-light_skin_tone_light_skin_tone",
-  "\ud83e\uddd1\ud83c\udffc\u200d\u2764\ufe0f\u200d\ud83e\uddd1\ud83c\udffd": "couple_with_heart_person_person_medium-light_skin_tone_medium_skin_tone",
-  "\ud83e\uddd1\ud83c\udffc\u200d\u2764\ufe0f\u200d\ud83e\uddd1\ud83c\udffe": "couple_with_heart_person_person_medium-light_skin_tone_medium-dark_skin_tone",
-  "\ud83e\uddd1\ud83c\udffc\u200d\u2764\ufe0f\u200d\ud83e\uddd1\ud83c\udfff": "couple_with_heart_person_person_medium-light_skin_tone_dark_skin_tone",
-  "\ud83e\uddd1\ud83c\udffc\u200d\ud83c\udf3e": "farmer_medium-light_skin_tone",
-  "\ud83e\uddd1\ud83c\udffc\u200d\ud83c\udf73": "cook_medium-light_skin_tone",
-  "\ud83e\uddd1\ud83c\udffc\u200d\ud83c\udf7c": "person_feeding_baby_medium-light_skin_tone",
-  "\ud83e\uddd1\ud83c\udffc\u200d\ud83c\udf84": "mx_claus_medium-light_skin_tone",
-  "\ud83e\uddd1\ud83c\udffc\u200d\ud83c\udf93": "student_medium-light_skin_tone",
-  "\ud83e\uddd1\ud83c\udffc\u200d\ud83c\udfa4": "singer_medium-light_skin_tone",
-  "\ud83e\uddd1\ud83c\udffc\u200d\ud83c\udfa8": "artist_medium-light_skin_tone",
-  "\ud83e\uddd1\ud83c\udffc\u200d\ud83c\udfeb": "teacher_medium-light_skin_tone",
-  "\ud83e\uddd1\ud83c\udffc\u200d\ud83c\udfed": "factory_worker_medium-light_skin_tone",
-  "\ud83e\uddd1\ud83c\udffc\u200d\ud83d\udcbb": "technologist_medium-light_skin_tone",
-  "\ud83e\uddd1\ud83c\udffc\u200d\ud83d\udcbc": "office_worker_medium-light_skin_tone",
-  "\ud83e\uddd1\ud83c\udffc\u200d\ud83d\udd27": "mechanic_medium-light_skin_tone",
-  "\ud83e\uddd1\ud83c\udffc\u200d\ud83d\udd2c": "scientist_medium-light_skin_tone",
-  "\ud83e\uddd1\ud83c\udffc\u200d\ud83d\ude80": "astronaut_medium-light_skin_tone",
-  "\ud83e\uddd1\ud83c\udffc\u200d\ud83d\ude92": "firefighter_medium-light_skin_tone",
-  "\ud83e\uddd1\ud83c\udffc\u200d\ud83e\udd1d\u200d\ud83e\uddd1\ud83c\udffb": "people_holding_hands_medium-light_skin_tone_light_skin_tone",
-  "\ud83e\uddd1\ud83c\udffc\u200d\ud83e\udd1d\u200d\ud83e\uddd1\ud83c\udffc": "people_holding_hands_medium-light_skin_tone",
-  "\ud83e\uddd1\ud83c\udffc\u200d\ud83e\udd1d\u200d\ud83e\uddd1\ud83c\udffd": "people_holding_hands_medium-light_skin_tone_medium_skin_tone",
-  "\ud83e\uddd1\ud83c\udffc\u200d\ud83e\udd1d\u200d\ud83e\uddd1\ud83c\udffe": "people_holding_hands_medium-light_skin_tone_medium-dark_skin_tone",
-  "\ud83e\uddd1\ud83c\udffc\u200d\ud83e\udd1d\u200d\ud83e\uddd1\ud83c\udfff": "people_holding_hands_medium-light_skin_tone_dark_skin_tone",
-  "\ud83e\uddd1\ud83c\udffc\u200d\ud83e\uddaf": "person_with_white_cane_medium-light_skin_tone",
-  "\ud83e\uddd1\ud83c\udffc\u200d\ud83e\uddaf\u200d\u27a1": "person_with_white_cane_facing_right_medium-light_skin_tone",
-  "\ud83e\uddd1\ud83c\udffc\u200d\ud83e\uddaf\u200d\u27a1\ufe0f": "person_with_white_cane_facing_right_medium-light_skin_tone",
-  "\ud83e\uddd1\ud83c\udffc\u200d\ud83e\uddb0": "person_medium-light_skin_tone_red_hair",
-  "\ud83e\uddd1\ud83c\udffc\u200d\ud83e\uddb1": "person_medium-light_skin_tone_curly_hair",
-  "\ud83e\uddd1\ud83c\udffc\u200d\ud83e\uddb2": "person_medium-light_skin_tone_bald",
-  "\ud83e\uddd1\ud83c\udffc\u200d\ud83e\uddb3": "person_medium-light_skin_tone_white_hair",
-  "\ud83e\uddd1\ud83c\udffc\u200d\ud83e\uddbc": "person_in_motorized_wheelchair_medium-light_skin_tone",
-  "\ud83e\uddd1\ud83c\udffc\u200d\ud83e\uddbc\u200d\u27a1": "person_in_motorized_wheelchair_facing_right_medium-light_skin_tone",
-  "\ud83e\uddd1\ud83c\udffc\u200d\ud83e\uddbc\u200d\u27a1\ufe0f": "person_in_motorized_wheelchair_facing_right_medium-light_skin_tone",
-  "\ud83e\uddd1\ud83c\udffc\u200d\ud83e\uddbd": "person_in_manual_wheelchair_medium-light_skin_tone",
-  "\ud83e\uddd1\ud83c\udffc\u200d\ud83e\uddbd\u200d\u27a1": "person_in_manual_wheelchair_facing_right_medium-light_skin_tone",
-  "\ud83e\uddd1\ud83c\udffc\u200d\ud83e\uddbd\u200d\u27a1\ufe0f": "person_in_manual_wheelchair_facing_right_medium-light_skin_tone",
-  "\ud83e\uddd1\ud83c\udffd": "person_medium_skin_tone",
-  "\ud83e\uddd1\ud83c\udffd\u200d\u2695": "health_worker_medium_skin_tone",
-  "\ud83e\uddd1\ud83c\udffd\u200d\u2695\ufe0f": "health_worker_medium_skin_tone",
-  "\ud83e\uddd1\ud83c\udffd\u200d\u2696": "judge_medium_skin_tone",
-  "\ud83e\uddd1\ud83c\udffd\u200d\u2696\ufe0f": "judge_medium_skin_tone",
-  "\ud83e\uddd1\ud83c\udffd\u200d\u2708": "pilot_medium_skin_tone",
-  "\ud83e\uddd1\ud83c\udffd\u200d\u2708\ufe0f": "pilot_medium_skin_tone",
-  "\ud83e\uddd1\ud83c\udffd\u200d\u2764\u200d\ud83d\udc8b\u200d\ud83e\uddd1\ud83c\udffb": "kiss_person_person_medium_skin_tone_light_skin_tone",
-  "\ud83e\uddd1\ud83c\udffd\u200d\u2764\u200d\ud83d\udc8b\u200d\ud83e\uddd1\ud83c\udffc": "kiss_person_person_medium_skin_tone_medium-light_skin_tone",
-  "\ud83e\uddd1\ud83c\udffd\u200d\u2764\u200d\ud83d\udc8b\u200d\ud83e\uddd1\ud83c\udffe": "kiss_person_person_medium_skin_tone_medium-dark_skin_tone",
-  "\ud83e\uddd1\ud83c\udffd\u200d\u2764\u200d\ud83d\udc8b\u200d\ud83e\uddd1\ud83c\udfff": "kiss_person_person_medium_skin_tone_dark_skin_tone",
-  "\ud83e\uddd1\ud83c\udffd\u200d\u2764\u200d\ud83e\uddd1\ud83c\udffb": "couple_with_heart_person_person_medium_skin_tone_light_skin_tone",
-  "\ud83e\uddd1\ud83c\udffd\u200d\u2764\u200d\ud83e\uddd1\ud83c\udffc": "couple_with_heart_person_person_medium_skin_tone_medium-light_skin_tone",
-  "\ud83e\uddd1\ud83c\udffd\u200d\u2764\u200d\ud83e\uddd1\ud83c\udffe": "couple_with_heart_person_person_medium_skin_tone_medium-dark_skin_tone",
-  "\ud83e\uddd1\ud83c\udffd\u200d\u2764\u200d\ud83e\uddd1\ud83c\udfff": "couple_with_heart_person_person_medium_skin_tone_dark_skin_tone",
-  "\ud83e\uddd1\ud83c\udffd\u200d\u2764\ufe0f\u200d\ud83d\udc8b\u200d\ud83e\uddd1\ud83c\udffb": "kiss_person_person_medium_skin_tone_light_skin_tone",
-  "\ud83e\uddd1\ud83c\udffd\u200d\u2764\ufe0f\u200d\ud83d\udc8b\u200d\ud83e\uddd1\ud83c\udffc": "kiss_person_person_medium_skin_tone_medium-light_skin_tone",
-  "\ud83e\uddd1\ud83c\udffd\u200d\u2764\ufe0f\u200d\ud83d\udc8b\u200d\ud83e\uddd1\ud83c\udffe": "kiss_person_person_medium_skin_tone_medium-dark_skin_tone",
-  "\ud83e\uddd1\ud83c\udffd\u200d\u2764\ufe0f\u200d\ud83d\udc8b\u200d\ud83e\uddd1\ud83c\udfff": "kiss_person_person_medium_skin_tone_dark_skin_tone",
-  "\ud83e\uddd1\ud83c\udffd\u200d\u2764\ufe0f\u200d\ud83e\uddd1\ud83c\udffb": "couple_with_heart_person_person_medium_skin_tone_light_skin_tone",
-  "\ud83e\uddd1\ud83c\udffd\u200d\u2764\ufe0f\u200d\ud83e\uddd1\ud83c\udffc": "couple_with_heart_person_person_medium_skin_tone_medium-light_skin_tone",
-  "\ud83e\uddd1\ud83c\udffd\u200d\u2764\ufe0f\u200d\ud83e\uddd1\ud83c\udffe": "couple_with_heart_person_person_medium_skin_tone_medium-dark_skin_tone",
-  "\ud83e\uddd1\ud83c\udffd\u200d\u2764\ufe0f\u200d\ud83e\uddd1\ud83c\udfff": "couple_with_heart_person_person_medium_skin_tone_dark_skin_tone",
-  "\ud83e\uddd1\ud83c\udffd\u200d\ud83c\udf3e": "farmer_medium_skin_tone",
-  "\ud83e\uddd1\ud83c\udffd\u200d\ud83c\udf73": "cook_medium_skin_tone",
-  "\ud83e\uddd1\ud83c\udffd\u200d\ud83c\udf7c": "person_feeding_baby_medium_skin_tone",
-  "\ud83e\uddd1\ud83c\udffd\u200d\ud83c\udf84": "mx_claus_medium_skin_tone",
-  "\ud83e\uddd1\ud83c\udffd\u200d\ud83c\udf93": "student_medium_skin_tone",
-  "\ud83e\uddd1\ud83c\udffd\u200d\ud83c\udfa4": "singer_medium_skin_tone",
-  "\ud83e\uddd1\ud83c\udffd\u200d\ud83c\udfa8": "artist_medium_skin_tone",
-  "\ud83e\uddd1\ud83c\udffd\u200d\ud83c\udfeb": "teacher_medium_skin_tone",
-  "\ud83e\uddd1\ud83c\udffd\u200d\ud83c\udfed": "factory_worker_medium_skin_tone",
-  "\ud83e\uddd1\ud83c\udffd\u200d\ud83d\udcbb": "technologist_medium_skin_tone",
-  "\ud83e\uddd1\ud83c\udffd\u200d\ud83d\udcbc": "office_worker_medium_skin_tone",
-  "\ud83e\uddd1\ud83c\udffd\u200d\ud83d\udd27": "mechanic_medium_skin_tone",
-  "\ud83e\uddd1\ud83c\udffd\u200d\ud83d\udd2c": "scientist_medium_skin_tone",
-  "\ud83e\uddd1\ud83c\udffd\u200d\ud83d\ude80": "astronaut_medium_skin_tone",
-  "\ud83e\uddd1\ud83c\udffd\u200d\ud83d\ude92": "firefighter_medium_skin_tone",
-  "\ud83e\uddd1\ud83c\udffd\u200d\ud83e\udd1d\u200d\ud83e\uddd1\ud83c\udffb": "people_holding_hands_medium_skin_tone_light_skin_tone",
-  "\ud83e\uddd1\ud83c\udffd\u200d\ud83e\udd1d\u200d\ud83e\uddd1\ud83c\udffc": "people_holding_hands_medium_skin_tone_medium-light_skin_tone",
-  "\ud83e\uddd1\ud83c\udffd\u200d\ud83e\udd1d\u200d\ud83e\uddd1\ud83c\udffd": "people_holding_hands_medium_skin_tone",
-  "\ud83e\uddd1\ud83c\udffd\u200d\ud83e\udd1d\u200d\ud83e\uddd1\ud83c\udffe": "people_holding_hands_medium_skin_tone_medium-dark_skin_tone",
-  "\ud83e\uddd1\ud83c\udffd\u200d\ud83e\udd1d\u200d\ud83e\uddd1\ud83c\udfff": "people_holding_hands_medium_skin_tone_dark_skin_tone",
-  "\ud83e\uddd1\ud83c\udffd\u200d\ud83e\uddaf": "person_with_white_cane_medium_skin_tone",
-  "\ud83e\uddd1\ud83c\udffd\u200d\ud83e\uddaf\u200d\u27a1": "person_with_white_cane_facing_right_medium_skin_tone",
-  "\ud83e\uddd1\ud83c\udffd\u200d\ud83e\uddaf\u200d\u27a1\ufe0f": "person_with_white_cane_facing_right_medium_skin_tone",
-  "\ud83e\uddd1\ud83c\udffd\u200d\ud83e\uddb0": "person_medium_skin_tone_red_hair",
-  "\ud83e\uddd1\ud83c\udffd\u200d\ud83e\uddb1": "person_medium_skin_tone_curly_hair",
-  "\ud83e\uddd1\ud83c\udffd\u200d\ud83e\uddb2": "person_medium_skin_tone_bald",
-  "\ud83e\uddd1\ud83c\udffd\u200d\ud83e\uddb3": "person_medium_skin_tone_white_hair",
-  "\ud83e\uddd1\ud83c\udffd\u200d\ud83e\uddbc": "person_in_motorized_wheelchair_medium_skin_tone",
-  "\ud83e\uddd1\ud83c\udffd\u200d\ud83e\uddbc\u200d\u27a1": "person_in_motorized_wheelchair_facing_right_medium_skin_tone",
-  "\ud83e\uddd1\ud83c\udffd\u200d\ud83e\uddbc\u200d\u27a1\ufe0f": "person_in_motorized_wheelchair_facing_right_medium_skin_tone",
-  "\ud83e\uddd1\ud83c\udffd\u200d\ud83e\uddbd": "person_in_manual_wheelchair_medium_skin_tone",
-  "\ud83e\uddd1\ud83c\udffd\u200d\ud83e\uddbd\u200d\u27a1": "person_in_manual_wheelchair_facing_right_medium_skin_tone",
-  "\ud83e\uddd1\ud83c\udffd\u200d\ud83e\uddbd\u200d\u27a1\ufe0f": "person_in_manual_wheelchair_facing_right_medium_skin_tone",
-  "\ud83e\uddd1\ud83c\udffe": "person_medium-dark_skin_tone",
-  "\ud83e\uddd1\ud83c\udffe\u200d\u2695": "health_worker_medium-dark_skin_tone",
-  "\ud83e\uddd1\ud83c\udffe\u200d\u2695\ufe0f": "health_worker_medium-dark_skin_tone",
-  "\ud83e\uddd1\ud83c\udffe\u200d\u2696": "judge_medium-dark_skin_tone",
-  "\ud83e\uddd1\ud83c\udffe\u200d\u2696\ufe0f": "judge_medium-dark_skin_tone",
-  "\ud83e\uddd1\ud83c\udffe\u200d\u2708": "pilot_medium-dark_skin_tone",
-  "\ud83e\uddd1\ud83c\udffe\u200d\u2708\ufe0f": "pilot_medium-dark_skin_tone",
-  "\ud83e\uddd1\ud83c\udffe\u200d\u2764\u200d\ud83d\udc8b\u200d\ud83e\uddd1\ud83c\udffb": "kiss_person_person_medium-dark_skin_tone_light_skin_tone",
-  "\ud83e\uddd1\ud83c\udffe\u200d\u2764\u200d\ud83d\udc8b\u200d\ud83e\uddd1\ud83c\udffc": "kiss_person_person_medium-dark_skin_tone_medium-light_skin_tone",
-  "\ud83e\uddd1\ud83c\udffe\u200d\u2764\u200d\ud83d\udc8b\u200d\ud83e\uddd1\ud83c\udffd": "kiss_person_person_medium-dark_skin_tone_medium_skin_tone",
-  "\ud83e\uddd1\ud83c\udffe\u200d\u2764\u200d\ud83d\udc8b\u200d\ud83e\uddd1\ud83c\udfff": "kiss_person_person_medium-dark_skin_tone_dark_skin_tone",
-  "\ud83e\uddd1\ud83c\udffe\u200d\u2764\u200d\ud83e\uddd1\ud83c\udffb": "couple_with_heart_person_person_medium-dark_skin_tone_light_skin_tone",
-  "\ud83e\uddd1\ud83c\udffe\u200d\u2764\u200d\ud83e\uddd1\ud83c\udffc": "couple_with_heart_person_person_medium-dark_skin_tone_medium-light_skin_tone",
-  "\ud83e\uddd1\ud83c\udffe\u200d\u2764\u200d\ud83e\uddd1\ud83c\udffd": "couple_with_heart_person_person_medium-dark_skin_tone_medium_skin_tone",
-  "\ud83e\uddd1\ud83c\udffe\u200d\u2764\u200d\ud83e\uddd1\ud83c\udfff": "couple_with_heart_person_person_medium-dark_skin_tone_dark_skin_tone",
-  "\ud83e\uddd1\ud83c\udffe\u200d\u2764\ufe0f\u200d\ud83d\udc8b\u200d\ud83e\uddd1\ud83c\udffb": "kiss_person_person_medium-dark_skin_tone_light_skin_tone",
-  "\ud83e\uddd1\ud83c\udffe\u200d\u2764\ufe0f\u200d\ud83d\udc8b\u200d\ud83e\uddd1\ud83c\udffc": "kiss_person_person_medium-dark_skin_tone_medium-light_skin_tone",
-  "\ud83e\uddd1\ud83c\udffe\u200d\u2764\ufe0f\u200d\ud83d\udc8b\u200d\ud83e\uddd1\ud83c\udffd": "kiss_person_person_medium-dark_skin_tone_medium_skin_tone",
-  "\ud83e\uddd1\ud83c\udffe\u200d\u2764\ufe0f\u200d\ud83d\udc8b\u200d\ud83e\uddd1\ud83c\udfff": "kiss_person_person_medium-dark_skin_tone_dark_skin_tone",
-  "\ud83e\uddd1\ud83c\udffe\u200d\u2764\ufe0f\u200d\ud83e\uddd1\ud83c\udffb": "couple_with_heart_person_person_medium-dark_skin_tone_light_skin_tone",
-  "\ud83e\uddd1\ud83c\udffe\u200d\u2764\ufe0f\u200d\ud83e\uddd1\ud83c\udffc": "couple_with_heart_person_person_medium-dark_skin_tone_medium-light_skin_tone",
-  "\ud83e\uddd1\ud83c\udffe\u200d\u2764\ufe0f\u200d\ud83e\uddd1\ud83c\udffd": "couple_with_heart_person_person_medium-dark_skin_tone_medium_skin_tone",
-  "\ud83e\uddd1\ud83c\udffe\u200d\u2764\ufe0f\u200d\ud83e\uddd1\ud83c\udfff": "couple_with_heart_person_person_medium-dark_skin_tone_dark_skin_tone",
-  "\ud83e\uddd1\ud83c\udffe\u200d\ud83c\udf3e": "farmer_medium-dark_skin_tone",
-  "\ud83e\uddd1\ud83c\udffe\u200d\ud83c\udf73": "cook_medium-dark_skin_tone",
-  "\ud83e\uddd1\ud83c\udffe\u200d\ud83c\udf7c": "person_feeding_baby_medium-dark_skin_tone",
-  "\ud83e\uddd1\ud83c\udffe\u200d\ud83c\udf84": "mx_claus_medium-dark_skin_tone",
-  "\ud83e\uddd1\ud83c\udffe\u200d\ud83c\udf93": "student_medium-dark_skin_tone",
-  "\ud83e\uddd1\ud83c\udffe\u200d\ud83c\udfa4": "singer_medium-dark_skin_tone",
-  "\ud83e\uddd1\ud83c\udffe\u200d\ud83c\udfa8": "artist_medium-dark_skin_tone",
-  "\ud83e\uddd1\ud83c\udffe\u200d\ud83c\udfeb": "teacher_medium-dark_skin_tone",
-  "\ud83e\uddd1\ud83c\udffe\u200d\ud83c\udfed": "factory_worker_medium-dark_skin_tone",
-  "\ud83e\uddd1\ud83c\udffe\u200d\ud83d\udcbb": "technologist_medium-dark_skin_tone",
-  "\ud83e\uddd1\ud83c\udffe\u200d\ud83d\udcbc": "office_worker_medium-dark_skin_tone",
-  "\ud83e\uddd1\ud83c\udffe\u200d\ud83d\udd27": "mechanic_medium-dark_skin_tone",
-  "\ud83e\uddd1\ud83c\udffe\u200d\ud83d\udd2c": "scientist_medium-dark_skin_tone",
-  "\ud83e\uddd1\ud83c\udffe\u200d\ud83d\ude80": "astronaut_medium-dark_skin_tone",
-  "\ud83e\uddd1\ud83c\udffe\u200d\ud83d\ude92": "firefighter_medium-dark_skin_tone",
-  "\ud83e\uddd1\ud83c\udffe\u200d\ud83e\udd1d\u200d\ud83e\uddd1\ud83c\udffb": "people_holding_hands_medium-dark_skin_tone_light_skin_tone",
-  "\ud83e\uddd1\ud83c\udffe\u200d\ud83e\udd1d\u200d\ud83e\uddd1\ud83c\udffc": "people_holding_hands_medium-dark_skin_tone_medium-light_skin_tone",
-  "\ud83e\uddd1\ud83c\udffe\u200d\ud83e\udd1d\u200d\ud83e\uddd1\ud83c\udffd": "people_holding_hands_medium-dark_skin_tone_medium_skin_tone",
-  "\ud83e\uddd1\ud83c\udffe\u200d\ud83e\udd1d\u200d\ud83e\uddd1\ud83c\udffe": "people_holding_hands_medium-dark_skin_tone",
-  "\ud83e\uddd1\ud83c\udffe\u200d\ud83e\udd1d\u200d\ud83e\uddd1\ud83c\udfff": "people_holding_hands_medium-dark_skin_tone_dark_skin_tone",
-  "\ud83e\uddd1\ud83c\udffe\u200d\ud83e\uddaf": "person_with_white_cane_medium-dark_skin_tone",
-  "\ud83e\uddd1\ud83c\udffe\u200d\ud83e\uddaf\u200d\u27a1": "person_with_white_cane_facing_right_medium-dark_skin_tone",
-  "\ud83e\uddd1\ud83c\udffe\u200d\ud83e\uddaf\u200d\u27a1\ufe0f": "person_with_white_cane_facing_right_medium-dark_skin_tone",
-  "\ud83e\uddd1\ud83c\udffe\u200d\ud83e\uddb0": "person_medium-dark_skin_tone_red_hair",
-  "\ud83e\uddd1\ud83c\udffe\u200d\ud83e\uddb1": "person_medium-dark_skin_tone_curly_hair",
-  "\ud83e\uddd1\ud83c\udffe\u200d\ud83e\uddb2": "person_medium-dark_skin_tone_bald",
-  "\ud83e\uddd1\ud83c\udffe\u200d\ud83e\uddb3": "person_medium-dark_skin_tone_white_hair",
-  "\ud83e\uddd1\ud83c\udffe\u200d\ud83e\uddbc": "person_in_motorized_wheelchair_medium-dark_skin_tone",
-  "\ud83e\uddd1\ud83c\udffe\u200d\ud83e\uddbc\u200d\u27a1": "person_in_motorized_wheelchair_facing_right_medium-dark_skin_tone",
-  "\ud83e\uddd1\ud83c\udffe\u200d\ud83e\uddbc\u200d\u27a1\ufe0f": "person_in_motorized_wheelchair_facing_right_medium-dark_skin_tone",
-  "\ud83e\uddd1\ud83c\udffe\u200d\ud83e\uddbd": "person_in_manual_wheelchair_medium-dark_skin_tone",
-  "\ud83e\uddd1\ud83c\udffe\u200d\ud83e\uddbd\u200d\u27a1": "person_in_manual_wheelchair_facing_right_medium-dark_skin_tone",
-  "\ud83e\uddd1\ud83c\udffe\u200d\ud83e\uddbd\u200d\u27a1\ufe0f": "person_in_manual_wheelchair_facing_right_medium-dark_skin_tone",
-  "\ud83e\uddd1\ud83c\udfff": "person_dark_skin_tone",
-  "\ud83e\uddd1\ud83c\udfff\u200d\u2695": "health_worker_dark_skin_tone",
-  "\ud83e\uddd1\ud83c\udfff\u200d\u2695\ufe0f": "health_worker_dark_skin_tone",
-  "\ud83e\uddd1\ud83c\udfff\u200d\u2696": "judge_dark_skin_tone",
-  "\ud83e\uddd1\ud83c\udfff\u200d\u2696\ufe0f": "judge_dark_skin_tone",
-  "\ud83e\uddd1\ud83c\udfff\u200d\u2708": "pilot_dark_skin_tone",
-  "\ud83e\uddd1\ud83c\udfff\u200d\u2708\ufe0f": "pilot_dark_skin_tone",
-  "\ud83e\uddd1\ud83c\udfff\u200d\u2764\u200d\ud83d\udc8b\u200d\ud83e\uddd1\ud83c\udffb": "kiss_person_person_dark_skin_tone_light_skin_tone",
-  "\ud83e\uddd1\ud83c\udfff\u200d\u2764\u200d\ud83d\udc8b\u200d\ud83e\uddd1\ud83c\udffc": "kiss_person_person_dark_skin_tone_medium-light_skin_tone",
-  "\ud83e\uddd1\ud83c\udfff\u200d\u2764\u200d\ud83d\udc8b\u200d\ud83e\uddd1\ud83c\udffd": "kiss_person_person_dark_skin_tone_medium_skin_tone",
-  "\ud83e\uddd1\ud83c\udfff\u200d\u2764\u200d\ud83d\udc8b\u200d\ud83e\uddd1\ud83c\udffe": "kiss_person_person_dark_skin_tone_medium-dark_skin_tone",
-  "\ud83e\uddd1\ud83c\udfff\u200d\u2764\u200d\ud83e\uddd1\ud83c\udffb": "couple_with_heart_person_person_dark_skin_tone_light_skin_tone",
-  "\ud83e\uddd1\ud83c\udfff\u200d\u2764\u200d\ud83e\uddd1\ud83c\udffc": "couple_with_heart_person_person_dark_skin_tone_medium-light_skin_tone",
-  "\ud83e\uddd1\ud83c\udfff\u200d\u2764\u200d\ud83e\uddd1\ud83c\udffd": "couple_with_heart_person_person_dark_skin_tone_medium_skin_tone",
-  "\ud83e\uddd1\ud83c\udfff\u200d\u2764\u200d\ud83e\uddd1\ud83c\udffe": "couple_with_heart_person_person_dark_skin_tone_medium-dark_skin_tone",
-  "\ud83e\uddd1\ud83c\udfff\u200d\u2764\ufe0f\u200d\ud83d\udc8b\u200d\ud83e\uddd1\ud83c\udffb": "kiss_person_person_dark_skin_tone_light_skin_tone",
-  "\ud83e\uddd1\ud83c\udfff\u200d\u2764\ufe0f\u200d\ud83d\udc8b\u200d\ud83e\uddd1\ud83c\udffc": "kiss_person_person_dark_skin_tone_medium-light_skin_tone",
-  "\ud83e\uddd1\ud83c\udfff\u200d\u2764\ufe0f\u200d\ud83d\udc8b\u200d\ud83e\uddd1\ud83c\udffd": "kiss_person_person_dark_skin_tone_medium_skin_tone",
-  "\ud83e\uddd1\ud83c\udfff\u200d\u2764\ufe0f\u200d\ud83d\udc8b\u200d\ud83e\uddd1\ud83c\udffe": "kiss_person_person_dark_skin_tone_medium-dark_skin_tone",
-  "\ud83e\uddd1\ud83c\udfff\u200d\u2764\ufe0f\u200d\ud83e\uddd1\ud83c\udffb": "couple_with_heart_person_person_dark_skin_tone_light_skin_tone",
-  "\ud83e\uddd1\ud83c\udfff\u200d\u2764\ufe0f\u200d\ud83e\uddd1\ud83c\udffc": "couple_with_heart_person_person_dark_skin_tone_medium-light_skin_tone",
-  "\ud83e\uddd1\ud83c\udfff\u200d\u2764\ufe0f\u200d\ud83e\uddd1\ud83c\udffd": "couple_with_heart_person_person_dark_skin_tone_medium_skin_tone",
-  "\ud83e\uddd1\ud83c\udfff\u200d\u2764\ufe0f\u200d\ud83e\uddd1\ud83c\udffe": "couple_with_heart_person_person_dark_skin_tone_medium-dark_skin_tone",
-  "\ud83e\uddd1\ud83c\udfff\u200d\ud83c\udf3e": "farmer_dark_skin_tone",
-  "\ud83e\uddd1\ud83c\udfff\u200d\ud83c\udf73": "cook_dark_skin_tone",
-  "\ud83e\uddd1\ud83c\udfff\u200d\ud83c\udf7c": "person_feeding_baby_dark_skin_tone",
-  "\ud83e\uddd1\ud83c\udfff\u200d\ud83c\udf84": "mx_claus_dark_skin_tone",
-  "\ud83e\uddd1\ud83c\udfff\u200d\ud83c\udf93": "student_dark_skin_tone",
-  "\ud83e\uddd1\ud83c\udfff\u200d\ud83c\udfa4": "singer_dark_skin_tone",
-  "\ud83e\uddd1\ud83c\udfff\u200d\ud83c\udfa8": "artist_dark_skin_tone",
-  "\ud83e\uddd1\ud83c\udfff\u200d\ud83c\udfeb": "teacher_dark_skin_tone",
-  "\ud83e\uddd1\ud83c\udfff\u200d\ud83c\udfed": "factory_worker_dark_skin_tone",
-  "\ud83e\uddd1\ud83c\udfff\u200d\ud83d\udcbb": "technologist_dark_skin_tone",
-  "\ud83e\uddd1\ud83c\udfff\u200d\ud83d\udcbc": "office_worker_dark_skin_tone",
-  "\ud83e\uddd1\ud83c\udfff\u200d\ud83d\udd27": "mechanic_dark_skin_tone",
-  "\ud83e\uddd1\ud83c\udfff\u200d\ud83d\udd2c": "scientist_dark_skin_tone",
-  "\ud83e\uddd1\ud83c\udfff\u200d\ud83d\ude80": "astronaut_dark_skin_tone",
-  "\ud83e\uddd1\ud83c\udfff\u200d\ud83d\ude92": "firefighter_dark_skin_tone",
-  "\ud83e\uddd1\ud83c\udfff\u200d\ud83e\udd1d\u200d\ud83e\uddd1\ud83c\udffb": "people_holding_hands_dark_skin_tone_light_skin_tone",
-  "\ud83e\uddd1\ud83c\udfff\u200d\ud83e\udd1d\u200d\ud83e\uddd1\ud83c\udffc": "people_holding_hands_dark_skin_tone_medium-light_skin_tone",
-  "\ud83e\uddd1\ud83c\udfff\u200d\ud83e\udd1d\u200d\ud83e\uddd1\ud83c\udffd": "people_holding_hands_dark_skin_tone_medium_skin_tone",
-  "\ud83e\uddd1\ud83c\udfff\u200d\ud83e\udd1d\u200d\ud83e\uddd1\ud83c\udffe": "people_holding_hands_dark_skin_tone_medium-dark_skin_tone",
-  "\ud83e\uddd1\ud83c\udfff\u200d\ud83e\udd1d\u200d\ud83e\uddd1\ud83c\udfff": "people_holding_hands_dark_skin_tone",
-  "\ud83e\uddd1\ud83c\udfff\u200d\ud83e\uddaf": "person_with_white_cane_dark_skin_tone",
-  "\ud83e\uddd1\ud83c\udfff\u200d\ud83e\uddaf\u200d\u27a1": "person_with_white_cane_facing_right_dark_skin_tone",
-  "\ud83e\uddd1\ud83c\udfff\u200d\ud83e\uddaf\u200d\u27a1\ufe0f": "person_with_white_cane_facing_right_dark_skin_tone",
-  "\ud83e\uddd1\ud83c\udfff\u200d\ud83e\uddb0": "person_dark_skin_tone_red_hair",
-  "\ud83e\uddd1\ud83c\udfff\u200d\ud83e\uddb1": "person_dark_skin_tone_curly_hair",
-  "\ud83e\uddd1\ud83c\udfff\u200d\ud83e\uddb2": "person_dark_skin_tone_bald",
-  "\ud83e\uddd1\ud83c\udfff\u200d\ud83e\uddb3": "person_dark_skin_tone_white_hair",
-  "\ud83e\uddd1\ud83c\udfff\u200d\ud83e\uddbc": "person_in_motorized_wheelchair_dark_skin_tone",
-  "\ud83e\uddd1\ud83c\udfff\u200d\ud83e\uddbc\u200d\u27a1": "person_in_motorized_wheelchair_facing_right_dark_skin_tone",
-  "\ud83e\uddd1\ud83c\udfff\u200d\ud83e\uddbc\u200d\u27a1\ufe0f": "person_in_motorized_wheelchair_facing_right_dark_skin_tone",
-  "\ud83e\uddd1\ud83c\udfff\u200d\ud83e\uddbd": "person_in_manual_wheelchair_dark_skin_tone",
-  "\ud83e\uddd1\ud83c\udfff\u200d\ud83e\uddbd\u200d\u27a1": "person_in_manual_wheelchair_facing_right_dark_skin_tone",
-  "\ud83e\uddd1\ud83c\udfff\u200d\ud83e\uddbd\u200d\u27a1\ufe0f": "person_in_manual_wheelchair_facing_right_dark_skin_tone",
-  "\ud83e\uddd2": "child",
-  "\ud83e\uddd2\ud83c\udffb": "child_light_skin_tone",
-  "\ud83e\uddd2\ud83c\udffc": "child_medium-light_skin_tone",
-  "\ud83e\uddd2\ud83c\udffd": "child_medium_skin_tone",
-  "\ud83e\uddd2\ud83c\udffe": "child_medium-dark_skin_tone",
-  "\ud83e\uddd2\ud83c\udfff": "child_dark_skin_tone",
-  "\ud83e\uddd3": "older_person",
-  "\ud83e\uddd3\ud83c\udffb": "older_person_light_skin_tone",
-  "\ud83e\uddd3\ud83c\udffc": "older_person_medium-light_skin_tone",
-  "\ud83e\uddd3\ud83c\udffd": "older_person_medium_skin_tone",
-  "\ud83e\uddd3\ud83c\udffe": "older_person_medium-dark_skin_tone",
-  "\ud83e\uddd3\ud83c\udfff": "older_person_dark_skin_tone",
-  "\ud83e\uddd4": "person_beard",
-  "\ud83e\uddd4\u200d\u2640": "woman_beard",
-  "\ud83e\uddd4\u200d\u2640\ufe0f": "woman_beard",
-  "\ud83e\uddd4\u200d\u2642": "man_beard",
-  "\ud83e\uddd4\u200d\u2642\ufe0f": "man_beard",
-  "\ud83e\uddd4\ud83c\udffb": "person_light_skin_tone_beard",
-  "\ud83e\uddd4\ud83c\udffb\u200d\u2640": "woman_light_skin_tone_beard",
-  "\ud83e\uddd4\ud83c\udffb\u200d\u2640\ufe0f": "woman_light_skin_tone_beard",
-  "\ud83e\uddd4\ud83c\udffb\u200d\u2642": "man_light_skin_tone_beard",
-  "\ud83e\uddd4\ud83c\udffb\u200d\u2642\ufe0f": "man_light_skin_tone_beard",
-  "\ud83e\uddd4\ud83c\udffc": "person_medium-light_skin_tone_beard",
-  "\ud83e\uddd4\ud83c\udffc\u200d\u2640": "woman_medium-light_skin_tone_beard",
-  "\ud83e\uddd4\ud83c\udffc\u200d\u2640\ufe0f": "woman_medium-light_skin_tone_beard",
-  "\ud83e\uddd4\ud83c\udffc\u200d\u2642": "man_medium-light_skin_tone_beard",
-  "\ud83e\uddd4\ud83c\udffc\u200d\u2642\ufe0f": "man_medium-light_skin_tone_beard",
-  "\ud83e\uddd4\ud83c\udffd": "person_medium_skin_tone_beard",
-  "\ud83e\uddd4\ud83c\udffd\u200d\u2640": "woman_medium_skin_tone_beard",
-  "\ud83e\uddd4\ud83c\udffd\u200d\u2640\ufe0f": "woman_medium_skin_tone_beard",
-  "\ud83e\uddd4\ud83c\udffd\u200d\u2642": "man_medium_skin_tone_beard",
-  "\ud83e\uddd4\ud83c\udffd\u200d\u2642\ufe0f": "man_medium_skin_tone_beard",
-  "\ud83e\uddd4\ud83c\udffe": "person_medium-dark_skin_tone_beard",
-  "\ud83e\uddd4\ud83c\udffe\u200d\u2640": "woman_medium-dark_skin_tone_beard",
-  "\ud83e\uddd4\ud83c\udffe\u200d\u2640\ufe0f": "woman_medium-dark_skin_tone_beard",
-  "\ud83e\uddd4\ud83c\udffe\u200d\u2642": "man_medium-dark_skin_tone_beard",
-  "\ud83e\uddd4\ud83c\udffe\u200d\u2642\ufe0f": "man_medium-dark_skin_tone_beard",
-  "\ud83e\uddd4\ud83c\udfff": "person_dark_skin_tone_beard",
-  "\ud83e\uddd4\ud83c\udfff\u200d\u2640": "woman_dark_skin_tone_beard",
-  "\ud83e\uddd4\ud83c\udfff\u200d\u2640\ufe0f": "woman_dark_skin_tone_beard",
-  "\ud83e\uddd4\ud83c\udfff\u200d\u2642": "man_dark_skin_tone_beard",
-  "\ud83e\uddd4\ud83c\udfff\u200d\u2642\ufe0f": "man_dark_skin_tone_beard",
-  "\ud83e\uddd5": "woman_with_headscarf",
-  "\ud83e\uddd5\ud83c\udffb": "woman_with_headscarf_light_skin_tone",
-  "\ud83e\uddd5\ud83c\udffc": "woman_with_headscarf_medium-light_skin_tone",
-  "\ud83e\uddd5\ud83c\udffd": "woman_with_headscarf_medium_skin_tone",
-  "\ud83e\uddd5\ud83c\udffe": "woman_with_headscarf_medium-dark_skin_tone",
-  "\ud83e\uddd5\ud83c\udfff": "woman_with_headscarf_dark_skin_tone",
-  "\ud83e\uddd6": "person_in_steamy_room",
-  "\ud83e\uddd6\u200d\u2640": "woman_in_steamy_room",
-  "\ud83e\uddd6\u200d\u2640\ufe0f": "woman_in_steamy_room",
-  "\ud83e\uddd6\u200d\u2642": "man_in_steamy_room",
-  "\ud83e\uddd6\u200d\u2642\ufe0f": "man_in_steamy_room",
-  "\ud83e\uddd6\ud83c\udffb": "person_in_steamy_room_light_skin_tone",
-  "\ud83e\uddd6\ud83c\udffb\u200d\u2640": "woman_in_steamy_room_light_skin_tone",
-  "\ud83e\uddd6\ud83c\udffb\u200d\u2640\ufe0f": "woman_in_steamy_room_light_skin_tone",
-  "\ud83e\uddd6\ud83c\udffb\u200d\u2642": "man_in_steamy_room_light_skin_tone",
-  "\ud83e\uddd6\ud83c\udffb\u200d\u2642\ufe0f": "man_in_steamy_room_light_skin_tone",
-  "\ud83e\uddd6\ud83c\udffc": "person_in_steamy_room_medium-light_skin_tone",
-  "\ud83e\uddd6\ud83c\udffc\u200d\u2640": "woman_in_steamy_room_medium-light_skin_tone",
-  "\ud83e\uddd6\ud83c\udffc\u200d\u2640\ufe0f": "woman_in_steamy_room_medium-light_skin_tone",
-  "\ud83e\uddd6\ud83c\udffc\u200d\u2642": "man_in_steamy_room_medium-light_skin_tone",
-  "\ud83e\uddd6\ud83c\udffc\u200d\u2642\ufe0f": "man_in_steamy_room_medium-light_skin_tone",
-  "\ud83e\uddd6\ud83c\udffd": "person_in_steamy_room_medium_skin_tone",
-  "\ud83e\uddd6\ud83c\udffd\u200d\u2640": "woman_in_steamy_room_medium_skin_tone",
-  "\ud83e\uddd6\ud83c\udffd\u200d\u2640\ufe0f": "woman_in_steamy_room_medium_skin_tone",
-  "\ud83e\uddd6\ud83c\udffd\u200d\u2642": "man_in_steamy_room_medium_skin_tone",
-  "\ud83e\uddd6\ud83c\udffd\u200d\u2642\ufe0f": "man_in_steamy_room_medium_skin_tone",
-  "\ud83e\uddd6\ud83c\udffe": "person_in_steamy_room_medium-dark_skin_tone",
-  "\ud83e\uddd6\ud83c\udffe\u200d\u2640": "woman_in_steamy_room_medium-dark_skin_tone",
-  "\ud83e\uddd6\ud83c\udffe\u200d\u2640\ufe0f": "woman_in_steamy_room_medium-dark_skin_tone",
-  "\ud83e\uddd6\ud83c\udffe\u200d\u2642": "man_in_steamy_room_medium-dark_skin_tone",
-  "\ud83e\uddd6\ud83c\udffe\u200d\u2642\ufe0f": "man_in_steamy_room_medium-dark_skin_tone",
-  "\ud83e\uddd6\ud83c\udfff": "person_in_steamy_room_dark_skin_tone",
-  "\ud83e\uddd6\ud83c\udfff\u200d\u2640": "woman_in_steamy_room_dark_skin_tone",
-  "\ud83e\uddd6\ud83c\udfff\u200d\u2640\ufe0f": "woman_in_steamy_room_dark_skin_tone",
-  "\ud83e\uddd6\ud83c\udfff\u200d\u2642": "man_in_steamy_room_dark_skin_tone",
-  "\ud83e\uddd6\ud83c\udfff\u200d\u2642\ufe0f": "man_in_steamy_room_dark_skin_tone",
-  "\ud83e\uddd7": "person_climbing",
-  "\ud83e\uddd7\u200d\u2640": "woman_climbing",
-  "\ud83e\uddd7\u200d\u2640\ufe0f": "woman_climbing",
-  "\ud83e\uddd7\u200d\u2642": "man_climbing",
-  "\ud83e\uddd7\u200d\u2642\ufe0f": "man_climbing",
-  "\ud83e\uddd7\ud83c\udffb": "person_climbing_light_skin_tone",
-  "\ud83e\uddd7\ud83c\udffb\u200d\u2640": "woman_climbing_light_skin_tone",
-  "\ud83e\uddd7\ud83c\udffb\u200d\u2640\ufe0f": "woman_climbing_light_skin_tone",
-  "\ud83e\uddd7\ud83c\udffb\u200d\u2642": "man_climbing_light_skin_tone",
-  "\ud83e\uddd7\ud83c\udffb\u200d\u2642\ufe0f": "man_climbing_light_skin_tone",
-  "\ud83e\uddd7\ud83c\udffc": "person_climbing_medium-light_skin_tone",
-  "\ud83e\uddd7\ud83c\udffc\u200d\u2640": "woman_climbing_medium-light_skin_tone",
-  "\ud83e\uddd7\ud83c\udffc\u200d\u2640\ufe0f": "woman_climbing_medium-light_skin_tone",
-  "\ud83e\uddd7\ud83c\udffc\u200d\u2642": "man_climbing_medium-light_skin_tone",
-  "\ud83e\uddd7\ud83c\udffc\u200d\u2642\ufe0f": "man_climbing_medium-light_skin_tone",
-  "\ud83e\uddd7\ud83c\udffd": "person_climbing_medium_skin_tone",
-  "\ud83e\uddd7\ud83c\udffd\u200d\u2640": "woman_climbing_medium_skin_tone",
-  "\ud83e\uddd7\ud83c\udffd\u200d\u2640\ufe0f": "woman_climbing_medium_skin_tone",
-  "\ud83e\uddd7\ud83c\udffd\u200d\u2642": "man_climbing_medium_skin_tone",
-  "\ud83e\uddd7\ud83c\udffd\u200d\u2642\ufe0f": "man_climbing_medium_skin_tone",
-  "\ud83e\uddd7\ud83c\udffe": "person_climbing_medium-dark_skin_tone",
-  "\ud83e\uddd7\ud83c\udffe\u200d\u2640": "woman_climbing_medium-dark_skin_tone",
-  "\ud83e\uddd7\ud83c\udffe\u200d\u2640\ufe0f": "woman_climbing_medium-dark_skin_tone",
-  "\ud83e\uddd7\ud83c\udffe\u200d\u2642": "man_climbing_medium-dark_skin_tone",
-  "\ud83e\uddd7\ud83c\udffe\u200d\u2642\ufe0f": "man_climbing_medium-dark_skin_tone",
-  "\ud83e\uddd7\ud83c\udfff": "person_climbing_dark_skin_tone",
-  "\ud83e\uddd7\ud83c\udfff\u200d\u2640": "woman_climbing_dark_skin_tone",
-  "\ud83e\uddd7\ud83c\udfff\u200d\u2640\ufe0f": "woman_climbing_dark_skin_tone",
-  "\ud83e\uddd7\ud83c\udfff\u200d\u2642": "man_climbing_dark_skin_tone",
-  "\ud83e\uddd7\ud83c\udfff\u200d\u2642\ufe0f": "man_climbing_dark_skin_tone",
-  "\ud83e\uddd8": "person_in_lotus_position",
-  "\ud83e\uddd8\u200d\u2640": "woman_in_lotus_position",
-  "\ud83e\uddd8\u200d\u2640\ufe0f": "woman_in_lotus_position",
-  "\ud83e\uddd8\u200d\u2642": "man_in_lotus_position",
-  "\ud83e\uddd8\u200d\u2642\ufe0f": "man_in_lotus_position",
-  "\ud83e\uddd8\ud83c\udffb": "person_in_lotus_position_light_skin_tone",
-  "\ud83e\uddd8\ud83c\udffb\u200d\u2640": "woman_in_lotus_position_light_skin_tone",
-  "\ud83e\uddd8\ud83c\udffb\u200d\u2640\ufe0f": "woman_in_lotus_position_light_skin_tone",
-  "\ud83e\uddd8\ud83c\udffb\u200d\u2642": "man_in_lotus_position_light_skin_tone",
-  "\ud83e\uddd8\ud83c\udffb\u200d\u2642\ufe0f": "man_in_lotus_position_light_skin_tone",
-  "\ud83e\uddd8\ud83c\udffc": "person_in_lotus_position_medium-light_skin_tone",
-  "\ud83e\uddd8\ud83c\udffc\u200d\u2640": "woman_in_lotus_position_medium-light_skin_tone",
-  "\ud83e\uddd8\ud83c\udffc\u200d\u2640\ufe0f": "woman_in_lotus_position_medium-light_skin_tone",
-  "\ud83e\uddd8\ud83c\udffc\u200d\u2642": "man_in_lotus_position_medium-light_skin_tone",
-  "\ud83e\uddd8\ud83c\udffc\u200d\u2642\ufe0f": "man_in_lotus_position_medium-light_skin_tone",
-  "\ud83e\uddd8\ud83c\udffd": "person_in_lotus_position_medium_skin_tone",
-  "\ud83e\uddd8\ud83c\udffd\u200d\u2640": "woman_in_lotus_position_medium_skin_tone",
-  "\ud83e\uddd8\ud83c\udffd\u200d\u2640\ufe0f": "woman_in_lotus_position_medium_skin_tone",
-  "\ud83e\uddd8\ud83c\udffd\u200d\u2642": "man_in_lotus_position_medium_skin_tone",
-  "\ud83e\uddd8\ud83c\udffd\u200d\u2642\ufe0f": "man_in_lotus_position_medium_skin_tone",
-  "\ud83e\uddd8\ud83c\udffe": "person_in_lotus_position_medium-dark_skin_tone",
-  "\ud83e\uddd8\ud83c\udffe\u200d\u2640": "woman_in_lotus_position_medium-dark_skin_tone",
-  "\ud83e\uddd8\ud83c\udffe\u200d\u2640\ufe0f": "woman_in_lotus_position_medium-dark_skin_tone",
-  "\ud83e\uddd8\ud83c\udffe\u200d\u2642": "man_in_lotus_position_medium-dark_skin_tone",
-  "\ud83e\uddd8\ud83c\udffe\u200d\u2642\ufe0f": "man_in_lotus_position_medium-dark_skin_tone",
-  "\ud83e\uddd8\ud83c\udfff": "person_in_lotus_position_dark_skin_tone",
-  "\ud83e\uddd8\ud83c\udfff\u200d\u2640": "woman_in_lotus_position_dark_skin_tone",
-  "\ud83e\uddd8\ud83c\udfff\u200d\u2640\ufe0f": "woman_in_lotus_position_dark_skin_tone",
-  "\ud83e\uddd8\ud83c\udfff\u200d\u2642": "man_in_lotus_position_dark_skin_tone",
-  "\ud83e\uddd8\ud83c\udfff\u200d\u2642\ufe0f": "man_in_lotus_position_dark_skin_tone",
-  "\ud83e\uddd9": "mage",
-  "\ud83e\uddd9\u200d\u2640": "woman_mage",
-  "\ud83e\uddd9\u200d\u2640\ufe0f": "woman_mage",
-  "\ud83e\uddd9\u200d\u2642": "man_mage",
-  "\ud83e\uddd9\u200d\u2642\ufe0f": "man_mage",
-  "\ud83e\uddd9\ud83c\udffb": "mage_light_skin_tone",
-  "\ud83e\uddd9\ud83c\udffb\u200d\u2640": "woman_mage_light_skin_tone",
-  "\ud83e\uddd9\ud83c\udffb\u200d\u2640\ufe0f": "woman_mage_light_skin_tone",
-  "\ud83e\uddd9\ud83c\udffb\u200d\u2642": "man_mage_light_skin_tone",
-  "\ud83e\uddd9\ud83c\udffb\u200d\u2642\ufe0f": "man_mage_light_skin_tone",
-  "\ud83e\uddd9\ud83c\udffc": "mage_medium-light_skin_tone",
-  "\ud83e\uddd9\ud83c\udffc\u200d\u2640": "woman_mage_medium-light_skin_tone",
-  "\ud83e\uddd9\ud83c\udffc\u200d\u2640\ufe0f": "woman_mage_medium-light_skin_tone",
-  "\ud83e\uddd9\ud83c\udffc\u200d\u2642": "man_mage_medium-light_skin_tone",
-  "\ud83e\uddd9\ud83c\udffc\u200d\u2642\ufe0f": "man_mage_medium-light_skin_tone",
-  "\ud83e\uddd9\ud83c\udffd": "mage_medium_skin_tone",
-  "\ud83e\uddd9\ud83c\udffd\u200d\u2640": "woman_mage_medium_skin_tone",
-  "\ud83e\uddd9\ud83c\udffd\u200d\u2640\ufe0f": "woman_mage_medium_skin_tone",
-  "\ud83e\uddd9\ud83c\udffd\u200d\u2642": "man_mage_medium_skin_tone",
-  "\ud83e\uddd9\ud83c\udffd\u200d\u2642\ufe0f": "man_mage_medium_skin_tone",
-  "\ud83e\uddd9\ud83c\udffe": "mage_medium-dark_skin_tone",
-  "\ud83e\uddd9\ud83c\udffe\u200d\u2640": "woman_mage_medium-dark_skin_tone",
-  "\ud83e\uddd9\ud83c\udffe\u200d\u2640\ufe0f": "woman_mage_medium-dark_skin_tone",
-  "\ud83e\uddd9\ud83c\udffe\u200d\u2642": "man_mage_medium-dark_skin_tone",
-  "\ud83e\uddd9\ud83c\udffe\u200d\u2642\ufe0f": "man_mage_medium-dark_skin_tone",
-  "\ud83e\uddd9\ud83c\udfff": "mage_dark_skin_tone",
-  "\ud83e\uddd9\ud83c\udfff\u200d\u2640": "woman_mage_dark_skin_tone",
-  "\ud83e\uddd9\ud83c\udfff\u200d\u2640\ufe0f": "woman_mage_dark_skin_tone",
-  "\ud83e\uddd9\ud83c\udfff\u200d\u2642": "man_mage_dark_skin_tone",
-  "\ud83e\uddd9\ud83c\udfff\u200d\u2642\ufe0f": "man_mage_dark_skin_tone",
-  "\ud83e\uddda": "fairy",
-  "\ud83e\uddda\u200d\u2640": "woman_fairy",
-  "\ud83e\uddda\u200d\u2640\ufe0f": "woman_fairy",
-  "\ud83e\uddda\u200d\u2642": "man_fairy",
-  "\ud83e\uddda\u200d\u2642\ufe0f": "man_fairy",
-  "\ud83e\uddda\ud83c\udffb": "fairy_light_skin_tone",
-  "\ud83e\uddda\ud83c\udffb\u200d\u2640": "woman_fairy_light_skin_tone",
-  "\ud83e\uddda\ud83c\udffb\u200d\u2640\ufe0f": "woman_fairy_light_skin_tone",
-  "\ud83e\uddda\ud83c\udffb\u200d\u2642": "man_fairy_light_skin_tone",
-  "\ud83e\uddda\ud83c\udffb\u200d\u2642\ufe0f": "man_fairy_light_skin_tone",
-  "\ud83e\uddda\ud83c\udffc": "fairy_medium-light_skin_tone",
-  "\ud83e\uddda\ud83c\udffc\u200d\u2640": "woman_fairy_medium-light_skin_tone",
-  "\ud83e\uddda\ud83c\udffc\u200d\u2640\ufe0f": "woman_fairy_medium-light_skin_tone",
-  "\ud83e\uddda\ud83c\udffc\u200d\u2642": "man_fairy_medium-light_skin_tone",
-  "\ud83e\uddda\ud83c\udffc\u200d\u2642\ufe0f": "man_fairy_medium-light_skin_tone",
-  "\ud83e\uddda\ud83c\udffd": "fairy_medium_skin_tone",
-  "\ud83e\uddda\ud83c\udffd\u200d\u2640": "woman_fairy_medium_skin_tone",
-  "\ud83e\uddda\ud83c\udffd\u200d\u2640\ufe0f": "woman_fairy_medium_skin_tone",
-  "\ud83e\uddda\ud83c\udffd\u200d\u2642": "man_fairy_medium_skin_tone",
-  "\ud83e\uddda\ud83c\udffd\u200d\u2642\ufe0f": "man_fairy_medium_skin_tone",
-  "\ud83e\uddda\ud83c\udffe": "fairy_medium-dark_skin_tone",
-  "\ud83e\uddda\ud83c\udffe\u200d\u2640": "woman_fairy_medium-dark_skin_tone",
-  "\ud83e\uddda\ud83c\udffe\u200d\u2640\ufe0f": "woman_fairy_medium-dark_skin_tone",
-  "\ud83e\uddda\ud83c\udffe\u200d\u2642": "man_fairy_medium-dark_skin_tone",
-  "\ud83e\uddda\ud83c\udffe\u200d\u2642\ufe0f": "man_fairy_medium-dark_skin_tone",
-  "\ud83e\uddda\ud83c\udfff": "fairy_dark_skin_tone",
-  "\ud83e\uddda\ud83c\udfff\u200d\u2640": "woman_fairy_dark_skin_tone",
-  "\ud83e\uddda\ud83c\udfff\u200d\u2640\ufe0f": "woman_fairy_dark_skin_tone",
-  "\ud83e\uddda\ud83c\udfff\u200d\u2642": "man_fairy_dark_skin_tone",
-  "\ud83e\uddda\ud83c\udfff\u200d\u2642\ufe0f": "man_fairy_dark_skin_tone",
-  "\ud83e\udddb": "vampire",
-  "\ud83e\udddb\u200d\u2640": "woman_vampire",
-  "\ud83e\udddb\u200d\u2640\ufe0f": "woman_vampire",
-  "\ud83e\udddb\u200d\u2642": "man_vampire",
-  "\ud83e\udddb\u200d\u2642\ufe0f": "man_vampire",
-  "\ud83e\udddb\ud83c\udffb": "vampire_light_skin_tone",
-  "\ud83e\udddb\ud83c\udffb\u200d\u2640": "woman_vampire_light_skin_tone",
-  "\ud83e\udddb\ud83c\udffb\u200d\u2640\ufe0f": "woman_vampire_light_skin_tone",
-  "\ud83e\udddb\ud83c\udffb\u200d\u2642": "man_vampire_light_skin_tone",
-  "\ud83e\udddb\ud83c\udffb\u200d\u2642\ufe0f": "man_vampire_light_skin_tone",
-  "\ud83e\udddb\ud83c\udffc": "vampire_medium-light_skin_tone",
-  "\ud83e\udddb\ud83c\udffc\u200d\u2640": "woman_vampire_medium-light_skin_tone",
-  "\ud83e\udddb\ud83c\udffc\u200d\u2640\ufe0f": "woman_vampire_medium-light_skin_tone",
-  "\ud83e\udddb\ud83c\udffc\u200d\u2642": "man_vampire_medium-light_skin_tone",
-  "\ud83e\udddb\ud83c\udffc\u200d\u2642\ufe0f": "man_vampire_medium-light_skin_tone",
-  "\ud83e\udddb\ud83c\udffd": "vampire_medium_skin_tone",
-  "\ud83e\udddb\ud83c\udffd\u200d\u2640": "woman_vampire_medium_skin_tone",
-  "\ud83e\udddb\ud83c\udffd\u200d\u2640\ufe0f": "woman_vampire_medium_skin_tone",
-  "\ud83e\udddb\ud83c\udffd\u200d\u2642": "man_vampire_medium_skin_tone",
-  "\ud83e\udddb\ud83c\udffd\u200d\u2642\ufe0f": "man_vampire_medium_skin_tone",
-  "\ud83e\udddb\ud83c\udffe": "vampire_medium-dark_skin_tone",
-  "\ud83e\udddb\ud83c\udffe\u200d\u2640": "woman_vampire_medium-dark_skin_tone",
-  "\ud83e\udddb\ud83c\udffe\u200d\u2640\ufe0f": "woman_vampire_medium-dark_skin_tone",
-  "\ud83e\udddb\ud83c\udffe\u200d\u2642": "man_vampire_medium-dark_skin_tone",
-  "\ud83e\udddb\ud83c\udffe\u200d\u2642\ufe0f": "man_vampire_medium-dark_skin_tone",
-  "\ud83e\udddb\ud83c\udfff": "vampire_dark_skin_tone",
-  "\ud83e\udddb\ud83c\udfff\u200d\u2640": "woman_vampire_dark_skin_tone",
-  "\ud83e\udddb\ud83c\udfff\u200d\u2640\ufe0f": "woman_vampire_dark_skin_tone",
-  "\ud83e\udddb\ud83c\udfff\u200d\u2642": "man_vampire_dark_skin_tone",
-  "\ud83e\udddb\ud83c\udfff\u200d\u2642\ufe0f": "man_vampire_dark_skin_tone",
-  "\ud83e\udddc": "merperson",
-  "\ud83e\udddc\u200d\u2640": "mermaid",
-  "\ud83e\udddc\u200d\u2640\ufe0f": "mermaid",
-  "\ud83e\udddc\u200d\u2642": "merman",
-  "\ud83e\udddc\u200d\u2642\ufe0f": "merman",
-  "\ud83e\udddc\ud83c\udffb": "merperson_light_skin_tone",
-  "\ud83e\udddc\ud83c\udffb\u200d\u2640": "mermaid_light_skin_tone",
-  "\ud83e\udddc\ud83c\udffb\u200d\u2640\ufe0f": "mermaid_light_skin_tone",
-  "\ud83e\udddc\ud83c\udffb\u200d\u2642": "merman_light_skin_tone",
-  "\ud83e\udddc\ud83c\udffb\u200d\u2642\ufe0f": "merman_light_skin_tone",
-  "\ud83e\udddc\ud83c\udffc": "merperson_medium-light_skin_tone",
-  "\ud83e\udddc\ud83c\udffc\u200d\u2640": "mermaid_medium-light_skin_tone",
-  "\ud83e\udddc\ud83c\udffc\u200d\u2640\ufe0f": "mermaid_medium-light_skin_tone",
-  "\ud83e\udddc\ud83c\udffc\u200d\u2642": "merman_medium-light_skin_tone",
-  "\ud83e\udddc\ud83c\udffc\u200d\u2642\ufe0f": "merman_medium-light_skin_tone",
-  "\ud83e\udddc\ud83c\udffd": "merperson_medium_skin_tone",
-  "\ud83e\udddc\ud83c\udffd\u200d\u2640": "mermaid_medium_skin_tone",
-  "\ud83e\udddc\ud83c\udffd\u200d\u2640\ufe0f": "mermaid_medium_skin_tone",
-  "\ud83e\udddc\ud83c\udffd\u200d\u2642": "merman_medium_skin_tone",
-  "\ud83e\udddc\ud83c\udffd\u200d\u2642\ufe0f": "merman_medium_skin_tone",
-  "\ud83e\udddc\ud83c\udffe": "merperson_medium-dark_skin_tone",
-  "\ud83e\udddc\ud83c\udffe\u200d\u2640": "mermaid_medium-dark_skin_tone",
-  "\ud83e\udddc\ud83c\udffe\u200d\u2640\ufe0f": "mermaid_medium-dark_skin_tone",
-  "\ud83e\udddc\ud83c\udffe\u200d\u2642": "merman_medium-dark_skin_tone",
-  "\ud83e\udddc\ud83c\udffe\u200d\u2642\ufe0f": "merman_medium-dark_skin_tone",
-  "\ud83e\udddc\ud83c\udfff": "merperson_dark_skin_tone",
-  "\ud83e\udddc\ud83c\udfff\u200d\u2640": "mermaid_dark_skin_tone",
-  "\ud83e\udddc\ud83c\udfff\u200d\u2640\ufe0f": "mermaid_dark_skin_tone",
-  "\ud83e\udddc\ud83c\udfff\u200d\u2642": "merman_dark_skin_tone",
-  "\ud83e\udddc\ud83c\udfff\u200d\u2642\ufe0f": "merman_dark_skin_tone",
-  "\ud83e\udddd": "elf",
-  "\ud83e\udddd\u200d\u2640": "woman_elf",
-  "\ud83e\udddd\u200d\u2640\ufe0f": "woman_elf",
-  "\ud83e\udddd\u200d\u2642": "man_elf",
-  "\ud83e\udddd\u200d\u2642\ufe0f": "man_elf",
-  "\ud83e\udddd\ud83c\udffb": "elf_light_skin_tone",
-  "\ud83e\udddd\ud83c\udffb\u200d\u2640": "woman_elf_light_skin_tone",
-  "\ud83e\udddd\ud83c\udffb\u200d\u2640\ufe0f": "woman_elf_light_skin_tone",
-  "\ud83e\udddd\ud83c\udffb\u200d\u2642": "man_elf_light_skin_tone",
-  "\ud83e\udddd\ud83c\udffb\u200d\u2642\ufe0f": "man_elf_light_skin_tone",
-  "\ud83e\udddd\ud83c\udffc": "elf_medium-light_skin_tone",
-  "\ud83e\udddd\ud83c\udffc\u200d\u2640": "woman_elf_medium-light_skin_tone",
-  "\ud83e\udddd\ud83c\udffc\u200d\u2640\ufe0f": "woman_elf_medium-light_skin_tone",
-  "\ud83e\udddd\ud83c\udffc\u200d\u2642": "man_elf_medium-light_skin_tone",
-  "\ud83e\udddd\ud83c\udffc\u200d\u2642\ufe0f": "man_elf_medium-light_skin_tone",
-  "\ud83e\udddd\ud83c\udffd": "elf_medium_skin_tone",
-  "\ud83e\udddd\ud83c\udffd\u200d\u2640": "woman_elf_medium_skin_tone",
-  "\ud83e\udddd\ud83c\udffd\u200d\u2640\ufe0f": "woman_elf_medium_skin_tone",
-  "\ud83e\udddd\ud83c\udffd\u200d\u2642": "man_elf_medium_skin_tone",
-  "\ud83e\udddd\ud83c\udffd\u200d\u2642\ufe0f": "man_elf_medium_skin_tone",
-  "\ud83e\udddd\ud83c\udffe": "elf_medium-dark_skin_tone",
-  "\ud83e\udddd\ud83c\udffe\u200d\u2640": "woman_elf_medium-dark_skin_tone",
-  "\ud83e\udddd\ud83c\udffe\u200d\u2640\ufe0f": "woman_elf_medium-dark_skin_tone",
-  "\ud83e\udddd\ud83c\udffe\u200d\u2642": "man_elf_medium-dark_skin_tone",
-  "\ud83e\udddd\ud83c\udffe\u200d\u2642\ufe0f": "man_elf_medium-dark_skin_tone",
-  "\ud83e\udddd\ud83c\udfff": "elf_dark_skin_tone",
-  "\ud83e\udddd\ud83c\udfff\u200d\u2640": "woman_elf_dark_skin_tone",
-  "\ud83e\udddd\ud83c\udfff\u200d\u2640\ufe0f": "woman_elf_dark_skin_tone",
-  "\ud83e\udddd\ud83c\udfff\u200d\u2642": "man_elf_dark_skin_tone",
-  "\ud83e\udddd\ud83c\udfff\u200d\u2642\ufe0f": "man_elf_dark_skin_tone",
-  "\ud83e\uddde": "genie",
-  "\ud83e\uddde\u200d\u2640": "woman_genie",
-  "\ud83e\uddde\u200d\u2640\ufe0f": "woman_genie",
-  "\ud83e\uddde\u200d\u2642": "man_genie",
-  "\ud83e\uddde\u200d\u2642\ufe0f": "man_genie",
-  "\ud83e\udddf": "zombie",
-  "\ud83e\udddf\u200d\u2640": "woman_zombie",
-  "\ud83e\udddf\u200d\u2640\ufe0f": "woman_zombie",
-  "\ud83e\udddf\u200d\u2642": "man_zombie",
-  "\ud83e\udddf\u200d\u2642\ufe0f": "man_zombie",
-  "\ud83e\udde0": "brain",
-  "\ud83e\udde1": "orange_heart",
-  "\ud83e\udde2": "billed_cap",
-  "\ud83e\udde3": "scarf",
-  "\ud83e\udde4": "gloves",
-  "\ud83e\udde5": "coat",
-  "\ud83e\udde6": "socks",
-  "\ud83e\udde7": "red_envelope",
-  "\ud83e\udde8": "firecracker",
-  "\ud83e\udde9": "puzzle_piece",
-  "\ud83e\uddea": "test_tube",
-  "\ud83e\uddeb": "petri_dish",
-  "\ud83e\uddec": "dna",
-  "\ud83e\udded": "compass",
-  "\ud83e\uddee": "abacus",
-  "\ud83e\uddef": "fire_extinguisher",
-  "\ud83e\uddf0": "toolbox",
-  "\ud83e\uddf1": "brick",
-  "\ud83e\uddf2": "magnet",
-  "\ud83e\uddf3": "luggage",
-  "\ud83e\uddf4": "lotion_bottle",
-  "\ud83e\uddf5": "thread",
-  "\ud83e\uddf6": "yarn",
-  "\ud83e\uddf7": "safety_pin",
-  "\ud83e\uddf8": "teddy_bear",
-  "\ud83e\uddf9": "broom",
-  "\ud83e\uddfa": "basket",
-  "\ud83e\uddfb": "roll_of_paper",
-  "\ud83e\uddfc": "soap",
-  "\ud83e\uddfd": "sponge",
-  "\ud83e\uddfe": "receipt",
-  "\ud83e\uddff": "nazar_amulet",
-  "\ud83e\ude70": "ballet_shoes",
-  "\ud83e\ude71": "one-piece_swimsuit",
-  "\ud83e\ude72": "briefs",
-  "\ud83e\ude73": "shorts",
-  "\ud83e\ude74": "thong_sandal",
-  "\ud83e\ude75": "light_blue_heart",
-  "\ud83e\ude76": "grey_heart",
-  "\ud83e\ude77": "pink_heart",
-  "\ud83e\ude78": "drop_of_blood",
-  "\ud83e\ude79": "adhesive_bandage",
-  "\ud83e\ude7a": "stethoscope",
-  "\ud83e\ude7b": "x-ray",
-  "\ud83e\ude7c": "crutch",
-  "\ud83e\ude80": "yo-yo",
-  "\ud83e\ude81": "kite",
-  "\ud83e\ude82": "parachute",
-  "\ud83e\ude83": "boomerang",
-  "\ud83e\ude84": "magic_wand",
-  "\ud83e\ude85": "pi\u00f1ata",
-  "\ud83e\ude86": "nesting_dolls",
-  "\ud83e\ude87": "maracas",
-  "\ud83e\ude88": "flute",
-  "\ud83e\ude90": "ringed_planet",
-  "\ud83e\ude91": "chair",
-  "\ud83e\ude92": "razor",
-  "\ud83e\ude93": "axe",
-  "\ud83e\ude94": "diya_lamp",
-  "\ud83e\ude95": "banjo",
-  "\ud83e\ude96": "military_helmet",
-  "\ud83e\ude97": "accordion",
-  "\ud83e\ude98": "long_drum",
-  "\ud83e\ude99": "coin",
-  "\ud83e\ude9a": "carpentry_saw",
-  "\ud83e\ude9b": "screwdriver",
-  "\ud83e\ude9c": "ladder",
-  "\ud83e\ude9d": "hook",
-  "\ud83e\ude9e": "mirror",
-  "\ud83e\ude9f": "window",
-  "\ud83e\udea0": "plunger",
-  "\ud83e\udea1": "sewing_needle",
-  "\ud83e\udea2": "knot",
-  "\ud83e\udea3": "bucket",
-  "\ud83e\udea4": "mouse_trap",
-  "\ud83e\udea5": "toothbrush",
-  "\ud83e\udea6": "headstone",
-  "\ud83e\udea7": "placard",
-  "\ud83e\udea8": "rock",
-  "\ud83e\udea9": "mirror_ball",
-  "\ud83e\udeaa": "identification_card",
-  "\ud83e\udeab": "low_battery",
-  "\ud83e\udeac": "hamsa",
-  "\ud83e\udead": "folding_hand_fan",
-  "\ud83e\udeae": "hair_pick",
-  "\ud83e\udeaf": "khanda",
-  "\ud83e\udeb0": "fly",
-  "\ud83e\udeb1": "worm",
-  "\ud83e\udeb2": "beetle",
-  "\ud83e\udeb3": "cockroach",
-  "\ud83e\udeb4": "potted_plant",
-  "\ud83e\udeb5": "wood",
-  "\ud83e\udeb6": "feather",
-  "\ud83e\udeb7": "lotus",
-  "\ud83e\udeb8": "coral",
-  "\ud83e\udeb9": "empty_nest",
-  "\ud83e\udeba": "nest_with_eggs",
-  "\ud83e\udebb": "hyacinth",
-  "\ud83e\udebc": "jellyfish",
-  "\ud83e\udebd": "wing",
-  "\ud83e\udebf": "goose",
-  "\ud83e\udec0": "anatomical_heart",
-  "\ud83e\udec1": "lungs",
-  "\ud83e\udec2": "people_hugging",
-  "\ud83e\udec3": "pregnant_man",
-  "\ud83e\udec3\ud83c\udffb": "pregnant_man_light_skin_tone",
-  "\ud83e\udec3\ud83c\udffc": "pregnant_man_medium-light_skin_tone",
-  "\ud83e\udec3\ud83c\udffd": "pregnant_man_medium_skin_tone",
-  "\ud83e\udec3\ud83c\udffe": "pregnant_man_medium-dark_skin_tone",
-  "\ud83e\udec3\ud83c\udfff": "pregnant_man_dark_skin_tone",
-  "\ud83e\udec4": "pregnant_person",
-  "\ud83e\udec4\ud83c\udffb": "pregnant_person_light_skin_tone",
-  "\ud83e\udec4\ud83c\udffc": "pregnant_person_medium-light_skin_tone",
-  "\ud83e\udec4\ud83c\udffd": "pregnant_person_medium_skin_tone",
-  "\ud83e\udec4\ud83c\udffe": "pregnant_person_medium-dark_skin_tone",
-  "\ud83e\udec4\ud83c\udfff": "pregnant_person_dark_skin_tone",
-  "\ud83e\udec5": "person_with_crown",
-  "\ud83e\udec5\ud83c\udffb": "person_with_crown_light_skin_tone",
-  "\ud83e\udec5\ud83c\udffc": "person_with_crown_medium-light_skin_tone",
-  "\ud83e\udec5\ud83c\udffd": "person_with_crown_medium_skin_tone",
-  "\ud83e\udec5\ud83c\udffe": "person_with_crown_medium-dark_skin_tone",
-  "\ud83e\udec5\ud83c\udfff": "person_with_crown_dark_skin_tone",
-  "\ud83e\udece": "moose",
-  "\ud83e\udecf": "donkey",
-  "\ud83e\uded0": "blueberries",
-  "\ud83e\uded1": "bell_pepper",
-  "\ud83e\uded2": "olive",
-  "\ud83e\uded3": "flatbread",
-  "\ud83e\uded4": "tamale",
-  "\ud83e\uded5": "fondue",
-  "\ud83e\uded6": "teapot",
-  "\ud83e\uded7": "pouring_liquid",
-  "\ud83e\uded8": "beans",
-  "\ud83e\uded9": "jar",
-  "\ud83e\udeda": "ginger_root",
-  "\ud83e\udedb": "pea_pod",
-  "\ud83e\udee0": "melting_face",
-  "\ud83e\udee1": "saluting_face",
-  "\ud83e\udee2": "face_with_open_eyes_and_hand_over_mouth",
-  "\ud83e\udee3": "face_with_peeking_eye",
-  "\ud83e\udee4": "face_with_diagonal_mouth",
-  "\ud83e\udee5": "dotted_line_face",
-  "\ud83e\udee6": "biting_lip",
-  "\ud83e\udee7": "bubbles",
-  "\ud83e\udee8": "shaking_face",
-  "\ud83e\udef0": "hand_with_index_finger_and_thumb_crossed",
-  "\ud83e\udef0\ud83c\udffb": "hand_with_index_finger_and_thumb_crossed_light_skin_tone",
-  "\ud83e\udef0\ud83c\udffc": "hand_with_index_finger_and_thumb_crossed_medium-light_skin_tone",
-  "\ud83e\udef0\ud83c\udffd": "hand_with_index_finger_and_thumb_crossed_medium_skin_tone",
-  "\ud83e\udef0\ud83c\udffe": "hand_with_index_finger_and_thumb_crossed_medium-dark_skin_tone",
-  "\ud83e\udef0\ud83c\udfff": "hand_with_index_finger_and_thumb_crossed_dark_skin_tone",
-  "\ud83e\udef1": "rightwards_hand",
-  "\ud83e\udef1\ud83c\udffb": "rightwards_hand_light_skin_tone",
-  "\ud83e\udef1\ud83c\udffb\u200d\ud83e\udef2\ud83c\udffc": "handshake_light_skin_tone_medium-light_skin_tone",
-  "\ud83e\udef1\ud83c\udffb\u200d\ud83e\udef2\ud83c\udffd": "handshake_light_skin_tone_medium_skin_tone",
-  "\ud83e\udef1\ud83c\udffb\u200d\ud83e\udef2\ud83c\udffe": "handshake_light_skin_tone_medium-dark_skin_tone",
-  "\ud83e\udef1\ud83c\udffb\u200d\ud83e\udef2\ud83c\udfff": "handshake_light_skin_tone_dark_skin_tone",
-  "\ud83e\udef1\ud83c\udffc": "rightwards_hand_medium-light_skin_tone",
-  "\ud83e\udef1\ud83c\udffc\u200d\ud83e\udef2\ud83c\udffb": "handshake_medium-light_skin_tone_light_skin_tone",
-  "\ud83e\udef1\ud83c\udffc\u200d\ud83e\udef2\ud83c\udffd": "handshake_medium-light_skin_tone_medium_skin_tone",
-  "\ud83e\udef1\ud83c\udffc\u200d\ud83e\udef2\ud83c\udffe": "handshake_medium-light_skin_tone_medium-dark_skin_tone",
-  "\ud83e\udef1\ud83c\udffc\u200d\ud83e\udef2\ud83c\udfff": "handshake_medium-light_skin_tone_dark_skin_tone",
-  "\ud83e\udef1\ud83c\udffd": "rightwards_hand_medium_skin_tone",
-  "\ud83e\udef1\ud83c\udffd\u200d\ud83e\udef2\ud83c\udffb": "handshake_medium_skin_tone_light_skin_tone",
-  "\ud83e\udef1\ud83c\udffd\u200d\ud83e\udef2\ud83c\udffc": "handshake_medium_skin_tone_medium-light_skin_tone",
-  "\ud83e\udef1\ud83c\udffd\u200d\ud83e\udef2\ud83c\udffe": "handshake_medium_skin_tone_medium-dark_skin_tone",
-  "\ud83e\udef1\ud83c\udffd\u200d\ud83e\udef2\ud83c\udfff": "handshake_medium_skin_tone_dark_skin_tone",
-  "\ud83e\udef1\ud83c\udffe": "rightwards_hand_medium-dark_skin_tone",
-  "\ud83e\udef1\ud83c\udffe\u200d\ud83e\udef2\ud83c\udffb": "handshake_medium-dark_skin_tone_light_skin_tone",
-  "\ud83e\udef1\ud83c\udffe\u200d\ud83e\udef2\ud83c\udffc": "handshake_medium-dark_skin_tone_medium-light_skin_tone",
-  "\ud83e\udef1\ud83c\udffe\u200d\ud83e\udef2\ud83c\udffd": "handshake_medium-dark_skin_tone_medium_skin_tone",
-  "\ud83e\udef1\ud83c\udffe\u200d\ud83e\udef2\ud83c\udfff": "handshake_medium-dark_skin_tone_dark_skin_tone",
-  "\ud83e\udef1\ud83c\udfff": "rightwards_hand_dark_skin_tone",
-  "\ud83e\udef1\ud83c\udfff\u200d\ud83e\udef2\ud83c\udffb": "handshake_dark_skin_tone_light_skin_tone",
-  "\ud83e\udef1\ud83c\udfff\u200d\ud83e\udef2\ud83c\udffc": "handshake_dark_skin_tone_medium-light_skin_tone",
-  "\ud83e\udef1\ud83c\udfff\u200d\ud83e\udef2\ud83c\udffd": "handshake_dark_skin_tone_medium_skin_tone",
-  "\ud83e\udef1\ud83c\udfff\u200d\ud83e\udef2\ud83c\udffe": "handshake_dark_skin_tone_medium-dark_skin_tone",
-  "\ud83e\udef2": "leftwards_hand",
-  "\ud83e\udef2\ud83c\udffb": "leftwards_hand_light_skin_tone",
-  "\ud83e\udef2\ud83c\udffc": "leftwards_hand_medium-light_skin_tone",
-  "\ud83e\udef2\ud83c\udffd": "leftwards_hand_medium_skin_tone",
-  "\ud83e\udef2\ud83c\udffe": "leftwards_hand_medium-dark_skin_tone",
-  "\ud83e\udef2\ud83c\udfff": "leftwards_hand_dark_skin_tone",
-  "\ud83e\udef3": "palm_down_hand",
-  "\ud83e\udef3\ud83c\udffb": "palm_down_hand_light_skin_tone",
-  "\ud83e\udef3\ud83c\udffc": "palm_down_hand_medium-light_skin_tone",
-  "\ud83e\udef3\ud83c\udffd": "palm_down_hand_medium_skin_tone",
-  "\ud83e\udef3\ud83c\udffe": "palm_down_hand_medium-dark_skin_tone",
-  "\ud83e\udef3\ud83c\udfff": "palm_down_hand_dark_skin_tone",
-  "\ud83e\udef4": "palm_up_hand",
-  "\ud83e\udef4\ud83c\udffb": "palm_up_hand_light_skin_tone",
-  "\ud83e\udef4\ud83c\udffc": "palm_up_hand_medium-light_skin_tone",
-  "\ud83e\udef4\ud83c\udffd": "palm_up_hand_medium_skin_tone",
-  "\ud83e\udef4\ud83c\udffe": "palm_up_hand_medium-dark_skin_tone",
-  "\ud83e\udef4\ud83c\udfff": "palm_up_hand_dark_skin_tone",
-  "\ud83e\udef5": "index_pointing_at_the_viewer",
-  "\ud83e\udef5\ud83c\udffb": "index_pointing_at_the_viewer_light_skin_tone",
-  "\ud83e\udef5\ud83c\udffc": "index_pointing_at_the_viewer_medium-light_skin_tone",
-  "\ud83e\udef5\ud83c\udffd": "index_pointing_at_the_viewer_medium_skin_tone",
-  "\ud83e\udef5\ud83c\udffe": "index_pointing_at_the_viewer_medium-dark_skin_tone",
-  "\ud83e\udef5\ud83c\udfff": "index_pointing_at_the_viewer_dark_skin_tone",
-  "\ud83e\udef6": "heart_hands",
-  "\ud83e\udef6\ud83c\udffb": "heart_hands_light_skin_tone",
-  "\ud83e\udef6\ud83c\udffc": "heart_hands_medium-light_skin_tone",
-  "\ud83e\udef6\ud83c\udffd": "heart_hands_medium_skin_tone",
-  "\ud83e\udef6\ud83c\udffe": "heart_hands_medium-dark_skin_tone",
-  "\ud83e\udef6\ud83c\udfff": "heart_hands_dark_skin_tone",
-  "\ud83e\udef7": "leftwards_pushing_hand",
-  "\ud83e\udef7\ud83c\udffb": "leftwards_pushing_hand_light_skin_tone",
-  "\ud83e\udef7\ud83c\udffc": "leftwards_pushing_hand_medium-light_skin_tone",
-  "\ud83e\udef7\ud83c\udffd": "leftwards_pushing_hand_medium_skin_tone",
-  "\ud83e\udef7\ud83c\udffe": "leftwards_pushing_hand_medium-dark_skin_tone",
-  "\ud83e\udef7\ud83c\udfff": "leftwards_pushing_hand_dark_skin_tone",
-  "\ud83e\udef8": "rightwards_pushing_hand",
-  "\ud83e\udef8\ud83c\udffb": "rightwards_pushing_hand_light_skin_tone",
-  "\ud83e\udef8\ud83c\udffc": "rightwards_pushing_hand_medium-light_skin_tone",
-  "\ud83e\udef8\ud83c\udffd": "rightwards_pushing_hand_medium_skin_tone",
-  "\ud83e\udef8\ud83c\udffe": "rightwards_pushing_hand_medium-dark_skin_tone",
-  "\ud83e\udef8\ud83c\udfff": "rightwards_pushing_hand_dark_skin_tone"
+  "#\u20e3": [
+    "keycap_#",
+    "hash"
+  ],
+  "#\ufe0f\u20e3": [
+    "keycap_#",
+    "hash"
+  ],
+  "*\u20e3": [
+    "keycap_*",
+    "asterisk"
+  ],
+  "*\ufe0f\u20e3": [
+    "keycap_*",
+    "asterisk"
+  ],
+  "0\u20e3": [
+    "keycap_0",
+    "zero"
+  ],
+  "0\ufe0f\u20e3": [
+    "keycap_0",
+    "zero"
+  ],
+  "1\u20e3": [
+    "keycap_1",
+    "one"
+  ],
+  "1\ufe0f\u20e3": [
+    "keycap_1",
+    "one"
+  ],
+  "2\u20e3": [
+    "keycap_2",
+    "two"
+  ],
+  "2\ufe0f\u20e3": [
+    "keycap_2",
+    "two"
+  ],
+  "3\u20e3": [
+    "keycap_3",
+    "three"
+  ],
+  "3\ufe0f\u20e3": [
+    "keycap_3",
+    "three"
+  ],
+  "4\u20e3": [
+    "keycap_4",
+    "four"
+  ],
+  "4\ufe0f\u20e3": [
+    "keycap_4",
+    "four"
+  ],
+  "5\u20e3": [
+    "keycap_5",
+    "five"
+  ],
+  "5\ufe0f\u20e3": [
+    "keycap_5",
+    "five"
+  ],
+  "6\u20e3": [
+    "keycap_6",
+    "six"
+  ],
+  "6\ufe0f\u20e3": [
+    "keycap_6",
+    "six"
+  ],
+  "7\u20e3": [
+    "keycap_7",
+    "seven"
+  ],
+  "7\ufe0f\u20e3": [
+    "keycap_7",
+    "seven"
+  ],
+  "8\u20e3": [
+    "keycap_8",
+    "eight"
+  ],
+  "8\ufe0f\u20e3": [
+    "keycap_8",
+    "eight"
+  ],
+  "9\u20e3": [
+    "keycap_9",
+    "nine"
+  ],
+  "9\ufe0f\u20e3": [
+    "keycap_9",
+    "nine"
+  ],
+  "\u00a9": [
+    "copyright"
+  ],
+  "\u00a9\ufe0f": [
+    "copyright"
+  ],
+  "\u00ae": [
+    "registered"
+  ],
+  "\u00ae\ufe0f": [
+    "registered"
+  ],
+  "\u203c": [
+    "double_exclamation_mark",
+    "bangbang"
+  ],
+  "\u203c\ufe0f": [
+    "double_exclamation_mark",
+    "bangbang"
+  ],
+  "\u2049": [
+    "exclamation_question_mark",
+    "interrobang"
+  ],
+  "\u2049\ufe0f": [
+    "exclamation_question_mark",
+    "interrobang"
+  ],
+  "\u2122": [
+    "trade_mark",
+    "tm"
+  ],
+  "\u2122\ufe0f": [
+    "trade_mark",
+    "tm"
+  ],
+  "\u2139": [
+    "information",
+    "information_source"
+  ],
+  "\u2139\ufe0f": [
+    "information",
+    "information_source"
+  ],
+  "\u2194": [
+    "left-right_arrow",
+    "left_right_arrow"
+  ],
+  "\u2194\ufe0f": [
+    "left-right_arrow",
+    "left_right_arrow"
+  ],
+  "\u2195": [
+    "up-down_arrow",
+    "arrow_up_down",
+    "up_down_arrow"
+  ],
+  "\u2195\ufe0f": [
+    "up-down_arrow",
+    "arrow_up_down",
+    "up_down_arrow"
+  ],
+  "\u2196": [
+    "up-left_arrow",
+    "arrow_upper_left",
+    "up_left_arrow"
+  ],
+  "\u2196\ufe0f": [
+    "up-left_arrow",
+    "arrow_upper_left",
+    "up_left_arrow"
+  ],
+  "\u2197": [
+    "up-right_arrow",
+    "arrow_upper_right",
+    "up_right_arrow"
+  ],
+  "\u2197\ufe0f": [
+    "up-right_arrow",
+    "arrow_upper_right",
+    "up_right_arrow"
+  ],
+  "\u2198": [
+    "down-right_arrow",
+    "arrow_lower_right",
+    "down_right_arrow"
+  ],
+  "\u2198\ufe0f": [
+    "down-right_arrow",
+    "arrow_lower_right",
+    "down_right_arrow"
+  ],
+  "\u2199": [
+    "down-left_arrow",
+    "arrow_lower_left",
+    "down_left_arrow"
+  ],
+  "\u2199\ufe0f": [
+    "down-left_arrow",
+    "arrow_lower_left",
+    "down_left_arrow"
+  ],
+  "\u21a9": [
+    "right_arrow_curving_left",
+    "leftwards_arrow_with_hook"
+  ],
+  "\u21a9\ufe0f": [
+    "right_arrow_curving_left",
+    "leftwards_arrow_with_hook"
+  ],
+  "\u21aa": [
+    "left_arrow_curving_right",
+    "arrow_right_hook"
+  ],
+  "\u21aa\ufe0f": [
+    "left_arrow_curving_right",
+    "arrow_right_hook"
+  ],
+  "\u231a": [
+    "watch"
+  ],
+  "\u231b": [
+    "hourglass_done",
+    "hourglass"
+  ],
+  "\u2328": [
+    "keyboard"
+  ],
+  "\u2328\ufe0f": [
+    "keyboard"
+  ],
+  "\u23cf": [
+    "eject_button",
+    "eject_symbol"
+  ],
+  "\u23cf\ufe0f": [
+    "eject_button",
+    "eject_symbol"
+  ],
+  "\u23e9": [
+    "fast-forward_button",
+    "fast_forward",
+    "fast_forward_button"
+  ],
+  "\u23ea": [
+    "fast_reverse_button",
+    "rewind"
+  ],
+  "\u23eb": [
+    "fast_up_button",
+    "arrow_double_up"
+  ],
+  "\u23ec": [
+    "fast_down_button",
+    "arrow_double_down"
+  ],
+  "\u23ed": [
+    "next_track_button",
+    "black_right_pointing_double_triangle_with_vertical_bar"
+  ],
+  "\u23ed\ufe0f": [
+    "next_track_button",
+    "black_right_pointing_double_triangle_with_vertical_bar"
+  ],
+  "\u23ee": [
+    "last_track_button",
+    "previous_track_button",
+    "black_left_pointing_double_triangle_with_vertical_bar"
+  ],
+  "\u23ee\ufe0f": [
+    "last_track_button",
+    "previous_track_button",
+    "black_left_pointing_double_triangle_with_vertical_bar"
+  ],
+  "\u23ef": [
+    "play_or_pause_button",
+    "black_right_pointing_triangle_with_double_vertical_bar"
+  ],
+  "\u23ef\ufe0f": [
+    "play_or_pause_button",
+    "black_right_pointing_triangle_with_double_vertical_bar"
+  ],
+  "\u23f0": [
+    "alarm_clock"
+  ],
+  "\u23f1": [
+    "stopwatch"
+  ],
+  "\u23f1\ufe0f": [
+    "stopwatch"
+  ],
+  "\u23f2": [
+    "timer_clock"
+  ],
+  "\u23f2\ufe0f": [
+    "timer_clock"
+  ],
+  "\u23f3": [
+    "hourglass_not_done",
+    "hourglass_flowing_sand"
+  ],
+  "\u23f8": [
+    "pause_button",
+    "double_vertical_bar"
+  ],
+  "\u23f8\ufe0f": [
+    "pause_button",
+    "double_vertical_bar"
+  ],
+  "\u23f9": [
+    "stop_button",
+    "black_square_for_stop"
+  ],
+  "\u23f9\ufe0f": [
+    "stop_button",
+    "black_square_for_stop"
+  ],
+  "\u23fa": [
+    "record_button",
+    "black_circle_for_record"
+  ],
+  "\u23fa\ufe0f": [
+    "record_button",
+    "black_circle_for_record"
+  ],
+  "\u24c2": [
+    "circled_m",
+    "m",
+    "circled_m"
+  ],
+  "\u24c2\ufe0f": [
+    "circled_m",
+    "m",
+    "circled_m"
+  ],
+  "\u25aa": [
+    "black_small_square"
+  ],
+  "\u25aa\ufe0f": [
+    "black_small_square"
+  ],
+  "\u25ab": [
+    "white_small_square"
+  ],
+  "\u25ab\ufe0f": [
+    "white_small_square"
+  ],
+  "\u25b6": [
+    "play_button",
+    "arrow_forward"
+  ],
+  "\u25b6\ufe0f": [
+    "play_button",
+    "arrow_forward"
+  ],
+  "\u25c0": [
+    "reverse_button",
+    "arrow_backward"
+  ],
+  "\u25c0\ufe0f": [
+    "reverse_button",
+    "arrow_backward"
+  ],
+  "\u25fb": [
+    "white_medium_square"
+  ],
+  "\u25fb\ufe0f": [
+    "white_medium_square"
+  ],
+  "\u25fc": [
+    "black_medium_square"
+  ],
+  "\u25fc\ufe0f": [
+    "black_medium_square"
+  ],
+  "\u25fd": [
+    "white_medium-small_square",
+    "white_medium_small_square"
+  ],
+  "\u25fe": [
+    "black_medium-small_square",
+    "black_medium_small_square"
+  ],
+  "\u2600": [
+    "sun",
+    "sunny"
+  ],
+  "\u2600\ufe0f": [
+    "sun",
+    "sunny"
+  ],
+  "\u2601": [
+    "cloud"
+  ],
+  "\u2601\ufe0f": [
+    "cloud"
+  ],
+  "\u2602": [
+    "umbrella",
+    "open_umbrella"
+  ],
+  "\u2602\ufe0f": [
+    "umbrella",
+    "open_umbrella"
+  ],
+  "\u2603": [
+    "snowman",
+    "snowman_with_snow"
+  ],
+  "\u2603\ufe0f": [
+    "snowman",
+    "snowman_with_snow"
+  ],
+  "\u2604": [
+    "comet"
+  ],
+  "\u2604\ufe0f": [
+    "comet"
+  ],
+  "\u260e": [
+    "telephone",
+    "phone"
+  ],
+  "\u260e\ufe0f": [
+    "telephone",
+    "phone"
+  ],
+  "\u2611": [
+    "check_box_with_check",
+    "ballot_box_with_check"
+  ],
+  "\u2611\ufe0f": [
+    "check_box_with_check",
+    "ballot_box_with_check"
+  ],
+  "\u2614": [
+    "umbrella_with_rain_drops",
+    "umbrella"
+  ],
+  "\u2615": [
+    "hot_beverage",
+    "coffee"
+  ],
+  "\u2618": [
+    "shamrock"
+  ],
+  "\u2618\ufe0f": [
+    "shamrock"
+  ],
+  "\u261d": [
+    "index_pointing_up",
+    "point_up"
+  ],
+  "\u261d\ufe0f": [
+    "index_pointing_up",
+    "point_up"
+  ],
+  "\u261d\ud83c\udffb": [
+    "index_pointing_up_light_skin_tone"
+  ],
+  "\u261d\ud83c\udffc": [
+    "index_pointing_up_medium-light_skin_tone"
+  ],
+  "\u261d\ud83c\udffd": [
+    "index_pointing_up_medium_skin_tone"
+  ],
+  "\u261d\ud83c\udffe": [
+    "index_pointing_up_medium-dark_skin_tone"
+  ],
+  "\u261d\ud83c\udfff": [
+    "index_pointing_up_dark_skin_tone"
+  ],
+  "\u2620": [
+    "skull_and_crossbones"
+  ],
+  "\u2620\ufe0f": [
+    "skull_and_crossbones"
+  ],
+  "\u2622": [
+    "radioactive",
+    "radioactive_sign"
+  ],
+  "\u2622\ufe0f": [
+    "radioactive",
+    "radioactive_sign"
+  ],
+  "\u2623": [
+    "biohazard",
+    "biohazard_sign"
+  ],
+  "\u2623\ufe0f": [
+    "biohazard",
+    "biohazard_sign"
+  ],
+  "\u2626": [
+    "orthodox_cross"
+  ],
+  "\u2626\ufe0f": [
+    "orthodox_cross"
+  ],
+  "\u262a": [
+    "star_and_crescent"
+  ],
+  "\u262a\ufe0f": [
+    "star_and_crescent"
+  ],
+  "\u262e": [
+    "peace_symbol"
+  ],
+  "\u262e\ufe0f": [
+    "peace_symbol"
+  ],
+  "\u262f": [
+    "yin_yang"
+  ],
+  "\u262f\ufe0f": [
+    "yin_yang"
+  ],
+  "\u2638": [
+    "wheel_of_dharma"
+  ],
+  "\u2638\ufe0f": [
+    "wheel_of_dharma"
+  ],
+  "\u2639": [
+    "frowning_face",
+    "white_frowning_face"
+  ],
+  "\u2639\ufe0f": [
+    "frowning_face",
+    "white_frowning_face"
+  ],
+  "\u263a": [
+    "smiling_face",
+    "relaxed"
+  ],
+  "\u263a\ufe0f": [
+    "smiling_face",
+    "relaxed"
+  ],
+  "\u2640": [
+    "female_sign"
+  ],
+  "\u2640\ufe0f": [
+    "female_sign"
+  ],
+  "\u2642": [
+    "male_sign"
+  ],
+  "\u2642\ufe0f": [
+    "male_sign"
+  ],
+  "\u2648": [
+    "aries",
+    "aries"
+  ],
+  "\u2649": [
+    "taurus",
+    "taurus"
+  ],
+  "\u264a": [
+    "gemini",
+    "gemini"
+  ],
+  "\u264b": [
+    "cancer",
+    "cancer"
+  ],
+  "\u264c": [
+    "leo",
+    "leo"
+  ],
+  "\u264d": [
+    "virgo",
+    "virgo"
+  ],
+  "\u264e": [
+    "libra",
+    "libra"
+  ],
+  "\u264f": [
+    "scorpio",
+    "scorpius",
+    "scorpio"
+  ],
+  "\u2650": [
+    "sagittarius",
+    "sagittarius"
+  ],
+  "\u2651": [
+    "capricorn",
+    "capricorn"
+  ],
+  "\u2652": [
+    "aquarius",
+    "aquarius"
+  ],
+  "\u2653": [
+    "pisces",
+    "pisces"
+  ],
+  "\u265f": [
+    "chess_pawn"
+  ],
+  "\u265f\ufe0f": [
+    "chess_pawn"
+  ],
+  "\u2660": [
+    "spade_suit",
+    "spades"
+  ],
+  "\u2660\ufe0f": [
+    "spade_suit",
+    "spades"
+  ],
+  "\u2663": [
+    "club_suit",
+    "clubs"
+  ],
+  "\u2663\ufe0f": [
+    "club_suit",
+    "clubs"
+  ],
+  "\u2665": [
+    "heart_suit",
+    "hearts"
+  ],
+  "\u2665\ufe0f": [
+    "heart_suit",
+    "hearts"
+  ],
+  "\u2666": [
+    "diamond_suit",
+    "diamonds"
+  ],
+  "\u2666\ufe0f": [
+    "diamond_suit",
+    "diamonds"
+  ],
+  "\u2668": [
+    "hot_springs",
+    "hotsprings"
+  ],
+  "\u2668\ufe0f": [
+    "hot_springs",
+    "hotsprings"
+  ],
+  "\u267b": [
+    "recycling_symbol",
+    "recycle"
+  ],
+  "\u267b\ufe0f": [
+    "recycling_symbol",
+    "recycle"
+  ],
+  "\u267e": [
+    "infinity"
+  ],
+  "\u267e\ufe0f": [
+    "infinity"
+  ],
+  "\u267f": [
+    "wheelchair_symbol",
+    "wheelchair"
+  ],
+  "\u2692": [
+    "hammer_and_pick"
+  ],
+  "\u2692\ufe0f": [
+    "hammer_and_pick"
+  ],
+  "\u2693": [
+    "anchor"
+  ],
+  "\u2694": [
+    "crossed_swords"
+  ],
+  "\u2694\ufe0f": [
+    "crossed_swords"
+  ],
+  "\u2695": [
+    "medical_symbol"
+  ],
+  "\u2695\ufe0f": [
+    "medical_symbol"
+  ],
+  "\u2696": [
+    "balance_scale",
+    "scales"
+  ],
+  "\u2696\ufe0f": [
+    "balance_scale",
+    "scales"
+  ],
+  "\u2697": [
+    "alembic"
+  ],
+  "\u2697\ufe0f": [
+    "alembic"
+  ],
+  "\u2699": [
+    "gear"
+  ],
+  "\u2699\ufe0f": [
+    "gear"
+  ],
+  "\u269b": [
+    "atom_symbol"
+  ],
+  "\u269b\ufe0f": [
+    "atom_symbol"
+  ],
+  "\u269c": [
+    "fleur-de-lis",
+    "fleur_de_lis"
+  ],
+  "\u269c\ufe0f": [
+    "fleur-de-lis",
+    "fleur_de_lis"
+  ],
+  "\u26a0": [
+    "warning"
+  ],
+  "\u26a0\ufe0f": [
+    "warning"
+  ],
+  "\u26a1": [
+    "high_voltage",
+    "zap"
+  ],
+  "\u26a7": [
+    "transgender_symbol"
+  ],
+  "\u26a7\ufe0f": [
+    "transgender_symbol"
+  ],
+  "\u26aa": [
+    "white_circle"
+  ],
+  "\u26ab": [
+    "black_circle"
+  ],
+  "\u26b0": [
+    "coffin"
+  ],
+  "\u26b0\ufe0f": [
+    "coffin"
+  ],
+  "\u26b1": [
+    "funeral_urn"
+  ],
+  "\u26b1\ufe0f": [
+    "funeral_urn"
+  ],
+  "\u26bd": [
+    "soccer_ball",
+    "soccer"
+  ],
+  "\u26be": [
+    "baseball"
+  ],
+  "\u26c4": [
+    "snowman_without_snow",
+    "snowman"
+  ],
+  "\u26c5": [
+    "sun_behind_cloud",
+    "partly_sunny"
+  ],
+  "\u26c8": [
+    "cloud_with_lightning_and_rain",
+    "thunder_cloud_and_rain"
+  ],
+  "\u26c8\ufe0f": [
+    "cloud_with_lightning_and_rain",
+    "thunder_cloud_and_rain"
+  ],
+  "\u26ce": [
+    "ophiuchus",
+    "ophiuchus"
+  ],
+  "\u26cf": [
+    "pick"
+  ],
+  "\u26cf\ufe0f": [
+    "pick"
+  ],
+  "\u26d1": [
+    "rescue_worker\u2019s_helmet",
+    "helmet_with_white_cross",
+    "rescue_worker_helmet",
+    "rescue_workers_helmet"
+  ],
+  "\u26d1\ufe0f": [
+    "rescue_worker\u2019s_helmet",
+    "helmet_with_white_cross",
+    "rescue_worker_helmet",
+    "rescue_workers_helmet"
+  ],
+  "\u26d3": [
+    "chains"
+  ],
+  "\u26d3\u200d\ud83d\udca5": [
+    "broken_chain"
+  ],
+  "\u26d3\ufe0f": [
+    "chains"
+  ],
+  "\u26d3\ufe0f\u200d\ud83d\udca5": [
+    "broken_chain"
+  ],
+  "\u26d4": [
+    "no_entry"
+  ],
+  "\u26e9": [
+    "shinto_shrine"
+  ],
+  "\u26e9\ufe0f": [
+    "shinto_shrine"
+  ],
+  "\u26ea": [
+    "church"
+  ],
+  "\u26f0": [
+    "mountain"
+  ],
+  "\u26f0\ufe0f": [
+    "mountain"
+  ],
+  "\u26f1": [
+    "umbrella_on_ground",
+    "parasol_on_ground"
+  ],
+  "\u26f1\ufe0f": [
+    "umbrella_on_ground",
+    "parasol_on_ground"
+  ],
+  "\u26f2": [
+    "fountain"
+  ],
+  "\u26f3": [
+    "flag_in_hole",
+    "golf"
+  ],
+  "\u26f4": [
+    "ferry"
+  ],
+  "\u26f4\ufe0f": [
+    "ferry"
+  ],
+  "\u26f5": [
+    "sailboat",
+    "boat"
+  ],
+  "\u26f7": [
+    "skier"
+  ],
+  "\u26f7\ufe0f": [
+    "skier"
+  ],
+  "\u26f8": [
+    "ice_skate"
+  ],
+  "\u26f8\ufe0f": [
+    "ice_skate"
+  ],
+  "\u26f9": [
+    "person_bouncing_ball",
+    "bouncing_ball_person",
+    "person_with_ball"
+  ],
+  "\u26f9\u200d\u2640": [
+    "woman_bouncing_ball",
+    "basketball_woman",
+    "bouncing_ball_woman"
+  ],
+  "\u26f9\u200d\u2640\ufe0f": [
+    "woman_bouncing_ball",
+    "basketball_woman",
+    "bouncing_ball_woman"
+  ],
+  "\u26f9\u200d\u2642": [
+    "man_bouncing_ball",
+    "basketball_man",
+    "bouncing_ball_man"
+  ],
+  "\u26f9\u200d\u2642\ufe0f": [
+    "man_bouncing_ball",
+    "basketball_man",
+    "bouncing_ball_man"
+  ],
+  "\u26f9\ufe0f": [
+    "person_bouncing_ball",
+    "bouncing_ball_person",
+    "person_with_ball"
+  ],
+  "\u26f9\ufe0f\u200d\u2640": [
+    "woman_bouncing_ball",
+    "basketball_woman",
+    "bouncing_ball_woman"
+  ],
+  "\u26f9\ufe0f\u200d\u2640\ufe0f": [
+    "woman_bouncing_ball",
+    "basketball_woman",
+    "bouncing_ball_woman"
+  ],
+  "\u26f9\ufe0f\u200d\u2642": [
+    "man_bouncing_ball",
+    "basketball_man",
+    "bouncing_ball_man"
+  ],
+  "\u26f9\ufe0f\u200d\u2642\ufe0f": [
+    "man_bouncing_ball",
+    "basketball_man",
+    "bouncing_ball_man"
+  ],
+  "\u26f9\ud83c\udffb": [
+    "person_bouncing_ball_light_skin_tone"
+  ],
+  "\u26f9\ud83c\udffb\u200d\u2640": [
+    "woman_bouncing_ball_light_skin_tone"
+  ],
+  "\u26f9\ud83c\udffb\u200d\u2640\ufe0f": [
+    "woman_bouncing_ball_light_skin_tone"
+  ],
+  "\u26f9\ud83c\udffb\u200d\u2642": [
+    "man_bouncing_ball_light_skin_tone"
+  ],
+  "\u26f9\ud83c\udffb\u200d\u2642\ufe0f": [
+    "man_bouncing_ball_light_skin_tone"
+  ],
+  "\u26f9\ud83c\udffc": [
+    "person_bouncing_ball_medium-light_skin_tone"
+  ],
+  "\u26f9\ud83c\udffc\u200d\u2640": [
+    "woman_bouncing_ball_medium-light_skin_tone"
+  ],
+  "\u26f9\ud83c\udffc\u200d\u2640\ufe0f": [
+    "woman_bouncing_ball_medium-light_skin_tone"
+  ],
+  "\u26f9\ud83c\udffc\u200d\u2642": [
+    "man_bouncing_ball_medium-light_skin_tone"
+  ],
+  "\u26f9\ud83c\udffc\u200d\u2642\ufe0f": [
+    "man_bouncing_ball_medium-light_skin_tone"
+  ],
+  "\u26f9\ud83c\udffd": [
+    "person_bouncing_ball_medium_skin_tone"
+  ],
+  "\u26f9\ud83c\udffd\u200d\u2640": [
+    "woman_bouncing_ball_medium_skin_tone"
+  ],
+  "\u26f9\ud83c\udffd\u200d\u2640\ufe0f": [
+    "woman_bouncing_ball_medium_skin_tone"
+  ],
+  "\u26f9\ud83c\udffd\u200d\u2642": [
+    "man_bouncing_ball_medium_skin_tone"
+  ],
+  "\u26f9\ud83c\udffd\u200d\u2642\ufe0f": [
+    "man_bouncing_ball_medium_skin_tone"
+  ],
+  "\u26f9\ud83c\udffe": [
+    "person_bouncing_ball_medium-dark_skin_tone"
+  ],
+  "\u26f9\ud83c\udffe\u200d\u2640": [
+    "woman_bouncing_ball_medium-dark_skin_tone"
+  ],
+  "\u26f9\ud83c\udffe\u200d\u2640\ufe0f": [
+    "woman_bouncing_ball_medium-dark_skin_tone"
+  ],
+  "\u26f9\ud83c\udffe\u200d\u2642": [
+    "man_bouncing_ball_medium-dark_skin_tone"
+  ],
+  "\u26f9\ud83c\udffe\u200d\u2642\ufe0f": [
+    "man_bouncing_ball_medium-dark_skin_tone"
+  ],
+  "\u26f9\ud83c\udfff": [
+    "person_bouncing_ball_dark_skin_tone"
+  ],
+  "\u26f9\ud83c\udfff\u200d\u2640": [
+    "woman_bouncing_ball_dark_skin_tone"
+  ],
+  "\u26f9\ud83c\udfff\u200d\u2640\ufe0f": [
+    "woman_bouncing_ball_dark_skin_tone"
+  ],
+  "\u26f9\ud83c\udfff\u200d\u2642": [
+    "man_bouncing_ball_dark_skin_tone"
+  ],
+  "\u26f9\ud83c\udfff\u200d\u2642\ufe0f": [
+    "man_bouncing_ball_dark_skin_tone"
+  ],
+  "\u26fa": [
+    "tent"
+  ],
+  "\u26fd": [
+    "fuel_pump",
+    "fuelpump"
+  ],
+  "\u2702": [
+    "scissors"
+  ],
+  "\u2702\ufe0f": [
+    "scissors"
+  ],
+  "\u2705": [
+    "check_mark_button",
+    "white_check_mark"
+  ],
+  "\u2708": [
+    "airplane"
+  ],
+  "\u2708\ufe0f": [
+    "airplane"
+  ],
+  "\u2709": [
+    "envelope"
+  ],
+  "\u2709\ufe0f": [
+    "envelope"
+  ],
+  "\u270a": [
+    "raised_fist",
+    "fist",
+    "fist_raised"
+  ],
+  "\u270a\ud83c\udffb": [
+    "raised_fist_light_skin_tone"
+  ],
+  "\u270a\ud83c\udffc": [
+    "raised_fist_medium-light_skin_tone"
+  ],
+  "\u270a\ud83c\udffd": [
+    "raised_fist_medium_skin_tone"
+  ],
+  "\u270a\ud83c\udffe": [
+    "raised_fist_medium-dark_skin_tone"
+  ],
+  "\u270a\ud83c\udfff": [
+    "raised_fist_dark_skin_tone"
+  ],
+  "\u270b": [
+    "raised_hand",
+    "hand"
+  ],
+  "\u270b\ud83c\udffb": [
+    "raised_hand_light_skin_tone"
+  ],
+  "\u270b\ud83c\udffc": [
+    "raised_hand_medium-light_skin_tone"
+  ],
+  "\u270b\ud83c\udffd": [
+    "raised_hand_medium_skin_tone"
+  ],
+  "\u270b\ud83c\udffe": [
+    "raised_hand_medium-dark_skin_tone"
+  ],
+  "\u270b\ud83c\udfff": [
+    "raised_hand_dark_skin_tone"
+  ],
+  "\u270c": [
+    "victory_hand",
+    "v"
+  ],
+  "\u270c\ufe0f": [
+    "victory_hand",
+    "v"
+  ],
+  "\u270c\ud83c\udffb": [
+    "victory_hand_light_skin_tone"
+  ],
+  "\u270c\ud83c\udffc": [
+    "victory_hand_medium-light_skin_tone"
+  ],
+  "\u270c\ud83c\udffd": [
+    "victory_hand_medium_skin_tone"
+  ],
+  "\u270c\ud83c\udffe": [
+    "victory_hand_medium-dark_skin_tone"
+  ],
+  "\u270c\ud83c\udfff": [
+    "victory_hand_dark_skin_tone"
+  ],
+  "\u270d": [
+    "writing_hand"
+  ],
+  "\u270d\ufe0f": [
+    "writing_hand"
+  ],
+  "\u270d\ud83c\udffb": [
+    "writing_hand_light_skin_tone"
+  ],
+  "\u270d\ud83c\udffc": [
+    "writing_hand_medium-light_skin_tone"
+  ],
+  "\u270d\ud83c\udffd": [
+    "writing_hand_medium_skin_tone"
+  ],
+  "\u270d\ud83c\udffe": [
+    "writing_hand_medium-dark_skin_tone"
+  ],
+  "\u270d\ud83c\udfff": [
+    "writing_hand_dark_skin_tone"
+  ],
+  "\u270f": [
+    "pencil",
+    "pencil2"
+  ],
+  "\u270f\ufe0f": [
+    "pencil",
+    "pencil2"
+  ],
+  "\u2712": [
+    "black_nib"
+  ],
+  "\u2712\ufe0f": [
+    "black_nib"
+  ],
+  "\u2714": [
+    "check_mark",
+    "heavy_check_mark"
+  ],
+  "\u2714\ufe0f": [
+    "check_mark",
+    "heavy_check_mark"
+  ],
+  "\u2716": [
+    "multiply",
+    "heavy_multiplication_x"
+  ],
+  "\u2716\ufe0f": [
+    "multiply",
+    "heavy_multiplication_x"
+  ],
+  "\u271d": [
+    "latin_cross"
+  ],
+  "\u271d\ufe0f": [
+    "latin_cross"
+  ],
+  "\u2721": [
+    "star_of_david",
+    "star_of_david"
+  ],
+  "\u2721\ufe0f": [
+    "star_of_david",
+    "star_of_david"
+  ],
+  "\u2728": [
+    "sparkles"
+  ],
+  "\u2733": [
+    "eight-spoked_asterisk",
+    "eight_spoked_asterisk"
+  ],
+  "\u2733\ufe0f": [
+    "eight-spoked_asterisk",
+    "eight_spoked_asterisk"
+  ],
+  "\u2734": [
+    "eight-pointed_star",
+    "eight_pointed_black_star",
+    "eight_pointed_star"
+  ],
+  "\u2734\ufe0f": [
+    "eight-pointed_star",
+    "eight_pointed_black_star",
+    "eight_pointed_star"
+  ],
+  "\u2744": [
+    "snowflake"
+  ],
+  "\u2744\ufe0f": [
+    "snowflake"
+  ],
+  "\u2747": [
+    "sparkle"
+  ],
+  "\u2747\ufe0f": [
+    "sparkle"
+  ],
+  "\u274c": [
+    "cross_mark",
+    "x"
+  ],
+  "\u274e": [
+    "cross_mark_button",
+    "negative_squared_cross_mark"
+  ],
+  "\u2753": [
+    "red_question_mark",
+    "question"
+  ],
+  "\u2754": [
+    "white_question_mark",
+    "grey_question"
+  ],
+  "\u2755": [
+    "white_exclamation_mark",
+    "grey_exclamation"
+  ],
+  "\u2757": [
+    "red_exclamation_mark",
+    "heavy_exclamation_mark",
+    "exclamation"
+  ],
+  "\u2763": [
+    "heart_exclamation",
+    "heavy_heart_exclamation",
+    "heavy_heart_exclamation_mark_ornament"
+  ],
+  "\u2763\ufe0f": [
+    "heart_exclamation",
+    "heavy_heart_exclamation",
+    "heavy_heart_exclamation_mark_ornament"
+  ],
+  "\u2764": [
+    "red_heart",
+    "heart"
+  ],
+  "\u2764\u200d\ud83d\udd25": [
+    "heart_on_fire"
+  ],
+  "\u2764\u200d\ud83e\ude79": [
+    "mending_heart"
+  ],
+  "\u2764\ufe0f": [
+    "red_heart",
+    "heart"
+  ],
+  "\u2764\ufe0f\u200d\ud83d\udd25": [
+    "heart_on_fire"
+  ],
+  "\u2764\ufe0f\u200d\ud83e\ude79": [
+    "mending_heart"
+  ],
+  "\u2795": [
+    "plus",
+    "heavy_plus_sign"
+  ],
+  "\u2796": [
+    "minus",
+    "heavy_minus_sign"
+  ],
+  "\u2797": [
+    "divide",
+    "heavy_division_sign"
+  ],
+  "\u27a1": [
+    "right_arrow",
+    "arrow_right"
+  ],
+  "\u27a1\ufe0f": [
+    "right_arrow",
+    "arrow_right"
+  ],
+  "\u27b0": [
+    "curly_loop"
+  ],
+  "\u27bf": [
+    "double_curly_loop",
+    "loop"
+  ],
+  "\u2934": [
+    "right_arrow_curving_up",
+    "arrow_heading_up"
+  ],
+  "\u2934\ufe0f": [
+    "right_arrow_curving_up",
+    "arrow_heading_up"
+  ],
+  "\u2935": [
+    "right_arrow_curving_down",
+    "arrow_heading_down"
+  ],
+  "\u2935\ufe0f": [
+    "right_arrow_curving_down",
+    "arrow_heading_down"
+  ],
+  "\u2b05": [
+    "left_arrow",
+    "arrow_left"
+  ],
+  "\u2b05\ufe0f": [
+    "left_arrow",
+    "arrow_left"
+  ],
+  "\u2b06": [
+    "up_arrow",
+    "arrow_up"
+  ],
+  "\u2b06\ufe0f": [
+    "up_arrow",
+    "arrow_up"
+  ],
+  "\u2b07": [
+    "down_arrow",
+    "arrow_down"
+  ],
+  "\u2b07\ufe0f": [
+    "down_arrow",
+    "arrow_down"
+  ],
+  "\u2b1b": [
+    "black_large_square"
+  ],
+  "\u2b1c": [
+    "white_large_square"
+  ],
+  "\u2b50": [
+    "star"
+  ],
+  "\u2b55": [
+    "hollow_red_circle",
+    "o"
+  ],
+  "\u3030": [
+    "wavy_dash"
+  ],
+  "\u3030\ufe0f": [
+    "wavy_dash"
+  ],
+  "\u303d": [
+    "part_alternation_mark"
+  ],
+  "\u303d\ufe0f": [
+    "part_alternation_mark"
+  ],
+  "\u3297": [
+    "japanese_congratulations_button",
+    "congratulations",
+    "japanese_congratulations_button"
+  ],
+  "\u3297\ufe0f": [
+    "japanese_congratulations_button",
+    "congratulations",
+    "japanese_congratulations_button"
+  ],
+  "\u3299": [
+    "japanese_secret_button",
+    "secret",
+    "japanese_secret_button"
+  ],
+  "\u3299\ufe0f": [
+    "japanese_secret_button",
+    "secret",
+    "japanese_secret_button"
+  ],
+  "\ud83c\udc04": [
+    "mahjong_red_dragon",
+    "mahjong"
+  ],
+  "\ud83c\udccf": [
+    "joker",
+    "black_joker"
+  ],
+  "\ud83c\udd70": [
+    "a_button_(blood_type)",
+    "a",
+    "a_button_blood_type"
+  ],
+  "\ud83c\udd70\ufe0f": [
+    "a_button_(blood_type)",
+    "a",
+    "a_button_blood_type"
+  ],
+  "\ud83c\udd71": [
+    "b_button_(blood_type)",
+    "b",
+    "b_button_blood_type"
+  ],
+  "\ud83c\udd71\ufe0f": [
+    "b_button_(blood_type)",
+    "b",
+    "b_button_blood_type"
+  ],
+  "\ud83c\udd7e": [
+    "o_button_(blood_type)",
+    "o2",
+    "o_button_blood_type"
+  ],
+  "\ud83c\udd7e\ufe0f": [
+    "o_button_(blood_type)",
+    "o2",
+    "o_button_blood_type"
+  ],
+  "\ud83c\udd7f": [
+    "p_button",
+    "parking",
+    "p_button"
+  ],
+  "\ud83c\udd7f\ufe0f": [
+    "p_button",
+    "parking",
+    "p_button"
+  ],
+  "\ud83c\udd8e": [
+    "ab_button_(blood_type)",
+    "ab",
+    "ab_button_blood_type"
+  ],
+  "\ud83c\udd91": [
+    "cl_button",
+    "cl",
+    "cl_button"
+  ],
+  "\ud83c\udd92": [
+    "cool_button",
+    "cool",
+    "cool_button"
+  ],
+  "\ud83c\udd93": [
+    "free_button",
+    "free",
+    "free_button"
+  ],
+  "\ud83c\udd94": [
+    "id_button",
+    "id",
+    "id_button"
+  ],
+  "\ud83c\udd95": [
+    "new_button",
+    "new",
+    "new_button"
+  ],
+  "\ud83c\udd96": [
+    "ng_button",
+    "ng",
+    "ng_button"
+  ],
+  "\ud83c\udd97": [
+    "ok_button",
+    "ok",
+    "ok_button"
+  ],
+  "\ud83c\udd98": [
+    "sos_button",
+    "sos",
+    "sos_button"
+  ],
+  "\ud83c\udd99": [
+    "up!_button",
+    "up",
+    "up_button"
+  ],
+  "\ud83c\udd9a": [
+    "vs_button",
+    "vs",
+    "vs_button"
+  ],
+  "\ud83c\udde6\ud83c\udde8": [
+    "ascension_island",
+    "flag_for_Ascension_Island"
+  ],
+  "\ud83c\udde6\ud83c\udde9": [
+    "andorra",
+    "flag_for_Andorra"
+  ],
+  "\ud83c\udde6\ud83c\uddea": [
+    "united_arab_emirates",
+    "flag_for_United_Arab_Emirates"
+  ],
+  "\ud83c\udde6\ud83c\uddeb": [
+    "afghanistan",
+    "flag_for_Afghanistan"
+  ],
+  "\ud83c\udde6\ud83c\uddec": [
+    "antigua_&_barbuda",
+    "flag_for_Antigua_&_Barbuda"
+  ],
+  "\ud83c\udde6\ud83c\uddee": [
+    "anguilla",
+    "flag_for_Anguilla"
+  ],
+  "\ud83c\udde6\ud83c\uddf1": [
+    "albania",
+    "flag_for_Albania"
+  ],
+  "\ud83c\udde6\ud83c\uddf2": [
+    "armenia",
+    "flag_for_Armenia"
+  ],
+  "\ud83c\udde6\ud83c\uddf4": [
+    "angola",
+    "flag_for_Angola"
+  ],
+  "\ud83c\udde6\ud83c\uddf6": [
+    "antarctica",
+    "flag_for_Antarctica"
+  ],
+  "\ud83c\udde6\ud83c\uddf7": [
+    "argentina",
+    "flag_for_Argentina"
+  ],
+  "\ud83c\udde6\ud83c\uddf8": [
+    "american_samoa",
+    "flag_for_American_Samoa"
+  ],
+  "\ud83c\udde6\ud83c\uddf9": [
+    "austria",
+    "flag_for_Austria"
+  ],
+  "\ud83c\udde6\ud83c\uddfa": [
+    "australia",
+    "flag_for_Australia"
+  ],
+  "\ud83c\udde6\ud83c\uddfc": [
+    "aruba",
+    "flag_for_Aruba"
+  ],
+  "\ud83c\udde6\ud83c\uddfd": [
+    "\u00e5land_islands",
+    "flag_for_\u00c5land_Islands"
+  ],
+  "\ud83c\udde6\ud83c\uddff": [
+    "azerbaijan",
+    "flag_for_Azerbaijan"
+  ],
+  "\ud83c\udde7\ud83c\udde6": [
+    "bosnia_&_herzegovina",
+    "flag_for_Bosnia_&_Herzegovina"
+  ],
+  "\ud83c\udde7\ud83c\udde7": [
+    "barbados",
+    "flag_for_Barbados"
+  ],
+  "\ud83c\udde7\ud83c\udde9": [
+    "bangladesh",
+    "flag_for_Bangladesh"
+  ],
+  "\ud83c\udde7\ud83c\uddea": [
+    "belgium",
+    "flag_for_Belgium"
+  ],
+  "\ud83c\udde7\ud83c\uddeb": [
+    "burkina_faso",
+    "flag_for_Burkina_Faso"
+  ],
+  "\ud83c\udde7\ud83c\uddec": [
+    "bulgaria",
+    "flag_for_Bulgaria"
+  ],
+  "\ud83c\udde7\ud83c\udded": [
+    "bahrain",
+    "flag_for_Bahrain"
+  ],
+  "\ud83c\udde7\ud83c\uddee": [
+    "burundi",
+    "flag_for_Burundi"
+  ],
+  "\ud83c\udde7\ud83c\uddef": [
+    "benin",
+    "flag_for_Benin"
+  ],
+  "\ud83c\udde7\ud83c\uddf1": [
+    "st._barth\u00e9lemy",
+    "flag_for_St._Barth\u00e9lemy"
+  ],
+  "\ud83c\udde7\ud83c\uddf2": [
+    "bermuda",
+    "flag_for_Bermuda"
+  ],
+  "\ud83c\udde7\ud83c\uddf3": [
+    "brunei",
+    "flag_for_Brunei"
+  ],
+  "\ud83c\udde7\ud83c\uddf4": [
+    "bolivia",
+    "flag_for_Bolivia"
+  ],
+  "\ud83c\udde7\ud83c\uddf6": [
+    "caribbean_netherlands",
+    "flag_for_Caribbean_Netherlands"
+  ],
+  "\ud83c\udde7\ud83c\uddf7": [
+    "brazil",
+    "flag_for_Brazil"
+  ],
+  "\ud83c\udde7\ud83c\uddf8": [
+    "bahamas",
+    "flag_for_Bahamas"
+  ],
+  "\ud83c\udde7\ud83c\uddf9": [
+    "bhutan",
+    "flag_for_Bhutan"
+  ],
+  "\ud83c\udde7\ud83c\uddfb": [
+    "bouvet_island",
+    "flag_for_Bouvet_Island"
+  ],
+  "\ud83c\udde7\ud83c\uddfc": [
+    "botswana",
+    "flag_for_Botswana"
+  ],
+  "\ud83c\udde7\ud83c\uddfe": [
+    "belarus",
+    "flag_for_Belarus"
+  ],
+  "\ud83c\udde7\ud83c\uddff": [
+    "belize",
+    "flag_for_Belize"
+  ],
+  "\ud83c\udde8\ud83c\udde6": [
+    "canada",
+    "flag_for_Canada"
+  ],
+  "\ud83c\udde8\ud83c\udde8": [
+    "cocos_(keeling)_islands",
+    "flag_for_Cocos_Islands"
+  ],
+  "\ud83c\udde8\ud83c\udde9": [
+    "congo-kinshasa",
+    "flag_for_Congo_Kinshasa"
+  ],
+  "\ud83c\udde8\ud83c\uddeb": [
+    "central_african_republic",
+    "flag_for_Central_African_Republic"
+  ],
+  "\ud83c\udde8\ud83c\uddec": [
+    "congo-brazzaville",
+    "flag_for_Congo_Brazzaville"
+  ],
+  "\ud83c\udde8\ud83c\udded": [
+    "switzerland",
+    "flag_for_Switzerland"
+  ],
+  "\ud83c\udde8\ud83c\uddee": [
+    "c\u00f4te_d\u2019ivoire",
+    "flag_for_C\u00f4te_d\u2019Ivoire"
+  ],
+  "\ud83c\udde8\ud83c\uddf0": [
+    "cook_islands",
+    "flag_for_Cook_Islands"
+  ],
+  "\ud83c\udde8\ud83c\uddf1": [
+    "chile",
+    "flag_for_Chile"
+  ],
+  "\ud83c\udde8\ud83c\uddf2": [
+    "cameroon",
+    "flag_for_Cameroon"
+  ],
+  "\ud83c\udde8\ud83c\uddf3": [
+    "china",
+    "flag_for_China"
+  ],
+  "\ud83c\udde8\ud83c\uddf4": [
+    "colombia",
+    "flag_for_Colombia"
+  ],
+  "\ud83c\udde8\ud83c\uddf5": [
+    "clipperton_island",
+    "flag_for_Clipperton_Island"
+  ],
+  "\ud83c\udde8\ud83c\uddf7": [
+    "costa_rica",
+    "flag_for_Costa_Rica"
+  ],
+  "\ud83c\udde8\ud83c\uddfa": [
+    "cuba",
+    "flag_for_Cuba"
+  ],
+  "\ud83c\udde8\ud83c\uddfb": [
+    "cape_verde",
+    "flag_for_Cape_Verde"
+  ],
+  "\ud83c\udde8\ud83c\uddfc": [
+    "cura\u00e7ao",
+    "flag_for_Cura\u00e7ao"
+  ],
+  "\ud83c\udde8\ud83c\uddfd": [
+    "christmas_island",
+    "flag_for_Christmas_Island"
+  ],
+  "\ud83c\udde8\ud83c\uddfe": [
+    "cyprus",
+    "flag_for_Cyprus"
+  ],
+  "\ud83c\udde8\ud83c\uddff": [
+    "czechia",
+    "flag_for_Czech_Republic"
+  ],
+  "\ud83c\udde9\ud83c\uddea": [
+    "germany",
+    "flag_for_Germany"
+  ],
+  "\ud83c\udde9\ud83c\uddec": [
+    "diego_garcia",
+    "flag_for_Diego_Garcia"
+  ],
+  "\ud83c\udde9\ud83c\uddef": [
+    "djibouti",
+    "flag_for_Djibouti"
+  ],
+  "\ud83c\udde9\ud83c\uddf0": [
+    "denmark",
+    "flag_for_Denmark"
+  ],
+  "\ud83c\udde9\ud83c\uddf2": [
+    "dominica",
+    "flag_for_Dominica"
+  ],
+  "\ud83c\udde9\ud83c\uddf4": [
+    "dominican_republic",
+    "flag_for_Dominican_Republic"
+  ],
+  "\ud83c\udde9\ud83c\uddff": [
+    "algeria",
+    "flag_for_Algeria"
+  ],
+  "\ud83c\uddea\ud83c\udde6": [
+    "ceuta_&_melilla",
+    "flag_for_Ceuta_&_Melilla"
+  ],
+  "\ud83c\uddea\ud83c\udde8": [
+    "ecuador",
+    "flag_for_Ecuador"
+  ],
+  "\ud83c\uddea\ud83c\uddea": [
+    "estonia",
+    "flag_for_Estonia"
+  ],
+  "\ud83c\uddea\ud83c\uddec": [
+    "egypt",
+    "flag_for_Egypt"
+  ],
+  "\ud83c\uddea\ud83c\udded": [
+    "western_sahara",
+    "flag_for_Western_Sahara"
+  ],
+  "\ud83c\uddea\ud83c\uddf7": [
+    "eritrea",
+    "flag_for_Eritrea"
+  ],
+  "\ud83c\uddea\ud83c\uddf8": [
+    "spain",
+    "flag_for_Spain"
+  ],
+  "\ud83c\uddea\ud83c\uddf9": [
+    "ethiopia",
+    "flag_for_Ethiopia"
+  ],
+  "\ud83c\uddea\ud83c\uddfa": [
+    "european_union",
+    "flag_for_European_Union"
+  ],
+  "\ud83c\uddeb\ud83c\uddee": [
+    "finland",
+    "flag_for_Finland"
+  ],
+  "\ud83c\uddeb\ud83c\uddef": [
+    "fiji",
+    "flag_for_Fiji"
+  ],
+  "\ud83c\uddeb\ud83c\uddf0": [
+    "falkland_islands",
+    "flag_for_Falkland_Islands"
+  ],
+  "\ud83c\uddeb\ud83c\uddf2": [
+    "micronesia",
+    "flag_for_Micronesia"
+  ],
+  "\ud83c\uddeb\ud83c\uddf4": [
+    "faroe_islands",
+    "flag_for_Faroe_Islands"
+  ],
+  "\ud83c\uddeb\ud83c\uddf7": [
+    "france",
+    "flag_for_France"
+  ],
+  "\ud83c\uddec\ud83c\udde6": [
+    "gabon",
+    "flag_for_Gabon"
+  ],
+  "\ud83c\uddec\ud83c\udde7": [
+    "united_kingdom",
+    "flag_for_United_Kingdom"
+  ],
+  "\ud83c\uddec\ud83c\udde9": [
+    "grenada",
+    "flag_for_Grenada"
+  ],
+  "\ud83c\uddec\ud83c\uddea": [
+    "georgia",
+    "flag_for_Georgia"
+  ],
+  "\ud83c\uddec\ud83c\uddeb": [
+    "french_guiana",
+    "flag_for_French_Guiana"
+  ],
+  "\ud83c\uddec\ud83c\uddec": [
+    "guernsey",
+    "flag_for_Guernsey"
+  ],
+  "\ud83c\uddec\ud83c\udded": [
+    "ghana",
+    "flag_for_Ghana"
+  ],
+  "\ud83c\uddec\ud83c\uddee": [
+    "gibraltar",
+    "flag_for_Gibraltar"
+  ],
+  "\ud83c\uddec\ud83c\uddf1": [
+    "greenland",
+    "flag_for_Greenland"
+  ],
+  "\ud83c\uddec\ud83c\uddf2": [
+    "gambia",
+    "flag_for_Gambia"
+  ],
+  "\ud83c\uddec\ud83c\uddf3": [
+    "guinea",
+    "flag_for_Guinea"
+  ],
+  "\ud83c\uddec\ud83c\uddf5": [
+    "guadeloupe",
+    "flag_for_Guadeloupe"
+  ],
+  "\ud83c\uddec\ud83c\uddf6": [
+    "equatorial_guinea",
+    "flag_for_Equatorial_Guinea"
+  ],
+  "\ud83c\uddec\ud83c\uddf7": [
+    "greece",
+    "flag_for_Greece"
+  ],
+  "\ud83c\uddec\ud83c\uddf8": [
+    "south_georgia_&_south_sandwich_islands",
+    "flag_for_South_Georgia_&_South_Sandwich_Islands"
+  ],
+  "\ud83c\uddec\ud83c\uddf9": [
+    "guatemala",
+    "flag_for_Guatemala"
+  ],
+  "\ud83c\uddec\ud83c\uddfa": [
+    "guam",
+    "flag_for_Guam"
+  ],
+  "\ud83c\uddec\ud83c\uddfc": [
+    "guinea-bissau",
+    "flag_for_Guinea_Bissau"
+  ],
+  "\ud83c\uddec\ud83c\uddfe": [
+    "guyana",
+    "flag_for_Guyana"
+  ],
+  "\ud83c\udded\ud83c\uddf0": [
+    "hong_kong_sar_china",
+    "flag_for_Hong_Kong"
+  ],
+  "\ud83c\udded\ud83c\uddf2": [
+    "heard_&_mcdonald_islands",
+    "flag_for_Heard_&_McDonald_Islands"
+  ],
+  "\ud83c\udded\ud83c\uddf3": [
+    "honduras",
+    "flag_for_Honduras"
+  ],
+  "\ud83c\udded\ud83c\uddf7": [
+    "croatia",
+    "flag_for_Croatia"
+  ],
+  "\ud83c\udded\ud83c\uddf9": [
+    "haiti",
+    "flag_for_Haiti"
+  ],
+  "\ud83c\udded\ud83c\uddfa": [
+    "hungary",
+    "flag_for_Hungary"
+  ],
+  "\ud83c\uddee\ud83c\udde8": [
+    "canary_islands",
+    "flag_for_Canary_Islands"
+  ],
+  "\ud83c\uddee\ud83c\udde9": [
+    "indonesia",
+    "flag_for_Indonesia"
+  ],
+  "\ud83c\uddee\ud83c\uddea": [
+    "ireland",
+    "flag_for_Ireland"
+  ],
+  "\ud83c\uddee\ud83c\uddf1": [
+    "israel",
+    "flag_for_Israel"
+  ],
+  "\ud83c\uddee\ud83c\uddf2": [
+    "isle_of_man",
+    "flag_for_Isle_of_Man"
+  ],
+  "\ud83c\uddee\ud83c\uddf3": [
+    "india",
+    "flag_for_India"
+  ],
+  "\ud83c\uddee\ud83c\uddf4": [
+    "british_indian_ocean_territory",
+    "flag_for_British_Indian_Ocean_Territory"
+  ],
+  "\ud83c\uddee\ud83c\uddf6": [
+    "iraq",
+    "flag_for_Iraq"
+  ],
+  "\ud83c\uddee\ud83c\uddf7": [
+    "iran",
+    "flag_for_Iran"
+  ],
+  "\ud83c\uddee\ud83c\uddf8": [
+    "iceland",
+    "flag_for_Iceland"
+  ],
+  "\ud83c\uddee\ud83c\uddf9": [
+    "italy",
+    "flag_for_Italy"
+  ],
+  "\ud83c\uddef\ud83c\uddea": [
+    "jersey",
+    "flag_for_Jersey"
+  ],
+  "\ud83c\uddef\ud83c\uddf2": [
+    "jamaica",
+    "flag_for_Jamaica"
+  ],
+  "\ud83c\uddef\ud83c\uddf4": [
+    "jordan",
+    "flag_for_Jordan"
+  ],
+  "\ud83c\uddef\ud83c\uddf5": [
+    "japan",
+    "flag_for_Japan"
+  ],
+  "\ud83c\uddf0\ud83c\uddea": [
+    "kenya",
+    "flag_for_Kenya"
+  ],
+  "\ud83c\uddf0\ud83c\uddec": [
+    "kyrgyzstan",
+    "flag_for_Kyrgyzstan"
+  ],
+  "\ud83c\uddf0\ud83c\udded": [
+    "cambodia",
+    "flag_for_Cambodia"
+  ],
+  "\ud83c\uddf0\ud83c\uddee": [
+    "kiribati",
+    "flag_for_Kiribati"
+  ],
+  "\ud83c\uddf0\ud83c\uddf2": [
+    "comoros",
+    "flag_for_Comoros"
+  ],
+  "\ud83c\uddf0\ud83c\uddf3": [
+    "st._kitts_&_nevis",
+    "flag_for_St._Kitts_&_Nevis"
+  ],
+  "\ud83c\uddf0\ud83c\uddf5": [
+    "north_korea",
+    "flag_for_North_Korea"
+  ],
+  "\ud83c\uddf0\ud83c\uddf7": [
+    "south_korea",
+    "flag_for_South_Korea"
+  ],
+  "\ud83c\uddf0\ud83c\uddfc": [
+    "kuwait",
+    "flag_for_Kuwait"
+  ],
+  "\ud83c\uddf0\ud83c\uddfe": [
+    "cayman_islands",
+    "flag_for_Cayman_Islands"
+  ],
+  "\ud83c\uddf0\ud83c\uddff": [
+    "kazakhstan",
+    "flag_for_Kazakhstan"
+  ],
+  "\ud83c\uddf1\ud83c\udde6": [
+    "laos",
+    "flag_for_Laos"
+  ],
+  "\ud83c\uddf1\ud83c\udde7": [
+    "lebanon",
+    "flag_for_Lebanon"
+  ],
+  "\ud83c\uddf1\ud83c\udde8": [
+    "st._lucia",
+    "flag_for_St._Lucia"
+  ],
+  "\ud83c\uddf1\ud83c\uddee": [
+    "liechtenstein",
+    "flag_for_Liechtenstein"
+  ],
+  "\ud83c\uddf1\ud83c\uddf0": [
+    "sri_lanka",
+    "flag_for_Sri_Lanka"
+  ],
+  "\ud83c\uddf1\ud83c\uddf7": [
+    "liberia",
+    "flag_for_Liberia"
+  ],
+  "\ud83c\uddf1\ud83c\uddf8": [
+    "lesotho",
+    "flag_for_Lesotho"
+  ],
+  "\ud83c\uddf1\ud83c\uddf9": [
+    "lithuania",
+    "flag_for_Lithuania"
+  ],
+  "\ud83c\uddf1\ud83c\uddfa": [
+    "luxembourg",
+    "flag_for_Luxembourg"
+  ],
+  "\ud83c\uddf1\ud83c\uddfb": [
+    "latvia",
+    "flag_for_Latvia"
+  ],
+  "\ud83c\uddf1\ud83c\uddfe": [
+    "libya",
+    "flag_for_Libya"
+  ],
+  "\ud83c\uddf2\ud83c\udde6": [
+    "morocco",
+    "flag_for_Morocco"
+  ],
+  "\ud83c\uddf2\ud83c\udde8": [
+    "monaco",
+    "flag_for_Monaco"
+  ],
+  "\ud83c\uddf2\ud83c\udde9": [
+    "moldova",
+    "flag_for_Moldova"
+  ],
+  "\ud83c\uddf2\ud83c\uddea": [
+    "montenegro",
+    "flag_for_Montenegro"
+  ],
+  "\ud83c\uddf2\ud83c\uddeb": [
+    "st._martin",
+    "flag_for_St._Martin"
+  ],
+  "\ud83c\uddf2\ud83c\uddec": [
+    "madagascar",
+    "flag_for_Madagascar"
+  ],
+  "\ud83c\uddf2\ud83c\udded": [
+    "marshall_islands",
+    "flag_for_Marshall_Islands"
+  ],
+  "\ud83c\uddf2\ud83c\uddf0": [
+    "north_macedonia",
+    "flag_for_Macedonia"
+  ],
+  "\ud83c\uddf2\ud83c\uddf1": [
+    "mali",
+    "flag_for_Mali"
+  ],
+  "\ud83c\uddf2\ud83c\uddf2": [
+    "myanmar_(burma)",
+    "flag_for_Myanmar"
+  ],
+  "\ud83c\uddf2\ud83c\uddf3": [
+    "mongolia",
+    "flag_for_Mongolia"
+  ],
+  "\ud83c\uddf2\ud83c\uddf4": [
+    "macao_sar_china",
+    "flag_for_Macau"
+  ],
+  "\ud83c\uddf2\ud83c\uddf5": [
+    "northern_mariana_islands",
+    "flag_for_Northern_Mariana_Islands"
+  ],
+  "\ud83c\uddf2\ud83c\uddf6": [
+    "martinique",
+    "flag_for_Martinique"
+  ],
+  "\ud83c\uddf2\ud83c\uddf7": [
+    "mauritania",
+    "flag_for_Mauritania"
+  ],
+  "\ud83c\uddf2\ud83c\uddf8": [
+    "montserrat",
+    "flag_for_Montserrat"
+  ],
+  "\ud83c\uddf2\ud83c\uddf9": [
+    "malta",
+    "flag_for_Malta"
+  ],
+  "\ud83c\uddf2\ud83c\uddfa": [
+    "mauritius",
+    "flag_for_Mauritius"
+  ],
+  "\ud83c\uddf2\ud83c\uddfb": [
+    "maldives",
+    "flag_for_Maldives"
+  ],
+  "\ud83c\uddf2\ud83c\uddfc": [
+    "malawi",
+    "flag_for_Malawi"
+  ],
+  "\ud83c\uddf2\ud83c\uddfd": [
+    "mexico",
+    "flag_for_Mexico"
+  ],
+  "\ud83c\uddf2\ud83c\uddfe": [
+    "malaysia",
+    "flag_for_Malaysia"
+  ],
+  "\ud83c\uddf2\ud83c\uddff": [
+    "mozambique",
+    "flag_for_Mozambique"
+  ],
+  "\ud83c\uddf3\ud83c\udde6": [
+    "namibia",
+    "flag_for_Namibia"
+  ],
+  "\ud83c\uddf3\ud83c\udde8": [
+    "new_caledonia",
+    "flag_for_New_Caledonia"
+  ],
+  "\ud83c\uddf3\ud83c\uddea": [
+    "niger",
+    "flag_for_Niger"
+  ],
+  "\ud83c\uddf3\ud83c\uddeb": [
+    "norfolk_island",
+    "flag_for_Norfolk_Island"
+  ],
+  "\ud83c\uddf3\ud83c\uddec": [
+    "nigeria",
+    "flag_for_Nigeria"
+  ],
+  "\ud83c\uddf3\ud83c\uddee": [
+    "nicaragua",
+    "flag_for_Nicaragua"
+  ],
+  "\ud83c\uddf3\ud83c\uddf1": [
+    "netherlands",
+    "flag_for_Netherlands"
+  ],
+  "\ud83c\uddf3\ud83c\uddf4": [
+    "norway",
+    "flag_for_Norway"
+  ],
+  "\ud83c\uddf3\ud83c\uddf5": [
+    "nepal",
+    "flag_for_Nepal"
+  ],
+  "\ud83c\uddf3\ud83c\uddf7": [
+    "nauru",
+    "flag_for_Nauru"
+  ],
+  "\ud83c\uddf3\ud83c\uddfa": [
+    "niue",
+    "flag_for_Niue"
+  ],
+  "\ud83c\uddf3\ud83c\uddff": [
+    "new_zealand",
+    "flag_for_New_Zealand"
+  ],
+  "\ud83c\uddf4\ud83c\uddf2": [
+    "oman",
+    "flag_for_Oman"
+  ],
+  "\ud83c\uddf5\ud83c\udde6": [
+    "panama",
+    "flag_for_Panama"
+  ],
+  "\ud83c\uddf5\ud83c\uddea": [
+    "peru",
+    "flag_for_Peru"
+  ],
+  "\ud83c\uddf5\ud83c\uddeb": [
+    "french_polynesia",
+    "flag_for_French_Polynesia"
+  ],
+  "\ud83c\uddf5\ud83c\uddec": [
+    "papua_new_guinea",
+    "flag_for_Papua_New_Guinea"
+  ],
+  "\ud83c\uddf5\ud83c\udded": [
+    "philippines",
+    "flag_for_Philippines"
+  ],
+  "\ud83c\uddf5\ud83c\uddf0": [
+    "pakistan",
+    "flag_for_Pakistan"
+  ],
+  "\ud83c\uddf5\ud83c\uddf1": [
+    "poland",
+    "flag_for_Poland"
+  ],
+  "\ud83c\uddf5\ud83c\uddf2": [
+    "st._pierre_&_miquelon",
+    "flag_for_St._Pierre_&_Miquelon"
+  ],
+  "\ud83c\uddf5\ud83c\uddf3": [
+    "pitcairn_islands",
+    "flag_for_Pitcairn_Islands"
+  ],
+  "\ud83c\uddf5\ud83c\uddf7": [
+    "puerto_rico",
+    "flag_for_Puerto_Rico"
+  ],
+  "\ud83c\uddf5\ud83c\uddf8": [
+    "palestinian_territories",
+    "flag_for_Palestinian_Territories"
+  ],
+  "\ud83c\uddf5\ud83c\uddf9": [
+    "portugal",
+    "flag_for_Portugal"
+  ],
+  "\ud83c\uddf5\ud83c\uddfc": [
+    "palau",
+    "flag_for_Palau"
+  ],
+  "\ud83c\uddf5\ud83c\uddfe": [
+    "paraguay",
+    "flag_for_Paraguay"
+  ],
+  "\ud83c\uddf6\ud83c\udde6": [
+    "qatar",
+    "flag_for_Qatar"
+  ],
+  "\ud83c\uddf7\ud83c\uddea": [
+    "r\u00e9union",
+    "flag_for_R\u00e9union"
+  ],
+  "\ud83c\uddf7\ud83c\uddf4": [
+    "romania",
+    "flag_for_Romania"
+  ],
+  "\ud83c\uddf7\ud83c\uddf8": [
+    "serbia",
+    "flag_for_Serbia"
+  ],
+  "\ud83c\uddf7\ud83c\uddfa": [
+    "russia",
+    "flag_for_Russia"
+  ],
+  "\ud83c\uddf7\ud83c\uddfc": [
+    "rwanda",
+    "flag_for_Rwanda"
+  ],
+  "\ud83c\uddf8\ud83c\udde6": [
+    "saudi_arabia",
+    "flag_for_Saudi_Arabia"
+  ],
+  "\ud83c\uddf8\ud83c\udde7": [
+    "solomon_islands",
+    "flag_for_Solomon_Islands"
+  ],
+  "\ud83c\uddf8\ud83c\udde8": [
+    "seychelles",
+    "flag_for_Seychelles"
+  ],
+  "\ud83c\uddf8\ud83c\udde9": [
+    "sudan",
+    "flag_for_Sudan"
+  ],
+  "\ud83c\uddf8\ud83c\uddea": [
+    "sweden",
+    "flag_for_Sweden"
+  ],
+  "\ud83c\uddf8\ud83c\uddec": [
+    "singapore",
+    "flag_for_Singapore"
+  ],
+  "\ud83c\uddf8\ud83c\udded": [
+    "st._helena",
+    "flag_for_St._Helena"
+  ],
+  "\ud83c\uddf8\ud83c\uddee": [
+    "slovenia",
+    "flag_for_Slovenia"
+  ],
+  "\ud83c\uddf8\ud83c\uddef": [
+    "svalbard_&_jan_mayen",
+    "flag_for_Svalbard_&_Jan_Mayen"
+  ],
+  "\ud83c\uddf8\ud83c\uddf0": [
+    "slovakia",
+    "flag_for_Slovakia"
+  ],
+  "\ud83c\uddf8\ud83c\uddf1": [
+    "sierra_leone",
+    "flag_for_Sierra_Leone"
+  ],
+  "\ud83c\uddf8\ud83c\uddf2": [
+    "san_marino",
+    "flag_for_San_Marino"
+  ],
+  "\ud83c\uddf8\ud83c\uddf3": [
+    "senegal",
+    "flag_for_Senegal"
+  ],
+  "\ud83c\uddf8\ud83c\uddf4": [
+    "somalia",
+    "flag_for_Somalia"
+  ],
+  "\ud83c\uddf8\ud83c\uddf7": [
+    "suriname",
+    "flag_for_Suriname"
+  ],
+  "\ud83c\uddf8\ud83c\uddf8": [
+    "south_sudan",
+    "flag_for_South_Sudan"
+  ],
+  "\ud83c\uddf8\ud83c\uddf9": [
+    "s\u00e3o_tom\u00e9_&_pr\u00edncipe",
+    "flag_for_S\u00e3o_Tom\u00e9_&_Pr\u00edncipe"
+  ],
+  "\ud83c\uddf8\ud83c\uddfb": [
+    "el_salvador",
+    "flag_for_El_Salvador"
+  ],
+  "\ud83c\uddf8\ud83c\uddfd": [
+    "sint_maarten",
+    "flag_for_Sint_Maarten"
+  ],
+  "\ud83c\uddf8\ud83c\uddfe": [
+    "syria",
+    "flag_for_Syria"
+  ],
+  "\ud83c\uddf8\ud83c\uddff": [
+    "eswatini",
+    "flag_for_Swaziland"
+  ],
+  "\ud83c\uddf9\ud83c\udde6": [
+    "tristan_da_cunha",
+    "flag_for_Tristan_da_Cunha"
+  ],
+  "\ud83c\uddf9\ud83c\udde8": [
+    "turks_&_caicos_islands",
+    "flag_for_Turks_&_Caicos_Islands"
+  ],
+  "\ud83c\uddf9\ud83c\udde9": [
+    "chad",
+    "flag_for_Chad"
+  ],
+  "\ud83c\uddf9\ud83c\uddeb": [
+    "french_southern_territories",
+    "flag_for_French_Southern_Territories"
+  ],
+  "\ud83c\uddf9\ud83c\uddec": [
+    "togo",
+    "flag_for_Togo"
+  ],
+  "\ud83c\uddf9\ud83c\udded": [
+    "thailand",
+    "flag_for_Thailand"
+  ],
+  "\ud83c\uddf9\ud83c\uddef": [
+    "tajikistan",
+    "flag_for_Tajikistan"
+  ],
+  "\ud83c\uddf9\ud83c\uddf0": [
+    "tokelau",
+    "flag_for_Tokelau"
+  ],
+  "\ud83c\uddf9\ud83c\uddf1": [
+    "timor-leste",
+    "flag_for_Timor_Leste"
+  ],
+  "\ud83c\uddf9\ud83c\uddf2": [
+    "turkmenistan",
+    "flag_for_Turkmenistan"
+  ],
+  "\ud83c\uddf9\ud83c\uddf3": [
+    "tunisia",
+    "flag_for_Tunisia"
+  ],
+  "\ud83c\uddf9\ud83c\uddf4": [
+    "tonga",
+    "flag_for_Tonga"
+  ],
+  "\ud83c\uddf9\ud83c\uddf7": [
+    "t\u00fcrkiye",
+    "flag_for_Turkey"
+  ],
+  "\ud83c\uddf9\ud83c\uddf9": [
+    "trinidad_&_tobago",
+    "flag_for_Trinidad_&_Tobago"
+  ],
+  "\ud83c\uddf9\ud83c\uddfb": [
+    "tuvalu",
+    "flag_for_Tuvalu"
+  ],
+  "\ud83c\uddf9\ud83c\uddfc": [
+    "taiwan",
+    "flag_for_Taiwan"
+  ],
+  "\ud83c\uddf9\ud83c\uddff": [
+    "tanzania",
+    "flag_for_Tanzania"
+  ],
+  "\ud83c\uddfa\ud83c\udde6": [
+    "ukraine",
+    "flag_for_Ukraine"
+  ],
+  "\ud83c\uddfa\ud83c\uddec": [
+    "uganda",
+    "flag_for_Uganda"
+  ],
+  "\ud83c\uddfa\ud83c\uddf2": [
+    "u.s._outlying_islands",
+    "flag_for_U.S._Outlying_Islands"
+  ],
+  "\ud83c\uddfa\ud83c\uddf3": [
+    "united_nations",
+    "united_nations"
+  ],
+  "\ud83c\uddfa\ud83c\uddf8": [
+    "united_states",
+    "flag_for_United_States"
+  ],
+  "\ud83c\uddfa\ud83c\uddfe": [
+    "uruguay",
+    "flag_for_Uruguay"
+  ],
+  "\ud83c\uddfa\ud83c\uddff": [
+    "uzbekistan",
+    "flag_for_Uzbekistan"
+  ],
+  "\ud83c\uddfb\ud83c\udde6": [
+    "vatican_city",
+    "flag_for_Vatican_City"
+  ],
+  "\ud83c\uddfb\ud83c\udde8": [
+    "st._vincent_&_grenadines",
+    "flag_for_St._Vincent_&_Grenadines"
+  ],
+  "\ud83c\uddfb\ud83c\uddea": [
+    "venezuela",
+    "flag_for_Venezuela"
+  ],
+  "\ud83c\uddfb\ud83c\uddec": [
+    "british_virgin_islands",
+    "flag_for_British_Virgin_Islands"
+  ],
+  "\ud83c\uddfb\ud83c\uddee": [
+    "u.s._virgin_islands",
+    "flag_for_U.S._Virgin_Islands"
+  ],
+  "\ud83c\uddfb\ud83c\uddf3": [
+    "vietnam",
+    "flag_for_Vietnam"
+  ],
+  "\ud83c\uddfb\ud83c\uddfa": [
+    "vanuatu",
+    "flag_for_Vanuatu"
+  ],
+  "\ud83c\uddfc\ud83c\uddeb": [
+    "wallis_&_futuna",
+    "flag_for_Wallis_&_Futuna"
+  ],
+  "\ud83c\uddfc\ud83c\uddf8": [
+    "samoa",
+    "flag_for_Samoa"
+  ],
+  "\ud83c\uddfd\ud83c\uddf0": [
+    "kosovo",
+    "flag_for_Kosovo"
+  ],
+  "\ud83c\uddfe\ud83c\uddea": [
+    "yemen",
+    "flag_for_Yemen"
+  ],
+  "\ud83c\uddfe\ud83c\uddf9": [
+    "mayotte",
+    "flag_for_Mayotte"
+  ],
+  "\ud83c\uddff\ud83c\udde6": [
+    "south_africa",
+    "flag_for_South_Africa"
+  ],
+  "\ud83c\uddff\ud83c\uddf2": [
+    "zambia",
+    "flag_for_Zambia"
+  ],
+  "\ud83c\uddff\ud83c\uddfc": [
+    "zimbabwe",
+    "flag_for_Zimbabwe"
+  ],
+  "\ud83c\ude01": [
+    "japanese_here_button",
+    "koko",
+    "japanese_here_button"
+  ],
+  "\ud83c\ude02": [
+    "japanese_service_charge_button",
+    "sa",
+    "japanese_service_charge_button"
+  ],
+  "\ud83c\ude02\ufe0f": [
+    "japanese_service_charge_button",
+    "sa",
+    "japanese_service_charge_button"
+  ],
+  "\ud83c\ude1a": [
+    "japanese_free_of_charge_button",
+    "u7121",
+    "japanese_free_of_charge_button"
+  ],
+  "\ud83c\ude2f": [
+    "japanese_reserved_button",
+    "u6307",
+    "japanese_reserved_button"
+  ],
+  "\ud83c\ude32": [
+    "japanese_prohibited_button",
+    "u7981",
+    "japanese_prohibited_button"
+  ],
+  "\ud83c\ude33": [
+    "japanese_vacancy_button",
+    "u7a7a",
+    "japanese_vacancy_button"
+  ],
+  "\ud83c\ude34": [
+    "japanese_passing_grade_button",
+    "u5408",
+    "japanese_passing_grade_button"
+  ],
+  "\ud83c\ude35": [
+    "japanese_no_vacancy_button",
+    "u6e80",
+    "japanese_no_vacancy_button"
+  ],
+  "\ud83c\ude36": [
+    "japanese_not_free_of_charge_button",
+    "u6709",
+    "japanese_not_free_of_charge_button"
+  ],
+  "\ud83c\ude37": [
+    "japanese_monthly_amount_button",
+    "u6708",
+    "japanese_monthly_amount_button"
+  ],
+  "\ud83c\ude37\ufe0f": [
+    "japanese_monthly_amount_button",
+    "u6708",
+    "japanese_monthly_amount_button"
+  ],
+  "\ud83c\ude38": [
+    "japanese_application_button",
+    "u7533",
+    "japanese_application_button"
+  ],
+  "\ud83c\ude39": [
+    "japanese_discount_button",
+    "u5272",
+    "japanese_discount_button"
+  ],
+  "\ud83c\ude3a": [
+    "japanese_open_for_business_button",
+    "u55b6",
+    "japanese_open_for_business_button"
+  ],
+  "\ud83c\ude50": [
+    "japanese_bargain_button",
+    "ideograph_advantage",
+    "japanese_bargain_button"
+  ],
+  "\ud83c\ude51": [
+    "japanese_acceptable_button",
+    "accept",
+    "japanese_acceptable_button"
+  ],
+  "\ud83c\udf00": [
+    "cyclone"
+  ],
+  "\ud83c\udf01": [
+    "foggy"
+  ],
+  "\ud83c\udf02": [
+    "closed_umbrella"
+  ],
+  "\ud83c\udf03": [
+    "night_with_stars"
+  ],
+  "\ud83c\udf04": [
+    "sunrise_over_mountains"
+  ],
+  "\ud83c\udf05": [
+    "sunrise"
+  ],
+  "\ud83c\udf06": [
+    "cityscape_at_dusk",
+    "city_sunset"
+  ],
+  "\ud83c\udf07": [
+    "sunset",
+    "city_sunrise"
+  ],
+  "\ud83c\udf08": [
+    "rainbow"
+  ],
+  "\ud83c\udf09": [
+    "bridge_at_night"
+  ],
+  "\ud83c\udf0a": [
+    "water_wave",
+    "ocean"
+  ],
+  "\ud83c\udf0b": [
+    "volcano"
+  ],
+  "\ud83c\udf0c": [
+    "milky_way"
+  ],
+  "\ud83c\udf0d": [
+    "globe_showing_europe-africa",
+    "earth_africa",
+    "globe_showing_europe_africa"
+  ],
+  "\ud83c\udf0e": [
+    "globe_showing_americas",
+    "earth_americas",
+    "globe_showing_americas"
+  ],
+  "\ud83c\udf0f": [
+    "globe_showing_asia-australia",
+    "earth_asia",
+    "globe_showing_asia_australia"
+  ],
+  "\ud83c\udf10": [
+    "globe_with_meridians"
+  ],
+  "\ud83c\udf11": [
+    "new_moon"
+  ],
+  "\ud83c\udf12": [
+    "waxing_crescent_moon"
+  ],
+  "\ud83c\udf13": [
+    "first_quarter_moon"
+  ],
+  "\ud83c\udf14": [
+    "waxing_gibbous_moon",
+    "moon"
+  ],
+  "\ud83c\udf15": [
+    "full_moon"
+  ],
+  "\ud83c\udf16": [
+    "waning_gibbous_moon"
+  ],
+  "\ud83c\udf17": [
+    "last_quarter_moon"
+  ],
+  "\ud83c\udf18": [
+    "waning_crescent_moon"
+  ],
+  "\ud83c\udf19": [
+    "crescent_moon"
+  ],
+  "\ud83c\udf1a": [
+    "new_moon_face",
+    "new_moon_with_face"
+  ],
+  "\ud83c\udf1b": [
+    "first_quarter_moon_face",
+    "first_quarter_moon_with_face"
+  ],
+  "\ud83c\udf1c": [
+    "last_quarter_moon_face",
+    "last_quarter_moon_with_face"
+  ],
+  "\ud83c\udf1d": [
+    "full_moon_face",
+    "full_moon_with_face"
+  ],
+  "\ud83c\udf1e": [
+    "sun_with_face"
+  ],
+  "\ud83c\udf1f": [
+    "glowing_star",
+    "star2"
+  ],
+  "\ud83c\udf20": [
+    "shooting_star",
+    "stars"
+  ],
+  "\ud83c\udf21": [
+    "thermometer"
+  ],
+  "\ud83c\udf21\ufe0f": [
+    "thermometer"
+  ],
+  "\ud83c\udf24": [
+    "sun_behind_small_cloud",
+    "white_sun_with_small_cloud"
+  ],
+  "\ud83c\udf24\ufe0f": [
+    "sun_behind_small_cloud",
+    "white_sun_with_small_cloud"
+  ],
+  "\ud83c\udf25": [
+    "sun_behind_large_cloud",
+    "white_sun_behind_cloud"
+  ],
+  "\ud83c\udf25\ufe0f": [
+    "sun_behind_large_cloud",
+    "white_sun_behind_cloud"
+  ],
+  "\ud83c\udf26": [
+    "sun_behind_rain_cloud",
+    "white_sun_behind_cloud_with_rain"
+  ],
+  "\ud83c\udf26\ufe0f": [
+    "sun_behind_rain_cloud",
+    "white_sun_behind_cloud_with_rain"
+  ],
+  "\ud83c\udf27": [
+    "cloud_with_rain"
+  ],
+  "\ud83c\udf27\ufe0f": [
+    "cloud_with_rain"
+  ],
+  "\ud83c\udf28": [
+    "cloud_with_snow"
+  ],
+  "\ud83c\udf28\ufe0f": [
+    "cloud_with_snow"
+  ],
+  "\ud83c\udf29": [
+    "cloud_with_lightning"
+  ],
+  "\ud83c\udf29\ufe0f": [
+    "cloud_with_lightning"
+  ],
+  "\ud83c\udf2a": [
+    "tornado",
+    "cloud_with_tornado"
+  ],
+  "\ud83c\udf2a\ufe0f": [
+    "tornado",
+    "cloud_with_tornado"
+  ],
+  "\ud83c\udf2b": [
+    "fog"
+  ],
+  "\ud83c\udf2b\ufe0f": [
+    "fog"
+  ],
+  "\ud83c\udf2c": [
+    "wind_face",
+    "wind_blowing_face"
+  ],
+  "\ud83c\udf2c\ufe0f": [
+    "wind_face",
+    "wind_blowing_face"
+  ],
+  "\ud83c\udf2d": [
+    "hot_dog",
+    "hotdog"
+  ],
+  "\ud83c\udf2e": [
+    "taco"
+  ],
+  "\ud83c\udf2f": [
+    "burrito"
+  ],
+  "\ud83c\udf30": [
+    "chestnut"
+  ],
+  "\ud83c\udf31": [
+    "seedling"
+  ],
+  "\ud83c\udf32": [
+    "evergreen_tree"
+  ],
+  "\ud83c\udf33": [
+    "deciduous_tree"
+  ],
+  "\ud83c\udf34": [
+    "palm_tree"
+  ],
+  "\ud83c\udf35": [
+    "cactus"
+  ],
+  "\ud83c\udf36": [
+    "hot_pepper"
+  ],
+  "\ud83c\udf36\ufe0f": [
+    "hot_pepper"
+  ],
+  "\ud83c\udf37": [
+    "tulip"
+  ],
+  "\ud83c\udf38": [
+    "cherry_blossom"
+  ],
+  "\ud83c\udf39": [
+    "rose"
+  ],
+  "\ud83c\udf3a": [
+    "hibiscus"
+  ],
+  "\ud83c\udf3b": [
+    "sunflower"
+  ],
+  "\ud83c\udf3c": [
+    "blossom"
+  ],
+  "\ud83c\udf3d": [
+    "ear_of_corn",
+    "corn"
+  ],
+  "\ud83c\udf3e": [
+    "sheaf_of_rice",
+    "ear_of_rice"
+  ],
+  "\ud83c\udf3f": [
+    "herb"
+  ],
+  "\ud83c\udf40": [
+    "four_leaf_clover"
+  ],
+  "\ud83c\udf41": [
+    "maple_leaf"
+  ],
+  "\ud83c\udf42": [
+    "fallen_leaf"
+  ],
+  "\ud83c\udf43": [
+    "leaf_fluttering_in_wind",
+    "leaves"
+  ],
+  "\ud83c\udf44": [
+    "mushroom"
+  ],
+  "\ud83c\udf44\u200d\ud83d\udfeb": [
+    "brown_mushroom"
+  ],
+  "\ud83c\udf45": [
+    "tomato"
+  ],
+  "\ud83c\udf46": [
+    "eggplant"
+  ],
+  "\ud83c\udf47": [
+    "grapes"
+  ],
+  "\ud83c\udf48": [
+    "melon"
+  ],
+  "\ud83c\udf49": [
+    "watermelon"
+  ],
+  "\ud83c\udf4a": [
+    "tangerine",
+    "orange",
+    "mandarin"
+  ],
+  "\ud83c\udf4b": [
+    "lemon"
+  ],
+  "\ud83c\udf4b\u200d\ud83d\udfe9": [
+    "lime"
+  ],
+  "\ud83c\udf4c": [
+    "banana"
+  ],
+  "\ud83c\udf4d": [
+    "pineapple"
+  ],
+  "\ud83c\udf4e": [
+    "red_apple",
+    "apple"
+  ],
+  "\ud83c\udf4f": [
+    "green_apple"
+  ],
+  "\ud83c\udf50": [
+    "pear"
+  ],
+  "\ud83c\udf51": [
+    "peach"
+  ],
+  "\ud83c\udf52": [
+    "cherries"
+  ],
+  "\ud83c\udf53": [
+    "strawberry"
+  ],
+  "\ud83c\udf54": [
+    "hamburger"
+  ],
+  "\ud83c\udf55": [
+    "pizza"
+  ],
+  "\ud83c\udf56": [
+    "meat_on_bone"
+  ],
+  "\ud83c\udf57": [
+    "poultry_leg"
+  ],
+  "\ud83c\udf58": [
+    "rice_cracker"
+  ],
+  "\ud83c\udf59": [
+    "rice_ball"
+  ],
+  "\ud83c\udf5a": [
+    "cooked_rice",
+    "rice"
+  ],
+  "\ud83c\udf5b": [
+    "curry_rice",
+    "curry"
+  ],
+  "\ud83c\udf5c": [
+    "steaming_bowl",
+    "ramen"
+  ],
+  "\ud83c\udf5d": [
+    "spaghetti"
+  ],
+  "\ud83c\udf5e": [
+    "bread"
+  ],
+  "\ud83c\udf5f": [
+    "french_fries",
+    "fries"
+  ],
+  "\ud83c\udf60": [
+    "roasted_sweet_potato",
+    "sweet_potato"
+  ],
+  "\ud83c\udf61": [
+    "dango"
+  ],
+  "\ud83c\udf62": [
+    "oden"
+  ],
+  "\ud83c\udf63": [
+    "sushi"
+  ],
+  "\ud83c\udf64": [
+    "fried_shrimp"
+  ],
+  "\ud83c\udf65": [
+    "fish_cake_with_swirl",
+    "fish_cake"
+  ],
+  "\ud83c\udf66": [
+    "soft_ice_cream",
+    "icecream"
+  ],
+  "\ud83c\udf67": [
+    "shaved_ice"
+  ],
+  "\ud83c\udf68": [
+    "ice_cream"
+  ],
+  "\ud83c\udf69": [
+    "doughnut"
+  ],
+  "\ud83c\udf6a": [
+    "cookie"
+  ],
+  "\ud83c\udf6b": [
+    "chocolate_bar"
+  ],
+  "\ud83c\udf6c": [
+    "candy"
+  ],
+  "\ud83c\udf6d": [
+    "lollipop"
+  ],
+  "\ud83c\udf6e": [
+    "custard"
+  ],
+  "\ud83c\udf6f": [
+    "honey_pot"
+  ],
+  "\ud83c\udf70": [
+    "shortcake",
+    "cake"
+  ],
+  "\ud83c\udf71": [
+    "bento_box",
+    "bento"
+  ],
+  "\ud83c\udf72": [
+    "pot_of_food",
+    "stew"
+  ],
+  "\ud83c\udf73": [
+    "cooking",
+    "egg",
+    "fried_egg"
+  ],
+  "\ud83c\udf74": [
+    "fork_and_knife"
+  ],
+  "\ud83c\udf75": [
+    "teacup_without_handle",
+    "tea"
+  ],
+  "\ud83c\udf76": [
+    "sake"
+  ],
+  "\ud83c\udf77": [
+    "wine_glass"
+  ],
+  "\ud83c\udf78": [
+    "cocktail_glass",
+    "cocktail"
+  ],
+  "\ud83c\udf79": [
+    "tropical_drink"
+  ],
+  "\ud83c\udf7a": [
+    "beer_mug",
+    "beer"
+  ],
+  "\ud83c\udf7b": [
+    "clinking_beer_mugs",
+    "beers"
+  ],
+  "\ud83c\udf7c": [
+    "baby_bottle"
+  ],
+  "\ud83c\udf7d": [
+    "fork_and_knife_with_plate",
+    "plate_with_cutlery"
+  ],
+  "\ud83c\udf7d\ufe0f": [
+    "fork_and_knife_with_plate",
+    "plate_with_cutlery"
+  ],
+  "\ud83c\udf7e": [
+    "bottle_with_popping_cork",
+    "champagne"
+  ],
+  "\ud83c\udf7f": [
+    "popcorn"
+  ],
+  "\ud83c\udf80": [
+    "ribbon"
+  ],
+  "\ud83c\udf81": [
+    "wrapped_gift",
+    "gift"
+  ],
+  "\ud83c\udf82": [
+    "birthday_cake",
+    "birthday"
+  ],
+  "\ud83c\udf83": [
+    "jack-o-lantern",
+    "jack_o_lantern"
+  ],
+  "\ud83c\udf84": [
+    "christmas_tree",
+    "christmas_tree"
+  ],
+  "\ud83c\udf85": [
+    "santa_claus",
+    "santa",
+    "santa_claus"
+  ],
+  "\ud83c\udf85\ud83c\udffb": [
+    "santa_claus_light_skin_tone"
+  ],
+  "\ud83c\udf85\ud83c\udffc": [
+    "santa_claus_medium-light_skin_tone"
+  ],
+  "\ud83c\udf85\ud83c\udffd": [
+    "santa_claus_medium_skin_tone"
+  ],
+  "\ud83c\udf85\ud83c\udffe": [
+    "santa_claus_medium-dark_skin_tone"
+  ],
+  "\ud83c\udf85\ud83c\udfff": [
+    "santa_claus_dark_skin_tone"
+  ],
+  "\ud83c\udf86": [
+    "fireworks"
+  ],
+  "\ud83c\udf87": [
+    "sparkler"
+  ],
+  "\ud83c\udf88": [
+    "balloon"
+  ],
+  "\ud83c\udf89": [
+    "party_popper",
+    "tada"
+  ],
+  "\ud83c\udf8a": [
+    "confetti_ball"
+  ],
+  "\ud83c\udf8b": [
+    "tanabata_tree"
+  ],
+  "\ud83c\udf8c": [
+    "crossed_flags"
+  ],
+  "\ud83c\udf8d": [
+    "pine_decoration",
+    "bamboo"
+  ],
+  "\ud83c\udf8e": [
+    "japanese_dolls",
+    "dolls",
+    "japanese_dolls"
+  ],
+  "\ud83c\udf8f": [
+    "carp_streamer",
+    "flags"
+  ],
+  "\ud83c\udf90": [
+    "wind_chime"
+  ],
+  "\ud83c\udf91": [
+    "moon_viewing_ceremony",
+    "rice_scene"
+  ],
+  "\ud83c\udf92": [
+    "backpack",
+    "school_satchel"
+  ],
+  "\ud83c\udf93": [
+    "graduation_cap",
+    "mortar_board"
+  ],
+  "\ud83c\udf96": [
+    "military_medal",
+    "medal_military"
+  ],
+  "\ud83c\udf96\ufe0f": [
+    "military_medal",
+    "medal_military"
+  ],
+  "\ud83c\udf97": [
+    "reminder_ribbon"
+  ],
+  "\ud83c\udf97\ufe0f": [
+    "reminder_ribbon"
+  ],
+  "\ud83c\udf99": [
+    "studio_microphone"
+  ],
+  "\ud83c\udf99\ufe0f": [
+    "studio_microphone"
+  ],
+  "\ud83c\udf9a": [
+    "level_slider"
+  ],
+  "\ud83c\udf9a\ufe0f": [
+    "level_slider"
+  ],
+  "\ud83c\udf9b": [
+    "control_knobs"
+  ],
+  "\ud83c\udf9b\ufe0f": [
+    "control_knobs"
+  ],
+  "\ud83c\udf9e": [
+    "film_frames",
+    "film_strip"
+  ],
+  "\ud83c\udf9e\ufe0f": [
+    "film_frames",
+    "film_strip"
+  ],
+  "\ud83c\udf9f": [
+    "admission_tickets",
+    "tickets"
+  ],
+  "\ud83c\udf9f\ufe0f": [
+    "admission_tickets",
+    "tickets"
+  ],
+  "\ud83c\udfa0": [
+    "carousel_horse"
+  ],
+  "\ud83c\udfa1": [
+    "ferris_wheel"
+  ],
+  "\ud83c\udfa2": [
+    "roller_coaster"
+  ],
+  "\ud83c\udfa3": [
+    "fishing_pole",
+    "fishing_pole_and_fish"
+  ],
+  "\ud83c\udfa4": [
+    "microphone"
+  ],
+  "\ud83c\udfa5": [
+    "movie_camera"
+  ],
+  "\ud83c\udfa6": [
+    "cinema"
+  ],
+  "\ud83c\udfa7": [
+    "headphone",
+    "headphones"
+  ],
+  "\ud83c\udfa8": [
+    "artist_palette",
+    "art"
+  ],
+  "\ud83c\udfa9": [
+    "top_hat",
+    "tophat"
+  ],
+  "\ud83c\udfaa": [
+    "circus_tent"
+  ],
+  "\ud83c\udfab": [
+    "ticket"
+  ],
+  "\ud83c\udfac": [
+    "clapper_board",
+    "clapper"
+  ],
+  "\ud83c\udfad": [
+    "performing_arts"
+  ],
+  "\ud83c\udfae": [
+    "video_game"
+  ],
+  "\ud83c\udfaf": [
+    "bullseye",
+    "dart"
+  ],
+  "\ud83c\udfb0": [
+    "slot_machine"
+  ],
+  "\ud83c\udfb1": [
+    "pool_8_ball",
+    "8ball"
+  ],
+  "\ud83c\udfb2": [
+    "game_die"
+  ],
+  "\ud83c\udfb3": [
+    "bowling"
+  ],
+  "\ud83c\udfb4": [
+    "flower_playing_cards"
+  ],
+  "\ud83c\udfb5": [
+    "musical_note"
+  ],
+  "\ud83c\udfb6": [
+    "musical_notes",
+    "notes"
+  ],
+  "\ud83c\udfb7": [
+    "saxophone"
+  ],
+  "\ud83c\udfb8": [
+    "guitar"
+  ],
+  "\ud83c\udfb9": [
+    "musical_keyboard"
+  ],
+  "\ud83c\udfba": [
+    "trumpet"
+  ],
+  "\ud83c\udfbb": [
+    "violin"
+  ],
+  "\ud83c\udfbc": [
+    "musical_score"
+  ],
+  "\ud83c\udfbd": [
+    "running_shirt",
+    "running_shirt_with_sash"
+  ],
+  "\ud83c\udfbe": [
+    "tennis"
+  ],
+  "\ud83c\udfbf": [
+    "skis",
+    "ski"
+  ],
+  "\ud83c\udfc0": [
+    "basketball"
+  ],
+  "\ud83c\udfc1": [
+    "chequered_flag",
+    "checkered_flag"
+  ],
+  "\ud83c\udfc2": [
+    "snowboarder"
+  ],
+  "\ud83c\udfc2\ud83c\udffb": [
+    "snowboarder_light_skin_tone"
+  ],
+  "\ud83c\udfc2\ud83c\udffc": [
+    "snowboarder_medium-light_skin_tone"
+  ],
+  "\ud83c\udfc2\ud83c\udffd": [
+    "snowboarder_medium_skin_tone"
+  ],
+  "\ud83c\udfc2\ud83c\udffe": [
+    "snowboarder_medium-dark_skin_tone"
+  ],
+  "\ud83c\udfc2\ud83c\udfff": [
+    "snowboarder_dark_skin_tone"
+  ],
+  "\ud83c\udfc3": [
+    "person_running",
+    "runner",
+    "running"
+  ],
+  "\ud83c\udfc3\u200d\u2640": [
+    "woman_running",
+    "running_woman"
+  ],
+  "\ud83c\udfc3\u200d\u2640\u200d\u27a1": [
+    "woman_running_facing_right"
+  ],
+  "\ud83c\udfc3\u200d\u2640\u200d\u27a1\ufe0f": [
+    "woman_running_facing_right"
+  ],
+  "\ud83c\udfc3\u200d\u2640\ufe0f": [
+    "woman_running",
+    "running_woman"
+  ],
+  "\ud83c\udfc3\u200d\u2640\ufe0f\u200d\u27a1": [
+    "woman_running_facing_right"
+  ],
+  "\ud83c\udfc3\u200d\u2640\ufe0f\u200d\u27a1\ufe0f": [
+    "woman_running_facing_right"
+  ],
+  "\ud83c\udfc3\u200d\u2642": [
+    "man_running",
+    "running_man"
+  ],
+  "\ud83c\udfc3\u200d\u2642\u200d\u27a1": [
+    "man_running_facing_right"
+  ],
+  "\ud83c\udfc3\u200d\u2642\u200d\u27a1\ufe0f": [
+    "man_running_facing_right"
+  ],
+  "\ud83c\udfc3\u200d\u2642\ufe0f": [
+    "man_running",
+    "running_man"
+  ],
+  "\ud83c\udfc3\u200d\u2642\ufe0f\u200d\u27a1": [
+    "man_running_facing_right"
+  ],
+  "\ud83c\udfc3\u200d\u2642\ufe0f\u200d\u27a1\ufe0f": [
+    "man_running_facing_right"
+  ],
+  "\ud83c\udfc3\u200d\u27a1": [
+    "person_running_facing_right"
+  ],
+  "\ud83c\udfc3\u200d\u27a1\ufe0f": [
+    "person_running_facing_right"
+  ],
+  "\ud83c\udfc3\ud83c\udffb": [
+    "person_running_light_skin_tone"
+  ],
+  "\ud83c\udfc3\ud83c\udffb\u200d\u2640": [
+    "woman_running_light_skin_tone"
+  ],
+  "\ud83c\udfc3\ud83c\udffb\u200d\u2640\u200d\u27a1": [
+    "woman_running_facing_right_light_skin_tone"
+  ],
+  "\ud83c\udfc3\ud83c\udffb\u200d\u2640\u200d\u27a1\ufe0f": [
+    "woman_running_facing_right_light_skin_tone"
+  ],
+  "\ud83c\udfc3\ud83c\udffb\u200d\u2640\ufe0f": [
+    "woman_running_light_skin_tone"
+  ],
+  "\ud83c\udfc3\ud83c\udffb\u200d\u2640\ufe0f\u200d\u27a1": [
+    "woman_running_facing_right_light_skin_tone"
+  ],
+  "\ud83c\udfc3\ud83c\udffb\u200d\u2640\ufe0f\u200d\u27a1\ufe0f": [
+    "woman_running_facing_right_light_skin_tone"
+  ],
+  "\ud83c\udfc3\ud83c\udffb\u200d\u2642": [
+    "man_running_light_skin_tone"
+  ],
+  "\ud83c\udfc3\ud83c\udffb\u200d\u2642\u200d\u27a1": [
+    "man_running_facing_right_light_skin_tone"
+  ],
+  "\ud83c\udfc3\ud83c\udffb\u200d\u2642\u200d\u27a1\ufe0f": [
+    "man_running_facing_right_light_skin_tone"
+  ],
+  "\ud83c\udfc3\ud83c\udffb\u200d\u2642\ufe0f": [
+    "man_running_light_skin_tone"
+  ],
+  "\ud83c\udfc3\ud83c\udffb\u200d\u2642\ufe0f\u200d\u27a1": [
+    "man_running_facing_right_light_skin_tone"
+  ],
+  "\ud83c\udfc3\ud83c\udffb\u200d\u2642\ufe0f\u200d\u27a1\ufe0f": [
+    "man_running_facing_right_light_skin_tone"
+  ],
+  "\ud83c\udfc3\ud83c\udffb\u200d\u27a1": [
+    "person_running_facing_right_light_skin_tone"
+  ],
+  "\ud83c\udfc3\ud83c\udffb\u200d\u27a1\ufe0f": [
+    "person_running_facing_right_light_skin_tone"
+  ],
+  "\ud83c\udfc3\ud83c\udffc": [
+    "person_running_medium-light_skin_tone"
+  ],
+  "\ud83c\udfc3\ud83c\udffc\u200d\u2640": [
+    "woman_running_medium-light_skin_tone"
+  ],
+  "\ud83c\udfc3\ud83c\udffc\u200d\u2640\u200d\u27a1": [
+    "woman_running_facing_right_medium-light_skin_tone"
+  ],
+  "\ud83c\udfc3\ud83c\udffc\u200d\u2640\u200d\u27a1\ufe0f": [
+    "woman_running_facing_right_medium-light_skin_tone"
+  ],
+  "\ud83c\udfc3\ud83c\udffc\u200d\u2640\ufe0f": [
+    "woman_running_medium-light_skin_tone"
+  ],
+  "\ud83c\udfc3\ud83c\udffc\u200d\u2640\ufe0f\u200d\u27a1": [
+    "woman_running_facing_right_medium-light_skin_tone"
+  ],
+  "\ud83c\udfc3\ud83c\udffc\u200d\u2640\ufe0f\u200d\u27a1\ufe0f": [
+    "woman_running_facing_right_medium-light_skin_tone"
+  ],
+  "\ud83c\udfc3\ud83c\udffc\u200d\u2642": [
+    "man_running_medium-light_skin_tone"
+  ],
+  "\ud83c\udfc3\ud83c\udffc\u200d\u2642\u200d\u27a1": [
+    "man_running_facing_right_medium-light_skin_tone"
+  ],
+  "\ud83c\udfc3\ud83c\udffc\u200d\u2642\u200d\u27a1\ufe0f": [
+    "man_running_facing_right_medium-light_skin_tone"
+  ],
+  "\ud83c\udfc3\ud83c\udffc\u200d\u2642\ufe0f": [
+    "man_running_medium-light_skin_tone"
+  ],
+  "\ud83c\udfc3\ud83c\udffc\u200d\u2642\ufe0f\u200d\u27a1": [
+    "man_running_facing_right_medium-light_skin_tone"
+  ],
+  "\ud83c\udfc3\ud83c\udffc\u200d\u2642\ufe0f\u200d\u27a1\ufe0f": [
+    "man_running_facing_right_medium-light_skin_tone"
+  ],
+  "\ud83c\udfc3\ud83c\udffc\u200d\u27a1": [
+    "person_running_facing_right_medium-light_skin_tone"
+  ],
+  "\ud83c\udfc3\ud83c\udffc\u200d\u27a1\ufe0f": [
+    "person_running_facing_right_medium-light_skin_tone"
+  ],
+  "\ud83c\udfc3\ud83c\udffd": [
+    "person_running_medium_skin_tone"
+  ],
+  "\ud83c\udfc3\ud83c\udffd\u200d\u2640": [
+    "woman_running_medium_skin_tone"
+  ],
+  "\ud83c\udfc3\ud83c\udffd\u200d\u2640\u200d\u27a1": [
+    "woman_running_facing_right_medium_skin_tone"
+  ],
+  "\ud83c\udfc3\ud83c\udffd\u200d\u2640\u200d\u27a1\ufe0f": [
+    "woman_running_facing_right_medium_skin_tone"
+  ],
+  "\ud83c\udfc3\ud83c\udffd\u200d\u2640\ufe0f": [
+    "woman_running_medium_skin_tone"
+  ],
+  "\ud83c\udfc3\ud83c\udffd\u200d\u2640\ufe0f\u200d\u27a1": [
+    "woman_running_facing_right_medium_skin_tone"
+  ],
+  "\ud83c\udfc3\ud83c\udffd\u200d\u2640\ufe0f\u200d\u27a1\ufe0f": [
+    "woman_running_facing_right_medium_skin_tone"
+  ],
+  "\ud83c\udfc3\ud83c\udffd\u200d\u2642": [
+    "man_running_medium_skin_tone"
+  ],
+  "\ud83c\udfc3\ud83c\udffd\u200d\u2642\u200d\u27a1": [
+    "man_running_facing_right_medium_skin_tone"
+  ],
+  "\ud83c\udfc3\ud83c\udffd\u200d\u2642\u200d\u27a1\ufe0f": [
+    "man_running_facing_right_medium_skin_tone"
+  ],
+  "\ud83c\udfc3\ud83c\udffd\u200d\u2642\ufe0f": [
+    "man_running_medium_skin_tone"
+  ],
+  "\ud83c\udfc3\ud83c\udffd\u200d\u2642\ufe0f\u200d\u27a1": [
+    "man_running_facing_right_medium_skin_tone"
+  ],
+  "\ud83c\udfc3\ud83c\udffd\u200d\u2642\ufe0f\u200d\u27a1\ufe0f": [
+    "man_running_facing_right_medium_skin_tone"
+  ],
+  "\ud83c\udfc3\ud83c\udffd\u200d\u27a1": [
+    "person_running_facing_right_medium_skin_tone"
+  ],
+  "\ud83c\udfc3\ud83c\udffd\u200d\u27a1\ufe0f": [
+    "person_running_facing_right_medium_skin_tone"
+  ],
+  "\ud83c\udfc3\ud83c\udffe": [
+    "person_running_medium-dark_skin_tone"
+  ],
+  "\ud83c\udfc3\ud83c\udffe\u200d\u2640": [
+    "woman_running_medium-dark_skin_tone"
+  ],
+  "\ud83c\udfc3\ud83c\udffe\u200d\u2640\u200d\u27a1": [
+    "woman_running_facing_right_medium-dark_skin_tone"
+  ],
+  "\ud83c\udfc3\ud83c\udffe\u200d\u2640\u200d\u27a1\ufe0f": [
+    "woman_running_facing_right_medium-dark_skin_tone"
+  ],
+  "\ud83c\udfc3\ud83c\udffe\u200d\u2640\ufe0f": [
+    "woman_running_medium-dark_skin_tone"
+  ],
+  "\ud83c\udfc3\ud83c\udffe\u200d\u2640\ufe0f\u200d\u27a1": [
+    "woman_running_facing_right_medium-dark_skin_tone"
+  ],
+  "\ud83c\udfc3\ud83c\udffe\u200d\u2640\ufe0f\u200d\u27a1\ufe0f": [
+    "woman_running_facing_right_medium-dark_skin_tone"
+  ],
+  "\ud83c\udfc3\ud83c\udffe\u200d\u2642": [
+    "man_running_medium-dark_skin_tone"
+  ],
+  "\ud83c\udfc3\ud83c\udffe\u200d\u2642\u200d\u27a1": [
+    "man_running_facing_right_medium-dark_skin_tone"
+  ],
+  "\ud83c\udfc3\ud83c\udffe\u200d\u2642\u200d\u27a1\ufe0f": [
+    "man_running_facing_right_medium-dark_skin_tone"
+  ],
+  "\ud83c\udfc3\ud83c\udffe\u200d\u2642\ufe0f": [
+    "man_running_medium-dark_skin_tone"
+  ],
+  "\ud83c\udfc3\ud83c\udffe\u200d\u2642\ufe0f\u200d\u27a1": [
+    "man_running_facing_right_medium-dark_skin_tone"
+  ],
+  "\ud83c\udfc3\ud83c\udffe\u200d\u2642\ufe0f\u200d\u27a1\ufe0f": [
+    "man_running_facing_right_medium-dark_skin_tone"
+  ],
+  "\ud83c\udfc3\ud83c\udffe\u200d\u27a1": [
+    "person_running_facing_right_medium-dark_skin_tone"
+  ],
+  "\ud83c\udfc3\ud83c\udffe\u200d\u27a1\ufe0f": [
+    "person_running_facing_right_medium-dark_skin_tone"
+  ],
+  "\ud83c\udfc3\ud83c\udfff": [
+    "person_running_dark_skin_tone"
+  ],
+  "\ud83c\udfc3\ud83c\udfff\u200d\u2640": [
+    "woman_running_dark_skin_tone"
+  ],
+  "\ud83c\udfc3\ud83c\udfff\u200d\u2640\u200d\u27a1": [
+    "woman_running_facing_right_dark_skin_tone"
+  ],
+  "\ud83c\udfc3\ud83c\udfff\u200d\u2640\u200d\u27a1\ufe0f": [
+    "woman_running_facing_right_dark_skin_tone"
+  ],
+  "\ud83c\udfc3\ud83c\udfff\u200d\u2640\ufe0f": [
+    "woman_running_dark_skin_tone"
+  ],
+  "\ud83c\udfc3\ud83c\udfff\u200d\u2640\ufe0f\u200d\u27a1": [
+    "woman_running_facing_right_dark_skin_tone"
+  ],
+  "\ud83c\udfc3\ud83c\udfff\u200d\u2640\ufe0f\u200d\u27a1\ufe0f": [
+    "woman_running_facing_right_dark_skin_tone"
+  ],
+  "\ud83c\udfc3\ud83c\udfff\u200d\u2642": [
+    "man_running_dark_skin_tone"
+  ],
+  "\ud83c\udfc3\ud83c\udfff\u200d\u2642\u200d\u27a1": [
+    "man_running_facing_right_dark_skin_tone"
+  ],
+  "\ud83c\udfc3\ud83c\udfff\u200d\u2642\u200d\u27a1\ufe0f": [
+    "man_running_facing_right_dark_skin_tone"
+  ],
+  "\ud83c\udfc3\ud83c\udfff\u200d\u2642\ufe0f": [
+    "man_running_dark_skin_tone"
+  ],
+  "\ud83c\udfc3\ud83c\udfff\u200d\u2642\ufe0f\u200d\u27a1": [
+    "man_running_facing_right_dark_skin_tone"
+  ],
+  "\ud83c\udfc3\ud83c\udfff\u200d\u2642\ufe0f\u200d\u27a1\ufe0f": [
+    "man_running_facing_right_dark_skin_tone"
+  ],
+  "\ud83c\udfc3\ud83c\udfff\u200d\u27a1": [
+    "person_running_facing_right_dark_skin_tone"
+  ],
+  "\ud83c\udfc3\ud83c\udfff\u200d\u27a1\ufe0f": [
+    "person_running_facing_right_dark_skin_tone"
+  ],
+  "\ud83c\udfc4": [
+    "person_surfing",
+    "surfer"
+  ],
+  "\ud83c\udfc4\u200d\u2640": [
+    "woman_surfing",
+    "surfing_woman"
+  ],
+  "\ud83c\udfc4\u200d\u2640\ufe0f": [
+    "woman_surfing",
+    "surfing_woman"
+  ],
+  "\ud83c\udfc4\u200d\u2642": [
+    "man_surfing",
+    "surfing_man"
+  ],
+  "\ud83c\udfc4\u200d\u2642\ufe0f": [
+    "man_surfing",
+    "surfing_man"
+  ],
+  "\ud83c\udfc4\ud83c\udffb": [
+    "person_surfing_light_skin_tone"
+  ],
+  "\ud83c\udfc4\ud83c\udffb\u200d\u2640": [
+    "woman_surfing_light_skin_tone"
+  ],
+  "\ud83c\udfc4\ud83c\udffb\u200d\u2640\ufe0f": [
+    "woman_surfing_light_skin_tone"
+  ],
+  "\ud83c\udfc4\ud83c\udffb\u200d\u2642": [
+    "man_surfing_light_skin_tone"
+  ],
+  "\ud83c\udfc4\ud83c\udffb\u200d\u2642\ufe0f": [
+    "man_surfing_light_skin_tone"
+  ],
+  "\ud83c\udfc4\ud83c\udffc": [
+    "person_surfing_medium-light_skin_tone"
+  ],
+  "\ud83c\udfc4\ud83c\udffc\u200d\u2640": [
+    "woman_surfing_medium-light_skin_tone"
+  ],
+  "\ud83c\udfc4\ud83c\udffc\u200d\u2640\ufe0f": [
+    "woman_surfing_medium-light_skin_tone"
+  ],
+  "\ud83c\udfc4\ud83c\udffc\u200d\u2642": [
+    "man_surfing_medium-light_skin_tone"
+  ],
+  "\ud83c\udfc4\ud83c\udffc\u200d\u2642\ufe0f": [
+    "man_surfing_medium-light_skin_tone"
+  ],
+  "\ud83c\udfc4\ud83c\udffd": [
+    "person_surfing_medium_skin_tone"
+  ],
+  "\ud83c\udfc4\ud83c\udffd\u200d\u2640": [
+    "woman_surfing_medium_skin_tone"
+  ],
+  "\ud83c\udfc4\ud83c\udffd\u200d\u2640\ufe0f": [
+    "woman_surfing_medium_skin_tone"
+  ],
+  "\ud83c\udfc4\ud83c\udffd\u200d\u2642": [
+    "man_surfing_medium_skin_tone"
+  ],
+  "\ud83c\udfc4\ud83c\udffd\u200d\u2642\ufe0f": [
+    "man_surfing_medium_skin_tone"
+  ],
+  "\ud83c\udfc4\ud83c\udffe": [
+    "person_surfing_medium-dark_skin_tone"
+  ],
+  "\ud83c\udfc4\ud83c\udffe\u200d\u2640": [
+    "woman_surfing_medium-dark_skin_tone"
+  ],
+  "\ud83c\udfc4\ud83c\udffe\u200d\u2640\ufe0f": [
+    "woman_surfing_medium-dark_skin_tone"
+  ],
+  "\ud83c\udfc4\ud83c\udffe\u200d\u2642": [
+    "man_surfing_medium-dark_skin_tone"
+  ],
+  "\ud83c\udfc4\ud83c\udffe\u200d\u2642\ufe0f": [
+    "man_surfing_medium-dark_skin_tone"
+  ],
+  "\ud83c\udfc4\ud83c\udfff": [
+    "person_surfing_dark_skin_tone"
+  ],
+  "\ud83c\udfc4\ud83c\udfff\u200d\u2640": [
+    "woman_surfing_dark_skin_tone"
+  ],
+  "\ud83c\udfc4\ud83c\udfff\u200d\u2640\ufe0f": [
+    "woman_surfing_dark_skin_tone"
+  ],
+  "\ud83c\udfc4\ud83c\udfff\u200d\u2642": [
+    "man_surfing_dark_skin_tone"
+  ],
+  "\ud83c\udfc4\ud83c\udfff\u200d\u2642\ufe0f": [
+    "man_surfing_dark_skin_tone"
+  ],
+  "\ud83c\udfc5": [
+    "sports_medal",
+    "medal_sports"
+  ],
+  "\ud83c\udfc6": [
+    "trophy"
+  ],
+  "\ud83c\udfc7": [
+    "horse_racing"
+  ],
+  "\ud83c\udfc7\ud83c\udffb": [
+    "horse_racing_light_skin_tone"
+  ],
+  "\ud83c\udfc7\ud83c\udffc": [
+    "horse_racing_medium-light_skin_tone"
+  ],
+  "\ud83c\udfc7\ud83c\udffd": [
+    "horse_racing_medium_skin_tone"
+  ],
+  "\ud83c\udfc7\ud83c\udffe": [
+    "horse_racing_medium-dark_skin_tone"
+  ],
+  "\ud83c\udfc7\ud83c\udfff": [
+    "horse_racing_dark_skin_tone"
+  ],
+  "\ud83c\udfc8": [
+    "american_football",
+    "football"
+  ],
+  "\ud83c\udfc9": [
+    "rugby_football"
+  ],
+  "\ud83c\udfca": [
+    "person_swimming",
+    "swimmer"
+  ],
+  "\ud83c\udfca\u200d\u2640": [
+    "woman_swimming",
+    "swimming_woman"
+  ],
+  "\ud83c\udfca\u200d\u2640\ufe0f": [
+    "woman_swimming",
+    "swimming_woman"
+  ],
+  "\ud83c\udfca\u200d\u2642": [
+    "man_swimming",
+    "swimming_man"
+  ],
+  "\ud83c\udfca\u200d\u2642\ufe0f": [
+    "man_swimming",
+    "swimming_man"
+  ],
+  "\ud83c\udfca\ud83c\udffb": [
+    "person_swimming_light_skin_tone"
+  ],
+  "\ud83c\udfca\ud83c\udffb\u200d\u2640": [
+    "woman_swimming_light_skin_tone"
+  ],
+  "\ud83c\udfca\ud83c\udffb\u200d\u2640\ufe0f": [
+    "woman_swimming_light_skin_tone"
+  ],
+  "\ud83c\udfca\ud83c\udffb\u200d\u2642": [
+    "man_swimming_light_skin_tone"
+  ],
+  "\ud83c\udfca\ud83c\udffb\u200d\u2642\ufe0f": [
+    "man_swimming_light_skin_tone"
+  ],
+  "\ud83c\udfca\ud83c\udffc": [
+    "person_swimming_medium-light_skin_tone"
+  ],
+  "\ud83c\udfca\ud83c\udffc\u200d\u2640": [
+    "woman_swimming_medium-light_skin_tone"
+  ],
+  "\ud83c\udfca\ud83c\udffc\u200d\u2640\ufe0f": [
+    "woman_swimming_medium-light_skin_tone"
+  ],
+  "\ud83c\udfca\ud83c\udffc\u200d\u2642": [
+    "man_swimming_medium-light_skin_tone"
+  ],
+  "\ud83c\udfca\ud83c\udffc\u200d\u2642\ufe0f": [
+    "man_swimming_medium-light_skin_tone"
+  ],
+  "\ud83c\udfca\ud83c\udffd": [
+    "person_swimming_medium_skin_tone"
+  ],
+  "\ud83c\udfca\ud83c\udffd\u200d\u2640": [
+    "woman_swimming_medium_skin_tone"
+  ],
+  "\ud83c\udfca\ud83c\udffd\u200d\u2640\ufe0f": [
+    "woman_swimming_medium_skin_tone"
+  ],
+  "\ud83c\udfca\ud83c\udffd\u200d\u2642": [
+    "man_swimming_medium_skin_tone"
+  ],
+  "\ud83c\udfca\ud83c\udffd\u200d\u2642\ufe0f": [
+    "man_swimming_medium_skin_tone"
+  ],
+  "\ud83c\udfca\ud83c\udffe": [
+    "person_swimming_medium-dark_skin_tone"
+  ],
+  "\ud83c\udfca\ud83c\udffe\u200d\u2640": [
+    "woman_swimming_medium-dark_skin_tone"
+  ],
+  "\ud83c\udfca\ud83c\udffe\u200d\u2640\ufe0f": [
+    "woman_swimming_medium-dark_skin_tone"
+  ],
+  "\ud83c\udfca\ud83c\udffe\u200d\u2642": [
+    "man_swimming_medium-dark_skin_tone"
+  ],
+  "\ud83c\udfca\ud83c\udffe\u200d\u2642\ufe0f": [
+    "man_swimming_medium-dark_skin_tone"
+  ],
+  "\ud83c\udfca\ud83c\udfff": [
+    "person_swimming_dark_skin_tone"
+  ],
+  "\ud83c\udfca\ud83c\udfff\u200d\u2640": [
+    "woman_swimming_dark_skin_tone"
+  ],
+  "\ud83c\udfca\ud83c\udfff\u200d\u2640\ufe0f": [
+    "woman_swimming_dark_skin_tone"
+  ],
+  "\ud83c\udfca\ud83c\udfff\u200d\u2642": [
+    "man_swimming_dark_skin_tone"
+  ],
+  "\ud83c\udfca\ud83c\udfff\u200d\u2642\ufe0f": [
+    "man_swimming_dark_skin_tone"
+  ],
+  "\ud83c\udfcb": [
+    "person_lifting_weights",
+    "weight_lifting",
+    "weight_lifter"
+  ],
+  "\ud83c\udfcb\u200d\u2640": [
+    "woman_lifting_weights",
+    "weight_lifting_woman"
+  ],
+  "\ud83c\udfcb\u200d\u2640\ufe0f": [
+    "woman_lifting_weights",
+    "weight_lifting_woman"
+  ],
+  "\ud83c\udfcb\u200d\u2642": [
+    "man_lifting_weights",
+    "weight_lifting_man"
+  ],
+  "\ud83c\udfcb\u200d\u2642\ufe0f": [
+    "man_lifting_weights",
+    "weight_lifting_man"
+  ],
+  "\ud83c\udfcb\ufe0f": [
+    "person_lifting_weights",
+    "weight_lifting",
+    "weight_lifter"
+  ],
+  "\ud83c\udfcb\ufe0f\u200d\u2640": [
+    "woman_lifting_weights",
+    "weight_lifting_woman"
+  ],
+  "\ud83c\udfcb\ufe0f\u200d\u2640\ufe0f": [
+    "woman_lifting_weights",
+    "weight_lifting_woman"
+  ],
+  "\ud83c\udfcb\ufe0f\u200d\u2642": [
+    "man_lifting_weights",
+    "weight_lifting_man"
+  ],
+  "\ud83c\udfcb\ufe0f\u200d\u2642\ufe0f": [
+    "man_lifting_weights",
+    "weight_lifting_man"
+  ],
+  "\ud83c\udfcb\ud83c\udffb": [
+    "person_lifting_weights_light_skin_tone"
+  ],
+  "\ud83c\udfcb\ud83c\udffb\u200d\u2640": [
+    "woman_lifting_weights_light_skin_tone"
+  ],
+  "\ud83c\udfcb\ud83c\udffb\u200d\u2640\ufe0f": [
+    "woman_lifting_weights_light_skin_tone"
+  ],
+  "\ud83c\udfcb\ud83c\udffb\u200d\u2642": [
+    "man_lifting_weights_light_skin_tone"
+  ],
+  "\ud83c\udfcb\ud83c\udffb\u200d\u2642\ufe0f": [
+    "man_lifting_weights_light_skin_tone"
+  ],
+  "\ud83c\udfcb\ud83c\udffc": [
+    "person_lifting_weights_medium-light_skin_tone"
+  ],
+  "\ud83c\udfcb\ud83c\udffc\u200d\u2640": [
+    "woman_lifting_weights_medium-light_skin_tone"
+  ],
+  "\ud83c\udfcb\ud83c\udffc\u200d\u2640\ufe0f": [
+    "woman_lifting_weights_medium-light_skin_tone"
+  ],
+  "\ud83c\udfcb\ud83c\udffc\u200d\u2642": [
+    "man_lifting_weights_medium-light_skin_tone"
+  ],
+  "\ud83c\udfcb\ud83c\udffc\u200d\u2642\ufe0f": [
+    "man_lifting_weights_medium-light_skin_tone"
+  ],
+  "\ud83c\udfcb\ud83c\udffd": [
+    "person_lifting_weights_medium_skin_tone"
+  ],
+  "\ud83c\udfcb\ud83c\udffd\u200d\u2640": [
+    "woman_lifting_weights_medium_skin_tone"
+  ],
+  "\ud83c\udfcb\ud83c\udffd\u200d\u2640\ufe0f": [
+    "woman_lifting_weights_medium_skin_tone"
+  ],
+  "\ud83c\udfcb\ud83c\udffd\u200d\u2642": [
+    "man_lifting_weights_medium_skin_tone"
+  ],
+  "\ud83c\udfcb\ud83c\udffd\u200d\u2642\ufe0f": [
+    "man_lifting_weights_medium_skin_tone"
+  ],
+  "\ud83c\udfcb\ud83c\udffe": [
+    "person_lifting_weights_medium-dark_skin_tone"
+  ],
+  "\ud83c\udfcb\ud83c\udffe\u200d\u2640": [
+    "woman_lifting_weights_medium-dark_skin_tone"
+  ],
+  "\ud83c\udfcb\ud83c\udffe\u200d\u2640\ufe0f": [
+    "woman_lifting_weights_medium-dark_skin_tone"
+  ],
+  "\ud83c\udfcb\ud83c\udffe\u200d\u2642": [
+    "man_lifting_weights_medium-dark_skin_tone"
+  ],
+  "\ud83c\udfcb\ud83c\udffe\u200d\u2642\ufe0f": [
+    "man_lifting_weights_medium-dark_skin_tone"
+  ],
+  "\ud83c\udfcb\ud83c\udfff": [
+    "person_lifting_weights_dark_skin_tone"
+  ],
+  "\ud83c\udfcb\ud83c\udfff\u200d\u2640": [
+    "woman_lifting_weights_dark_skin_tone"
+  ],
+  "\ud83c\udfcb\ud83c\udfff\u200d\u2640\ufe0f": [
+    "woman_lifting_weights_dark_skin_tone"
+  ],
+  "\ud83c\udfcb\ud83c\udfff\u200d\u2642": [
+    "man_lifting_weights_dark_skin_tone"
+  ],
+  "\ud83c\udfcb\ud83c\udfff\u200d\u2642\ufe0f": [
+    "man_lifting_weights_dark_skin_tone"
+  ],
+  "\ud83c\udfcc": [
+    "person_golfing",
+    "golfing",
+    "golfer"
+  ],
+  "\ud83c\udfcc\u200d\u2640": [
+    "woman_golfing",
+    "golfing_woman"
+  ],
+  "\ud83c\udfcc\u200d\u2640\ufe0f": [
+    "woman_golfing",
+    "golfing_woman"
+  ],
+  "\ud83c\udfcc\u200d\u2642": [
+    "man_golfing",
+    "golfing_man"
+  ],
+  "\ud83c\udfcc\u200d\u2642\ufe0f": [
+    "man_golfing",
+    "golfing_man"
+  ],
+  "\ud83c\udfcc\ufe0f": [
+    "person_golfing",
+    "golfing",
+    "golfer"
+  ],
+  "\ud83c\udfcc\ufe0f\u200d\u2640": [
+    "woman_golfing",
+    "golfing_woman"
+  ],
+  "\ud83c\udfcc\ufe0f\u200d\u2640\ufe0f": [
+    "woman_golfing",
+    "golfing_woman"
+  ],
+  "\ud83c\udfcc\ufe0f\u200d\u2642": [
+    "man_golfing",
+    "golfing_man"
+  ],
+  "\ud83c\udfcc\ufe0f\u200d\u2642\ufe0f": [
+    "man_golfing",
+    "golfing_man"
+  ],
+  "\ud83c\udfcc\ud83c\udffb": [
+    "person_golfing_light_skin_tone"
+  ],
+  "\ud83c\udfcc\ud83c\udffb\u200d\u2640": [
+    "woman_golfing_light_skin_tone"
+  ],
+  "\ud83c\udfcc\ud83c\udffb\u200d\u2640\ufe0f": [
+    "woman_golfing_light_skin_tone"
+  ],
+  "\ud83c\udfcc\ud83c\udffb\u200d\u2642": [
+    "man_golfing_light_skin_tone"
+  ],
+  "\ud83c\udfcc\ud83c\udffb\u200d\u2642\ufe0f": [
+    "man_golfing_light_skin_tone"
+  ],
+  "\ud83c\udfcc\ud83c\udffc": [
+    "person_golfing_medium-light_skin_tone"
+  ],
+  "\ud83c\udfcc\ud83c\udffc\u200d\u2640": [
+    "woman_golfing_medium-light_skin_tone"
+  ],
+  "\ud83c\udfcc\ud83c\udffc\u200d\u2640\ufe0f": [
+    "woman_golfing_medium-light_skin_tone"
+  ],
+  "\ud83c\udfcc\ud83c\udffc\u200d\u2642": [
+    "man_golfing_medium-light_skin_tone"
+  ],
+  "\ud83c\udfcc\ud83c\udffc\u200d\u2642\ufe0f": [
+    "man_golfing_medium-light_skin_tone"
+  ],
+  "\ud83c\udfcc\ud83c\udffd": [
+    "person_golfing_medium_skin_tone"
+  ],
+  "\ud83c\udfcc\ud83c\udffd\u200d\u2640": [
+    "woman_golfing_medium_skin_tone"
+  ],
+  "\ud83c\udfcc\ud83c\udffd\u200d\u2640\ufe0f": [
+    "woman_golfing_medium_skin_tone"
+  ],
+  "\ud83c\udfcc\ud83c\udffd\u200d\u2642": [
+    "man_golfing_medium_skin_tone"
+  ],
+  "\ud83c\udfcc\ud83c\udffd\u200d\u2642\ufe0f": [
+    "man_golfing_medium_skin_tone"
+  ],
+  "\ud83c\udfcc\ud83c\udffe": [
+    "person_golfing_medium-dark_skin_tone"
+  ],
+  "\ud83c\udfcc\ud83c\udffe\u200d\u2640": [
+    "woman_golfing_medium-dark_skin_tone"
+  ],
+  "\ud83c\udfcc\ud83c\udffe\u200d\u2640\ufe0f": [
+    "woman_golfing_medium-dark_skin_tone"
+  ],
+  "\ud83c\udfcc\ud83c\udffe\u200d\u2642": [
+    "man_golfing_medium-dark_skin_tone"
+  ],
+  "\ud83c\udfcc\ud83c\udffe\u200d\u2642\ufe0f": [
+    "man_golfing_medium-dark_skin_tone"
+  ],
+  "\ud83c\udfcc\ud83c\udfff": [
+    "person_golfing_dark_skin_tone"
+  ],
+  "\ud83c\udfcc\ud83c\udfff\u200d\u2640": [
+    "woman_golfing_dark_skin_tone"
+  ],
+  "\ud83c\udfcc\ud83c\udfff\u200d\u2640\ufe0f": [
+    "woman_golfing_dark_skin_tone"
+  ],
+  "\ud83c\udfcc\ud83c\udfff\u200d\u2642": [
+    "man_golfing_dark_skin_tone"
+  ],
+  "\ud83c\udfcc\ud83c\udfff\u200d\u2642\ufe0f": [
+    "man_golfing_dark_skin_tone"
+  ],
+  "\ud83c\udfcd": [
+    "motorcycle",
+    "racing_motorcycle"
+  ],
+  "\ud83c\udfcd\ufe0f": [
+    "motorcycle",
+    "racing_motorcycle"
+  ],
+  "\ud83c\udfce": [
+    "racing_car"
+  ],
+  "\ud83c\udfce\ufe0f": [
+    "racing_car"
+  ],
+  "\ud83c\udfcf": [
+    "cricket_game",
+    "cricket_bat_and_ball"
+  ],
+  "\ud83c\udfd0": [
+    "volleyball"
+  ],
+  "\ud83c\udfd1": [
+    "field_hockey",
+    "field_hockey_stick_and_ball"
+  ],
+  "\ud83c\udfd2": [
+    "ice_hockey",
+    "ice_hockey_stick_and_puck"
+  ],
+  "\ud83c\udfd3": [
+    "ping_pong",
+    "table_tennis_paddle_and_ball"
+  ],
+  "\ud83c\udfd4": [
+    "snow-capped_mountain",
+    "mountain_snow",
+    "snow_capped_mountain"
+  ],
+  "\ud83c\udfd4\ufe0f": [
+    "snow-capped_mountain",
+    "mountain_snow",
+    "snow_capped_mountain"
+  ],
+  "\ud83c\udfd5": [
+    "camping"
+  ],
+  "\ud83c\udfd5\ufe0f": [
+    "camping"
+  ],
+  "\ud83c\udfd6": [
+    "beach_with_umbrella",
+    "beach_umbrella"
+  ],
+  "\ud83c\udfd6\ufe0f": [
+    "beach_with_umbrella",
+    "beach_umbrella"
+  ],
+  "\ud83c\udfd7": [
+    "building_construction"
+  ],
+  "\ud83c\udfd7\ufe0f": [
+    "building_construction"
+  ],
+  "\ud83c\udfd8": [
+    "houses",
+    "house_buildings"
+  ],
+  "\ud83c\udfd8\ufe0f": [
+    "houses",
+    "house_buildings"
+  ],
+  "\ud83c\udfd9": [
+    "cityscape"
+  ],
+  "\ud83c\udfd9\ufe0f": [
+    "cityscape"
+  ],
+  "\ud83c\udfda": [
+    "derelict_house",
+    "derelict_house_building"
+  ],
+  "\ud83c\udfda\ufe0f": [
+    "derelict_house",
+    "derelict_house_building"
+  ],
+  "\ud83c\udfdb": [
+    "classical_building"
+  ],
+  "\ud83c\udfdb\ufe0f": [
+    "classical_building"
+  ],
+  "\ud83c\udfdc": [
+    "desert"
+  ],
+  "\ud83c\udfdc\ufe0f": [
+    "desert"
+  ],
+  "\ud83c\udfdd": [
+    "desert_island"
+  ],
+  "\ud83c\udfdd\ufe0f": [
+    "desert_island"
+  ],
+  "\ud83c\udfde": [
+    "national_park"
+  ],
+  "\ud83c\udfde\ufe0f": [
+    "national_park"
+  ],
+  "\ud83c\udfdf": [
+    "stadium"
+  ],
+  "\ud83c\udfdf\ufe0f": [
+    "stadium"
+  ],
+  "\ud83c\udfe0": [
+    "house"
+  ],
+  "\ud83c\udfe1": [
+    "house_with_garden"
+  ],
+  "\ud83c\udfe2": [
+    "office_building",
+    "office"
+  ],
+  "\ud83c\udfe3": [
+    "japanese_post_office",
+    "post_office",
+    "japanese_post_office"
+  ],
+  "\ud83c\udfe4": [
+    "post_office",
+    "european_post_office"
+  ],
+  "\ud83c\udfe5": [
+    "hospital"
+  ],
+  "\ud83c\udfe6": [
+    "bank"
+  ],
+  "\ud83c\udfe7": [
+    "atm_sign",
+    "atm",
+    "atm_sign"
+  ],
+  "\ud83c\udfe8": [
+    "hotel"
+  ],
+  "\ud83c\udfe9": [
+    "love_hotel"
+  ],
+  "\ud83c\udfea": [
+    "convenience_store"
+  ],
+  "\ud83c\udfeb": [
+    "school"
+  ],
+  "\ud83c\udfec": [
+    "department_store"
+  ],
+  "\ud83c\udfed": [
+    "factory"
+  ],
+  "\ud83c\udfee": [
+    "red_paper_lantern",
+    "izakaya_lantern",
+    "lantern"
+  ],
+  "\ud83c\udfef": [
+    "japanese_castle",
+    "japanese_castle"
+  ],
+  "\ud83c\udff0": [
+    "castle",
+    "european_castle"
+  ],
+  "\ud83c\udff3": [
+    "white_flag",
+    "waving_white_flag"
+  ],
+  "\ud83c\udff3\u200d\u26a7": [
+    "transgender_flag"
+  ],
+  "\ud83c\udff3\u200d\u26a7\ufe0f": [
+    "transgender_flag"
+  ],
+  "\ud83c\udff3\u200d\ud83c\udf08": [
+    "rainbow_flag"
+  ],
+  "\ud83c\udff3\ufe0f": [
+    "white_flag",
+    "waving_white_flag"
+  ],
+  "\ud83c\udff3\ufe0f\u200d\u26a7": [
+    "transgender_flag"
+  ],
+  "\ud83c\udff3\ufe0f\u200d\u26a7\ufe0f": [
+    "transgender_flag"
+  ],
+  "\ud83c\udff3\ufe0f\u200d\ud83c\udf08": [
+    "rainbow_flag"
+  ],
+  "\ud83c\udff4": [
+    "black_flag",
+    "waving_black_flag"
+  ],
+  "\ud83c\udff4\u200d\u2620": [
+    "pirate_flag"
+  ],
+  "\ud83c\udff4\u200d\u2620\ufe0f": [
+    "pirate_flag"
+  ],
+  "\ud83c\udff4\udb40\udc67\udb40\udc62\udb40\udc65\udb40\udc6e\udb40\udc67\udb40\udc7f": [
+    "england",
+    "england"
+  ],
+  "\ud83c\udff4\udb40\udc67\udb40\udc62\udb40\udc73\udb40\udc63\udb40\udc74\udb40\udc7f": [
+    "scotland",
+    "scotland"
+  ],
+  "\ud83c\udff4\udb40\udc67\udb40\udc62\udb40\udc77\udb40\udc6c\udb40\udc73\udb40\udc7f": [
+    "wales",
+    "wales"
+  ],
+  "\ud83c\udff5": [
+    "rosette"
+  ],
+  "\ud83c\udff5\ufe0f": [
+    "rosette"
+  ],
+  "\ud83c\udff7": [
+    "label"
+  ],
+  "\ud83c\udff7\ufe0f": [
+    "label"
+  ],
+  "\ud83c\udff8": [
+    "badminton",
+    "badminton_racquet_and_shuttlecock"
+  ],
+  "\ud83c\udff9": [
+    "bow_and_arrow"
+  ],
+  "\ud83c\udffa": [
+    "amphora"
+  ],
+  "\ud83c\udffb": [
+    "light_skin_tone",
+    "emoji_modifier_fitzpatrick_type_1_2"
+  ],
+  "\ud83c\udffc": [
+    "medium-light_skin_tone",
+    "emoji_modifier_fitzpatrick_type_3"
+  ],
+  "\ud83c\udffd": [
+    "medium_skin_tone",
+    "emoji_modifier_fitzpatrick_type_4"
+  ],
+  "\ud83c\udffe": [
+    "medium-dark_skin_tone",
+    "emoji_modifier_fitzpatrick_type_5"
+  ],
+  "\ud83c\udfff": [
+    "dark_skin_tone",
+    "emoji_modifier_fitzpatrick_type_6"
+  ],
+  "\ud83d\udc00": [
+    "rat"
+  ],
+  "\ud83d\udc01": [
+    "mouse",
+    "mouse2"
+  ],
+  "\ud83d\udc02": [
+    "ox"
+  ],
+  "\ud83d\udc03": [
+    "water_buffalo"
+  ],
+  "\ud83d\udc04": [
+    "cow",
+    "cow2"
+  ],
+  "\ud83d\udc05": [
+    "tiger",
+    "tiger2"
+  ],
+  "\ud83d\udc06": [
+    "leopard"
+  ],
+  "\ud83d\udc07": [
+    "rabbit",
+    "rabbit2"
+  ],
+  "\ud83d\udc08": [
+    "cat",
+    "cat2"
+  ],
+  "\ud83d\udc08\u200d\u2b1b": [
+    "black_cat"
+  ],
+  "\ud83d\udc09": [
+    "dragon"
+  ],
+  "\ud83d\udc0a": [
+    "crocodile"
+  ],
+  "\ud83d\udc0b": [
+    "whale",
+    "whale2"
+  ],
+  "\ud83d\udc0c": [
+    "snail"
+  ],
+  "\ud83d\udc0d": [
+    "snake"
+  ],
+  "\ud83d\udc0e": [
+    "horse",
+    "racehorse"
+  ],
+  "\ud83d\udc0f": [
+    "ram"
+  ],
+  "\ud83d\udc10": [
+    "goat"
+  ],
+  "\ud83d\udc11": [
+    "ewe",
+    "sheep"
+  ],
+  "\ud83d\udc12": [
+    "monkey"
+  ],
+  "\ud83d\udc13": [
+    "rooster"
+  ],
+  "\ud83d\udc14": [
+    "chicken"
+  ],
+  "\ud83d\udc15": [
+    "dog",
+    "dog2"
+  ],
+  "\ud83d\udc15\u200d\ud83e\uddba": [
+    "service_dog"
+  ],
+  "\ud83d\udc16": [
+    "pig",
+    "pig2"
+  ],
+  "\ud83d\udc17": [
+    "boar"
+  ],
+  "\ud83d\udc18": [
+    "elephant"
+  ],
+  "\ud83d\udc19": [
+    "octopus"
+  ],
+  "\ud83d\udc1a": [
+    "spiral_shell",
+    "shell"
+  ],
+  "\ud83d\udc1b": [
+    "bug"
+  ],
+  "\ud83d\udc1c": [
+    "ant"
+  ],
+  "\ud83d\udc1d": [
+    "honeybee",
+    "bee"
+  ],
+  "\ud83d\udc1e": [
+    "lady_beetle",
+    "beetle"
+  ],
+  "\ud83d\udc1f": [
+    "fish"
+  ],
+  "\ud83d\udc20": [
+    "tropical_fish"
+  ],
+  "\ud83d\udc21": [
+    "blowfish"
+  ],
+  "\ud83d\udc22": [
+    "turtle"
+  ],
+  "\ud83d\udc23": [
+    "hatching_chick"
+  ],
+  "\ud83d\udc24": [
+    "baby_chick"
+  ],
+  "\ud83d\udc25": [
+    "front-facing_baby_chick",
+    "hatched_chick",
+    "front_facing_baby_chick"
+  ],
+  "\ud83d\udc26": [
+    "bird"
+  ],
+  "\ud83d\udc26\u200d\u2b1b": [
+    "black_bird",
+    "raven",
+    "crow",
+    "rook"
+  ],
+  "\ud83d\udc26\u200d\ud83d\udd25": [
+    "phoenix"
+  ],
+  "\ud83d\udc27": [
+    "penguin"
+  ],
+  "\ud83d\udc28": [
+    "koala"
+  ],
+  "\ud83d\udc29": [
+    "poodle"
+  ],
+  "\ud83d\udc2a": [
+    "camel",
+    "dromedary_camel"
+  ],
+  "\ud83d\udc2b": [
+    "two-hump_camel",
+    "camel",
+    "two_hump_camel"
+  ],
+  "\ud83d\udc2c": [
+    "dolphin",
+    "flipper"
+  ],
+  "\ud83d\udc2d": [
+    "mouse_face",
+    "mouse"
+  ],
+  "\ud83d\udc2e": [
+    "cow_face",
+    "cow"
+  ],
+  "\ud83d\udc2f": [
+    "tiger_face",
+    "tiger"
+  ],
+  "\ud83d\udc30": [
+    "rabbit_face",
+    "rabbit"
+  ],
+  "\ud83d\udc31": [
+    "cat_face",
+    "cat"
+  ],
+  "\ud83d\udc32": [
+    "dragon_face"
+  ],
+  "\ud83d\udc33": [
+    "spouting_whale",
+    "whale"
+  ],
+  "\ud83d\udc34": [
+    "horse_face",
+    "horse"
+  ],
+  "\ud83d\udc35": [
+    "monkey_face"
+  ],
+  "\ud83d\udc36": [
+    "dog_face",
+    "dog"
+  ],
+  "\ud83d\udc37": [
+    "pig_face",
+    "pig"
+  ],
+  "\ud83d\udc38": [
+    "frog"
+  ],
+  "\ud83d\udc39": [
+    "hamster"
+  ],
+  "\ud83d\udc3a": [
+    "wolf"
+  ],
+  "\ud83d\udc3b": [
+    "bear"
+  ],
+  "\ud83d\udc3b\u200d\u2744": [
+    "polar_bear"
+  ],
+  "\ud83d\udc3b\u200d\u2744\ufe0f": [
+    "polar_bear"
+  ],
+  "\ud83d\udc3c": [
+    "panda",
+    "panda_face"
+  ],
+  "\ud83d\udc3d": [
+    "pig_nose"
+  ],
+  "\ud83d\udc3e": [
+    "paw_prints",
+    "feet"
+  ],
+  "\ud83d\udc3f": [
+    "chipmunk"
+  ],
+  "\ud83d\udc3f\ufe0f": [
+    "chipmunk"
+  ],
+  "\ud83d\udc40": [
+    "eyes"
+  ],
+  "\ud83d\udc41": [
+    "eye"
+  ],
+  "\ud83d\udc41\u200d\ud83d\udde8": [
+    "eye_in_speech_bubble",
+    "eye_speech_bubble"
+  ],
+  "\ud83d\udc41\u200d\ud83d\udde8\ufe0f": [
+    "eye_in_speech_bubble",
+    "eye_speech_bubble"
+  ],
+  "\ud83d\udc41\ufe0f": [
+    "eye"
+  ],
+  "\ud83d\udc41\ufe0f\u200d\ud83d\udde8": [
+    "eye_in_speech_bubble",
+    "eye_speech_bubble"
+  ],
+  "\ud83d\udc41\ufe0f\u200d\ud83d\udde8\ufe0f": [
+    "eye_in_speech_bubble",
+    "eye_speech_bubble"
+  ],
+  "\ud83d\udc42": [
+    "ear"
+  ],
+  "\ud83d\udc42\ud83c\udffb": [
+    "ear_light_skin_tone"
+  ],
+  "\ud83d\udc42\ud83c\udffc": [
+    "ear_medium-light_skin_tone"
+  ],
+  "\ud83d\udc42\ud83c\udffd": [
+    "ear_medium_skin_tone"
+  ],
+  "\ud83d\udc42\ud83c\udffe": [
+    "ear_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc42\ud83c\udfff": [
+    "ear_dark_skin_tone"
+  ],
+  "\ud83d\udc43": [
+    "nose"
+  ],
+  "\ud83d\udc43\ud83c\udffb": [
+    "nose_light_skin_tone"
+  ],
+  "\ud83d\udc43\ud83c\udffc": [
+    "nose_medium-light_skin_tone"
+  ],
+  "\ud83d\udc43\ud83c\udffd": [
+    "nose_medium_skin_tone"
+  ],
+  "\ud83d\udc43\ud83c\udffe": [
+    "nose_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc43\ud83c\udfff": [
+    "nose_dark_skin_tone"
+  ],
+  "\ud83d\udc44": [
+    "mouth",
+    "lips"
+  ],
+  "\ud83d\udc45": [
+    "tongue"
+  ],
+  "\ud83d\udc46": [
+    "backhand_index_pointing_up",
+    "point_up_2"
+  ],
+  "\ud83d\udc46\ud83c\udffb": [
+    "backhand_index_pointing_up_light_skin_tone"
+  ],
+  "\ud83d\udc46\ud83c\udffc": [
+    "backhand_index_pointing_up_medium-light_skin_tone"
+  ],
+  "\ud83d\udc46\ud83c\udffd": [
+    "backhand_index_pointing_up_medium_skin_tone"
+  ],
+  "\ud83d\udc46\ud83c\udffe": [
+    "backhand_index_pointing_up_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc46\ud83c\udfff": [
+    "backhand_index_pointing_up_dark_skin_tone"
+  ],
+  "\ud83d\udc47": [
+    "backhand_index_pointing_down",
+    "point_down"
+  ],
+  "\ud83d\udc47\ud83c\udffb": [
+    "backhand_index_pointing_down_light_skin_tone"
+  ],
+  "\ud83d\udc47\ud83c\udffc": [
+    "backhand_index_pointing_down_medium-light_skin_tone"
+  ],
+  "\ud83d\udc47\ud83c\udffd": [
+    "backhand_index_pointing_down_medium_skin_tone"
+  ],
+  "\ud83d\udc47\ud83c\udffe": [
+    "backhand_index_pointing_down_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc47\ud83c\udfff": [
+    "backhand_index_pointing_down_dark_skin_tone"
+  ],
+  "\ud83d\udc48": [
+    "backhand_index_pointing_left",
+    "point_left"
+  ],
+  "\ud83d\udc48\ud83c\udffb": [
+    "backhand_index_pointing_left_light_skin_tone"
+  ],
+  "\ud83d\udc48\ud83c\udffc": [
+    "backhand_index_pointing_left_medium-light_skin_tone"
+  ],
+  "\ud83d\udc48\ud83c\udffd": [
+    "backhand_index_pointing_left_medium_skin_tone"
+  ],
+  "\ud83d\udc48\ud83c\udffe": [
+    "backhand_index_pointing_left_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc48\ud83c\udfff": [
+    "backhand_index_pointing_left_dark_skin_tone"
+  ],
+  "\ud83d\udc49": [
+    "backhand_index_pointing_right",
+    "point_right"
+  ],
+  "\ud83d\udc49\ud83c\udffb": [
+    "backhand_index_pointing_right_light_skin_tone"
+  ],
+  "\ud83d\udc49\ud83c\udffc": [
+    "backhand_index_pointing_right_medium-light_skin_tone"
+  ],
+  "\ud83d\udc49\ud83c\udffd": [
+    "backhand_index_pointing_right_medium_skin_tone"
+  ],
+  "\ud83d\udc49\ud83c\udffe": [
+    "backhand_index_pointing_right_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc49\ud83c\udfff": [
+    "backhand_index_pointing_right_dark_skin_tone"
+  ],
+  "\ud83d\udc4a": [
+    "oncoming_fist",
+    "fist_oncoming",
+    "punch",
+    "facepunch"
+  ],
+  "\ud83d\udc4a\ud83c\udffb": [
+    "oncoming_fist_light_skin_tone"
+  ],
+  "\ud83d\udc4a\ud83c\udffc": [
+    "oncoming_fist_medium-light_skin_tone"
+  ],
+  "\ud83d\udc4a\ud83c\udffd": [
+    "oncoming_fist_medium_skin_tone"
+  ],
+  "\ud83d\udc4a\ud83c\udffe": [
+    "oncoming_fist_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc4a\ud83c\udfff": [
+    "oncoming_fist_dark_skin_tone"
+  ],
+  "\ud83d\udc4b": [
+    "waving_hand",
+    "wave"
+  ],
+  "\ud83d\udc4b\ud83c\udffb": [
+    "waving_hand_light_skin_tone"
+  ],
+  "\ud83d\udc4b\ud83c\udffc": [
+    "waving_hand_medium-light_skin_tone"
+  ],
+  "\ud83d\udc4b\ud83c\udffd": [
+    "waving_hand_medium_skin_tone"
+  ],
+  "\ud83d\udc4b\ud83c\udffe": [
+    "waving_hand_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc4b\ud83c\udfff": [
+    "waving_hand_dark_skin_tone"
+  ],
+  "\ud83d\udc4c": [
+    "ok_hand",
+    "ok_hand"
+  ],
+  "\ud83d\udc4c\ud83c\udffb": [
+    "ok_hand_light_skin_tone"
+  ],
+  "\ud83d\udc4c\ud83c\udffc": [
+    "ok_hand_medium-light_skin_tone"
+  ],
+  "\ud83d\udc4c\ud83c\udffd": [
+    "ok_hand_medium_skin_tone"
+  ],
+  "\ud83d\udc4c\ud83c\udffe": [
+    "ok_hand_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc4c\ud83c\udfff": [
+    "ok_hand_dark_skin_tone"
+  ],
+  "\ud83d\udc4d": [
+    "thumbs_up",
+    "thumbsup",
+    "+1"
+  ],
+  "\ud83d\udc4d\ud83c\udffb": [
+    "thumbs_up_light_skin_tone"
+  ],
+  "\ud83d\udc4d\ud83c\udffc": [
+    "thumbs_up_medium-light_skin_tone"
+  ],
+  "\ud83d\udc4d\ud83c\udffd": [
+    "thumbs_up_medium_skin_tone"
+  ],
+  "\ud83d\udc4d\ud83c\udffe": [
+    "thumbs_up_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc4d\ud83c\udfff": [
+    "thumbs_up_dark_skin_tone"
+  ],
+  "\ud83d\udc4e": [
+    "thumbs_down",
+    "thumbsdown",
+    "_1",
+    "-1"
+  ],
+  "\ud83d\udc4e\ud83c\udffb": [
+    "thumbs_down_light_skin_tone"
+  ],
+  "\ud83d\udc4e\ud83c\udffc": [
+    "thumbs_down_medium-light_skin_tone"
+  ],
+  "\ud83d\udc4e\ud83c\udffd": [
+    "thumbs_down_medium_skin_tone"
+  ],
+  "\ud83d\udc4e\ud83c\udffe": [
+    "thumbs_down_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc4e\ud83c\udfff": [
+    "thumbs_down_dark_skin_tone"
+  ],
+  "\ud83d\udc4f": [
+    "clapping_hands",
+    "clap"
+  ],
+  "\ud83d\udc4f\ud83c\udffb": [
+    "clapping_hands_light_skin_tone"
+  ],
+  "\ud83d\udc4f\ud83c\udffc": [
+    "clapping_hands_medium-light_skin_tone"
+  ],
+  "\ud83d\udc4f\ud83c\udffd": [
+    "clapping_hands_medium_skin_tone"
+  ],
+  "\ud83d\udc4f\ud83c\udffe": [
+    "clapping_hands_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc4f\ud83c\udfff": [
+    "clapping_hands_dark_skin_tone"
+  ],
+  "\ud83d\udc50": [
+    "open_hands"
+  ],
+  "\ud83d\udc50\ud83c\udffb": [
+    "open_hands_light_skin_tone"
+  ],
+  "\ud83d\udc50\ud83c\udffc": [
+    "open_hands_medium-light_skin_tone"
+  ],
+  "\ud83d\udc50\ud83c\udffd": [
+    "open_hands_medium_skin_tone"
+  ],
+  "\ud83d\udc50\ud83c\udffe": [
+    "open_hands_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc50\ud83c\udfff": [
+    "open_hands_dark_skin_tone"
+  ],
+  "\ud83d\udc51": [
+    "crown"
+  ],
+  "\ud83d\udc52": [
+    "woman\u2019s_hat",
+    "womans_hat"
+  ],
+  "\ud83d\udc53": [
+    "glasses",
+    "eyeglasses"
+  ],
+  "\ud83d\udc54": [
+    "necktie"
+  ],
+  "\ud83d\udc55": [
+    "t-shirt",
+    "tshirt",
+    "shirt",
+    "t_shirt"
+  ],
+  "\ud83d\udc56": [
+    "jeans"
+  ],
+  "\ud83d\udc57": [
+    "dress"
+  ],
+  "\ud83d\udc58": [
+    "kimono"
+  ],
+  "\ud83d\udc59": [
+    "bikini"
+  ],
+  "\ud83d\udc5a": [
+    "woman\u2019s_clothes",
+    "womans_clothes"
+  ],
+  "\ud83d\udc5b": [
+    "purse"
+  ],
+  "\ud83d\udc5c": [
+    "handbag"
+  ],
+  "\ud83d\udc5d": [
+    "clutch_bag",
+    "pouch"
+  ],
+  "\ud83d\udc5e": [
+    "man\u2019s_shoe",
+    "mans_shoe",
+    "shoe"
+  ],
+  "\ud83d\udc5f": [
+    "running_shoe",
+    "athletic_shoe"
+  ],
+  "\ud83d\udc60": [
+    "high-heeled_shoe",
+    "high_heel",
+    "high_heeled_shoe"
+  ],
+  "\ud83d\udc61": [
+    "woman\u2019s_sandal",
+    "sandal",
+    "womans_sandal"
+  ],
+  "\ud83d\udc62": [
+    "woman\u2019s_boot",
+    "boot",
+    "womans_boot"
+  ],
+  "\ud83d\udc63": [
+    "footprints"
+  ],
+  "\ud83d\udc64": [
+    "bust_in_silhouette"
+  ],
+  "\ud83d\udc65": [
+    "busts_in_silhouette"
+  ],
+  "\ud83d\udc66": [
+    "boy"
+  ],
+  "\ud83d\udc66\ud83c\udffb": [
+    "boy_light_skin_tone"
+  ],
+  "\ud83d\udc66\ud83c\udffc": [
+    "boy_medium-light_skin_tone"
+  ],
+  "\ud83d\udc66\ud83c\udffd": [
+    "boy_medium_skin_tone"
+  ],
+  "\ud83d\udc66\ud83c\udffe": [
+    "boy_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc66\ud83c\udfff": [
+    "boy_dark_skin_tone"
+  ],
+  "\ud83d\udc67": [
+    "girl"
+  ],
+  "\ud83d\udc67\ud83c\udffb": [
+    "girl_light_skin_tone"
+  ],
+  "\ud83d\udc67\ud83c\udffc": [
+    "girl_medium-light_skin_tone"
+  ],
+  "\ud83d\udc67\ud83c\udffd": [
+    "girl_medium_skin_tone"
+  ],
+  "\ud83d\udc67\ud83c\udffe": [
+    "girl_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc67\ud83c\udfff": [
+    "girl_dark_skin_tone"
+  ],
+  "\ud83d\udc68": [
+    "man"
+  ],
+  "\ud83d\udc68\u200d\u2695": [
+    "man_health_worker"
+  ],
+  "\ud83d\udc68\u200d\u2695\ufe0f": [
+    "man_health_worker"
+  ],
+  "\ud83d\udc68\u200d\u2696": [
+    "man_judge"
+  ],
+  "\ud83d\udc68\u200d\u2696\ufe0f": [
+    "man_judge"
+  ],
+  "\ud83d\udc68\u200d\u2708": [
+    "man_pilot"
+  ],
+  "\ud83d\udc68\u200d\u2708\ufe0f": [
+    "man_pilot"
+  ],
+  "\ud83d\udc68\u200d\u2764\u200d\ud83d\udc68": [
+    "couple_with_heart_man_man"
+  ],
+  "\ud83d\udc68\u200d\u2764\u200d\ud83d\udc8b\u200d\ud83d\udc68": [
+    "kiss_man_man",
+    "couplekiss_man_man"
+  ],
+  "\ud83d\udc68\u200d\u2764\ufe0f\u200d\ud83d\udc68": [
+    "couple_with_heart_man_man"
+  ],
+  "\ud83d\udc68\u200d\u2764\ufe0f\u200d\ud83d\udc8b\u200d\ud83d\udc68": [
+    "kiss_man_man",
+    "couplekiss_man_man"
+  ],
+  "\ud83d\udc68\u200d\ud83c\udf3e": [
+    "man_farmer"
+  ],
+  "\ud83d\udc68\u200d\ud83c\udf73": [
+    "man_cook"
+  ],
+  "\ud83d\udc68\u200d\ud83c\udf7c": [
+    "man_feeding_baby"
+  ],
+  "\ud83d\udc68\u200d\ud83c\udf93": [
+    "man_student"
+  ],
+  "\ud83d\udc68\u200d\ud83c\udfa4": [
+    "man_singer"
+  ],
+  "\ud83d\udc68\u200d\ud83c\udfa8": [
+    "man_artist"
+  ],
+  "\ud83d\udc68\u200d\ud83c\udfeb": [
+    "man_teacher"
+  ],
+  "\ud83d\udc68\u200d\ud83c\udfed": [
+    "man_factory_worker"
+  ],
+  "\ud83d\udc68\u200d\ud83d\udc66": [
+    "family_man_boy"
+  ],
+  "\ud83d\udc68\u200d\ud83d\udc66\u200d\ud83d\udc66": [
+    "family_man_boy_boy"
+  ],
+  "\ud83d\udc68\u200d\ud83d\udc67": [
+    "family_man_girl"
+  ],
+  "\ud83d\udc68\u200d\ud83d\udc67\u200d\ud83d\udc66": [
+    "family_man_girl_boy"
+  ],
+  "\ud83d\udc68\u200d\ud83d\udc67\u200d\ud83d\udc67": [
+    "family_man_girl_girl"
+  ],
+  "\ud83d\udc68\u200d\ud83d\udc68\u200d\ud83d\udc66": [
+    "family_man_man_boy"
+  ],
+  "\ud83d\udc68\u200d\ud83d\udc68\u200d\ud83d\udc66\u200d\ud83d\udc66": [
+    "family_man_man_boy_boy"
+  ],
+  "\ud83d\udc68\u200d\ud83d\udc68\u200d\ud83d\udc67": [
+    "family_man_man_girl"
+  ],
+  "\ud83d\udc68\u200d\ud83d\udc68\u200d\ud83d\udc67\u200d\ud83d\udc66": [
+    "family_man_man_girl_boy"
+  ],
+  "\ud83d\udc68\u200d\ud83d\udc68\u200d\ud83d\udc67\u200d\ud83d\udc67": [
+    "family_man_man_girl_girl"
+  ],
+  "\ud83d\udc68\u200d\ud83d\udc69\u200d\ud83d\udc66": [
+    "family_man_woman_boy"
+  ],
+  "\ud83d\udc68\u200d\ud83d\udc69\u200d\ud83d\udc66\u200d\ud83d\udc66": [
+    "family_man_woman_boy_boy"
+  ],
+  "\ud83d\udc68\u200d\ud83d\udc69\u200d\ud83d\udc67": [
+    "family_man_woman_girl"
+  ],
+  "\ud83d\udc68\u200d\ud83d\udc69\u200d\ud83d\udc67\u200d\ud83d\udc66": [
+    "family_man_woman_girl_boy"
+  ],
+  "\ud83d\udc68\u200d\ud83d\udc69\u200d\ud83d\udc67\u200d\ud83d\udc67": [
+    "family_man_woman_girl_girl"
+  ],
+  "\ud83d\udc68\u200d\ud83d\udcbb": [
+    "man_technologist"
+  ],
+  "\ud83d\udc68\u200d\ud83d\udcbc": [
+    "man_office_worker"
+  ],
+  "\ud83d\udc68\u200d\ud83d\udd27": [
+    "man_mechanic"
+  ],
+  "\ud83d\udc68\u200d\ud83d\udd2c": [
+    "man_scientist"
+  ],
+  "\ud83d\udc68\u200d\ud83d\ude80": [
+    "man_astronaut"
+  ],
+  "\ud83d\udc68\u200d\ud83d\ude92": [
+    "man_firefighter"
+  ],
+  "\ud83d\udc68\u200d\ud83e\uddaf": [
+    "man_with_white_cane",
+    "man_with_probing_cane"
+  ],
+  "\ud83d\udc68\u200d\ud83e\uddaf\u200d\u27a1": [
+    "man_with_white_cane_facing_right"
+  ],
+  "\ud83d\udc68\u200d\ud83e\uddaf\u200d\u27a1\ufe0f": [
+    "man_with_white_cane_facing_right"
+  ],
+  "\ud83d\udc68\u200d\ud83e\uddb0": [
+    "man_red_hair",
+    "red_haired_man"
+  ],
+  "\ud83d\udc68\u200d\ud83e\uddb1": [
+    "man_curly_hair",
+    "curly_haired_man"
+  ],
+  "\ud83d\udc68\u200d\ud83e\uddb2": [
+    "man_bald",
+    "bald_man"
+  ],
+  "\ud83d\udc68\u200d\ud83e\uddb3": [
+    "man_white_hair",
+    "white_haired_man"
+  ],
+  "\ud83d\udc68\u200d\ud83e\uddbc": [
+    "man_in_motorized_wheelchair"
+  ],
+  "\ud83d\udc68\u200d\ud83e\uddbc\u200d\u27a1": [
+    "man_in_motorized_wheelchair_facing_right"
+  ],
+  "\ud83d\udc68\u200d\ud83e\uddbc\u200d\u27a1\ufe0f": [
+    "man_in_motorized_wheelchair_facing_right"
+  ],
+  "\ud83d\udc68\u200d\ud83e\uddbd": [
+    "man_in_manual_wheelchair"
+  ],
+  "\ud83d\udc68\u200d\ud83e\uddbd\u200d\u27a1": [
+    "man_in_manual_wheelchair_facing_right"
+  ],
+  "\ud83d\udc68\u200d\ud83e\uddbd\u200d\u27a1\ufe0f": [
+    "man_in_manual_wheelchair_facing_right"
+  ],
+  "\ud83d\udc68\ud83c\udffb": [
+    "man_light_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffb\u200d\u2695": [
+    "man_health_worker_light_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffb\u200d\u2695\ufe0f": [
+    "man_health_worker_light_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffb\u200d\u2696": [
+    "man_judge_light_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffb\u200d\u2696\ufe0f": [
+    "man_judge_light_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffb\u200d\u2708": [
+    "man_pilot_light_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffb\u200d\u2708\ufe0f": [
+    "man_pilot_light_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffb\u200d\u2764\u200d\ud83d\udc68\ud83c\udffb": [
+    "couple_with_heart_man_man_light_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffb\u200d\u2764\u200d\ud83d\udc68\ud83c\udffc": [
+    "couple_with_heart_man_man_light_skin_tone_medium-light_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffb\u200d\u2764\u200d\ud83d\udc68\ud83c\udffd": [
+    "couple_with_heart_man_man_light_skin_tone_medium_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffb\u200d\u2764\u200d\ud83d\udc68\ud83c\udffe": [
+    "couple_with_heart_man_man_light_skin_tone_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffb\u200d\u2764\u200d\ud83d\udc68\ud83c\udfff": [
+    "couple_with_heart_man_man_light_skin_tone_dark_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffb\u200d\u2764\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udffb": [
+    "kiss_man_man_light_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffb\u200d\u2764\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udffc": [
+    "kiss_man_man_light_skin_tone_medium-light_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffb\u200d\u2764\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udffd": [
+    "kiss_man_man_light_skin_tone_medium_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffb\u200d\u2764\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udffe": [
+    "kiss_man_man_light_skin_tone_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffb\u200d\u2764\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udfff": [
+    "kiss_man_man_light_skin_tone_dark_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffb\u200d\u2764\ufe0f\u200d\ud83d\udc68\ud83c\udffb": [
+    "couple_with_heart_man_man_light_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffb\u200d\u2764\ufe0f\u200d\ud83d\udc68\ud83c\udffc": [
+    "couple_with_heart_man_man_light_skin_tone_medium-light_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffb\u200d\u2764\ufe0f\u200d\ud83d\udc68\ud83c\udffd": [
+    "couple_with_heart_man_man_light_skin_tone_medium_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffb\u200d\u2764\ufe0f\u200d\ud83d\udc68\ud83c\udffe": [
+    "couple_with_heart_man_man_light_skin_tone_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffb\u200d\u2764\ufe0f\u200d\ud83d\udc68\ud83c\udfff": [
+    "couple_with_heart_man_man_light_skin_tone_dark_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffb\u200d\u2764\ufe0f\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udffb": [
+    "kiss_man_man_light_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffb\u200d\u2764\ufe0f\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udffc": [
+    "kiss_man_man_light_skin_tone_medium-light_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffb\u200d\u2764\ufe0f\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udffd": [
+    "kiss_man_man_light_skin_tone_medium_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffb\u200d\u2764\ufe0f\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udffe": [
+    "kiss_man_man_light_skin_tone_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffb\u200d\u2764\ufe0f\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udfff": [
+    "kiss_man_man_light_skin_tone_dark_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffb\u200d\ud83c\udf3e": [
+    "man_farmer_light_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffb\u200d\ud83c\udf73": [
+    "man_cook_light_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffb\u200d\ud83c\udf7c": [
+    "man_feeding_baby_light_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffb\u200d\ud83c\udf93": [
+    "man_student_light_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffb\u200d\ud83c\udfa4": [
+    "man_singer_light_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffb\u200d\ud83c\udfa8": [
+    "man_artist_light_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffb\u200d\ud83c\udfeb": [
+    "man_teacher_light_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffb\u200d\ud83c\udfed": [
+    "man_factory_worker_light_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffb\u200d\ud83d\udcbb": [
+    "man_technologist_light_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffb\u200d\ud83d\udcbc": [
+    "man_office_worker_light_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffb\u200d\ud83d\udd27": [
+    "man_mechanic_light_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffb\u200d\ud83d\udd2c": [
+    "man_scientist_light_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffb\u200d\ud83d\ude80": [
+    "man_astronaut_light_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffb\u200d\ud83d\ude92": [
+    "man_firefighter_light_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffb\u200d\ud83e\udd1d\u200d\ud83d\udc68\ud83c\udffc": [
+    "men_holding_hands_light_skin_tone_medium-light_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffb\u200d\ud83e\udd1d\u200d\ud83d\udc68\ud83c\udffd": [
+    "men_holding_hands_light_skin_tone_medium_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffb\u200d\ud83e\udd1d\u200d\ud83d\udc68\ud83c\udffe": [
+    "men_holding_hands_light_skin_tone_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffb\u200d\ud83e\udd1d\u200d\ud83d\udc68\ud83c\udfff": [
+    "men_holding_hands_light_skin_tone_dark_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffb\u200d\ud83e\uddaf": [
+    "man_with_white_cane_light_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffb\u200d\ud83e\uddaf\u200d\u27a1": [
+    "man_with_white_cane_facing_right_light_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffb\u200d\ud83e\uddaf\u200d\u27a1\ufe0f": [
+    "man_with_white_cane_facing_right_light_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffb\u200d\ud83e\uddb0": [
+    "man_light_skin_tone_red_hair"
+  ],
+  "\ud83d\udc68\ud83c\udffb\u200d\ud83e\uddb1": [
+    "man_light_skin_tone_curly_hair"
+  ],
+  "\ud83d\udc68\ud83c\udffb\u200d\ud83e\uddb2": [
+    "man_light_skin_tone_bald"
+  ],
+  "\ud83d\udc68\ud83c\udffb\u200d\ud83e\uddb3": [
+    "man_light_skin_tone_white_hair"
+  ],
+  "\ud83d\udc68\ud83c\udffb\u200d\ud83e\uddbc": [
+    "man_in_motorized_wheelchair_light_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffb\u200d\ud83e\uddbc\u200d\u27a1": [
+    "man_in_motorized_wheelchair_facing_right_light_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffb\u200d\ud83e\uddbc\u200d\u27a1\ufe0f": [
+    "man_in_motorized_wheelchair_facing_right_light_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffb\u200d\ud83e\uddbd": [
+    "man_in_manual_wheelchair_light_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffb\u200d\ud83e\uddbd\u200d\u27a1": [
+    "man_in_manual_wheelchair_facing_right_light_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffb\u200d\ud83e\uddbd\u200d\u27a1\ufe0f": [
+    "man_in_manual_wheelchair_facing_right_light_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffc": [
+    "man_medium-light_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffc\u200d\u2695": [
+    "man_health_worker_medium-light_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffc\u200d\u2695\ufe0f": [
+    "man_health_worker_medium-light_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffc\u200d\u2696": [
+    "man_judge_medium-light_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffc\u200d\u2696\ufe0f": [
+    "man_judge_medium-light_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffc\u200d\u2708": [
+    "man_pilot_medium-light_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffc\u200d\u2708\ufe0f": [
+    "man_pilot_medium-light_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffc\u200d\u2764\u200d\ud83d\udc68\ud83c\udffb": [
+    "couple_with_heart_man_man_medium-light_skin_tone_light_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffc\u200d\u2764\u200d\ud83d\udc68\ud83c\udffc": [
+    "couple_with_heart_man_man_medium-light_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffc\u200d\u2764\u200d\ud83d\udc68\ud83c\udffd": [
+    "couple_with_heart_man_man_medium-light_skin_tone_medium_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffc\u200d\u2764\u200d\ud83d\udc68\ud83c\udffe": [
+    "couple_with_heart_man_man_medium-light_skin_tone_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffc\u200d\u2764\u200d\ud83d\udc68\ud83c\udfff": [
+    "couple_with_heart_man_man_medium-light_skin_tone_dark_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffc\u200d\u2764\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udffb": [
+    "kiss_man_man_medium-light_skin_tone_light_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffc\u200d\u2764\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udffc": [
+    "kiss_man_man_medium-light_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffc\u200d\u2764\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udffd": [
+    "kiss_man_man_medium-light_skin_tone_medium_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffc\u200d\u2764\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udffe": [
+    "kiss_man_man_medium-light_skin_tone_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffc\u200d\u2764\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udfff": [
+    "kiss_man_man_medium-light_skin_tone_dark_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffc\u200d\u2764\ufe0f\u200d\ud83d\udc68\ud83c\udffb": [
+    "couple_with_heart_man_man_medium-light_skin_tone_light_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffc\u200d\u2764\ufe0f\u200d\ud83d\udc68\ud83c\udffc": [
+    "couple_with_heart_man_man_medium-light_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffc\u200d\u2764\ufe0f\u200d\ud83d\udc68\ud83c\udffd": [
+    "couple_with_heart_man_man_medium-light_skin_tone_medium_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffc\u200d\u2764\ufe0f\u200d\ud83d\udc68\ud83c\udffe": [
+    "couple_with_heart_man_man_medium-light_skin_tone_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffc\u200d\u2764\ufe0f\u200d\ud83d\udc68\ud83c\udfff": [
+    "couple_with_heart_man_man_medium-light_skin_tone_dark_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffc\u200d\u2764\ufe0f\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udffb": [
+    "kiss_man_man_medium-light_skin_tone_light_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffc\u200d\u2764\ufe0f\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udffc": [
+    "kiss_man_man_medium-light_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffc\u200d\u2764\ufe0f\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udffd": [
+    "kiss_man_man_medium-light_skin_tone_medium_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffc\u200d\u2764\ufe0f\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udffe": [
+    "kiss_man_man_medium-light_skin_tone_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffc\u200d\u2764\ufe0f\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udfff": [
+    "kiss_man_man_medium-light_skin_tone_dark_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffc\u200d\ud83c\udf3e": [
+    "man_farmer_medium-light_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffc\u200d\ud83c\udf73": [
+    "man_cook_medium-light_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffc\u200d\ud83c\udf7c": [
+    "man_feeding_baby_medium-light_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffc\u200d\ud83c\udf93": [
+    "man_student_medium-light_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffc\u200d\ud83c\udfa4": [
+    "man_singer_medium-light_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffc\u200d\ud83c\udfa8": [
+    "man_artist_medium-light_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffc\u200d\ud83c\udfeb": [
+    "man_teacher_medium-light_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffc\u200d\ud83c\udfed": [
+    "man_factory_worker_medium-light_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffc\u200d\ud83d\udcbb": [
+    "man_technologist_medium-light_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffc\u200d\ud83d\udcbc": [
+    "man_office_worker_medium-light_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffc\u200d\ud83d\udd27": [
+    "man_mechanic_medium-light_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffc\u200d\ud83d\udd2c": [
+    "man_scientist_medium-light_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffc\u200d\ud83d\ude80": [
+    "man_astronaut_medium-light_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffc\u200d\ud83d\ude92": [
+    "man_firefighter_medium-light_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffc\u200d\ud83e\udd1d\u200d\ud83d\udc68\ud83c\udffb": [
+    "men_holding_hands_medium-light_skin_tone_light_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffc\u200d\ud83e\udd1d\u200d\ud83d\udc68\ud83c\udffd": [
+    "men_holding_hands_medium-light_skin_tone_medium_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffc\u200d\ud83e\udd1d\u200d\ud83d\udc68\ud83c\udffe": [
+    "men_holding_hands_medium-light_skin_tone_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffc\u200d\ud83e\udd1d\u200d\ud83d\udc68\ud83c\udfff": [
+    "men_holding_hands_medium-light_skin_tone_dark_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffc\u200d\ud83e\uddaf": [
+    "man_with_white_cane_medium-light_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffc\u200d\ud83e\uddaf\u200d\u27a1": [
+    "man_with_white_cane_facing_right_medium-light_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffc\u200d\ud83e\uddaf\u200d\u27a1\ufe0f": [
+    "man_with_white_cane_facing_right_medium-light_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffc\u200d\ud83e\uddb0": [
+    "man_medium-light_skin_tone_red_hair"
+  ],
+  "\ud83d\udc68\ud83c\udffc\u200d\ud83e\uddb1": [
+    "man_medium-light_skin_tone_curly_hair"
+  ],
+  "\ud83d\udc68\ud83c\udffc\u200d\ud83e\uddb2": [
+    "man_medium-light_skin_tone_bald"
+  ],
+  "\ud83d\udc68\ud83c\udffc\u200d\ud83e\uddb3": [
+    "man_medium-light_skin_tone_white_hair"
+  ],
+  "\ud83d\udc68\ud83c\udffc\u200d\ud83e\uddbc": [
+    "man_in_motorized_wheelchair_medium-light_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffc\u200d\ud83e\uddbc\u200d\u27a1": [
+    "man_in_motorized_wheelchair_facing_right_medium-light_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffc\u200d\ud83e\uddbc\u200d\u27a1\ufe0f": [
+    "man_in_motorized_wheelchair_facing_right_medium-light_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffc\u200d\ud83e\uddbd": [
+    "man_in_manual_wheelchair_medium-light_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffc\u200d\ud83e\uddbd\u200d\u27a1": [
+    "man_in_manual_wheelchair_facing_right_medium-light_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffc\u200d\ud83e\uddbd\u200d\u27a1\ufe0f": [
+    "man_in_manual_wheelchair_facing_right_medium-light_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffd": [
+    "man_medium_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffd\u200d\u2695": [
+    "man_health_worker_medium_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffd\u200d\u2695\ufe0f": [
+    "man_health_worker_medium_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffd\u200d\u2696": [
+    "man_judge_medium_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffd\u200d\u2696\ufe0f": [
+    "man_judge_medium_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffd\u200d\u2708": [
+    "man_pilot_medium_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffd\u200d\u2708\ufe0f": [
+    "man_pilot_medium_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffd\u200d\u2764\u200d\ud83d\udc68\ud83c\udffb": [
+    "couple_with_heart_man_man_medium_skin_tone_light_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffd\u200d\u2764\u200d\ud83d\udc68\ud83c\udffc": [
+    "couple_with_heart_man_man_medium_skin_tone_medium-light_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffd\u200d\u2764\u200d\ud83d\udc68\ud83c\udffd": [
+    "couple_with_heart_man_man_medium_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffd\u200d\u2764\u200d\ud83d\udc68\ud83c\udffe": [
+    "couple_with_heart_man_man_medium_skin_tone_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffd\u200d\u2764\u200d\ud83d\udc68\ud83c\udfff": [
+    "couple_with_heart_man_man_medium_skin_tone_dark_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffd\u200d\u2764\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udffb": [
+    "kiss_man_man_medium_skin_tone_light_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffd\u200d\u2764\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udffc": [
+    "kiss_man_man_medium_skin_tone_medium-light_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffd\u200d\u2764\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udffd": [
+    "kiss_man_man_medium_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffd\u200d\u2764\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udffe": [
+    "kiss_man_man_medium_skin_tone_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffd\u200d\u2764\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udfff": [
+    "kiss_man_man_medium_skin_tone_dark_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffd\u200d\u2764\ufe0f\u200d\ud83d\udc68\ud83c\udffb": [
+    "couple_with_heart_man_man_medium_skin_tone_light_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffd\u200d\u2764\ufe0f\u200d\ud83d\udc68\ud83c\udffc": [
+    "couple_with_heart_man_man_medium_skin_tone_medium-light_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffd\u200d\u2764\ufe0f\u200d\ud83d\udc68\ud83c\udffd": [
+    "couple_with_heart_man_man_medium_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffd\u200d\u2764\ufe0f\u200d\ud83d\udc68\ud83c\udffe": [
+    "couple_with_heart_man_man_medium_skin_tone_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffd\u200d\u2764\ufe0f\u200d\ud83d\udc68\ud83c\udfff": [
+    "couple_with_heart_man_man_medium_skin_tone_dark_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffd\u200d\u2764\ufe0f\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udffb": [
+    "kiss_man_man_medium_skin_tone_light_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffd\u200d\u2764\ufe0f\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udffc": [
+    "kiss_man_man_medium_skin_tone_medium-light_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffd\u200d\u2764\ufe0f\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udffd": [
+    "kiss_man_man_medium_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffd\u200d\u2764\ufe0f\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udffe": [
+    "kiss_man_man_medium_skin_tone_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffd\u200d\u2764\ufe0f\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udfff": [
+    "kiss_man_man_medium_skin_tone_dark_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffd\u200d\ud83c\udf3e": [
+    "man_farmer_medium_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffd\u200d\ud83c\udf73": [
+    "man_cook_medium_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffd\u200d\ud83c\udf7c": [
+    "man_feeding_baby_medium_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffd\u200d\ud83c\udf93": [
+    "man_student_medium_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffd\u200d\ud83c\udfa4": [
+    "man_singer_medium_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffd\u200d\ud83c\udfa8": [
+    "man_artist_medium_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffd\u200d\ud83c\udfeb": [
+    "man_teacher_medium_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffd\u200d\ud83c\udfed": [
+    "man_factory_worker_medium_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffd\u200d\ud83d\udcbb": [
+    "man_technologist_medium_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffd\u200d\ud83d\udcbc": [
+    "man_office_worker_medium_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffd\u200d\ud83d\udd27": [
+    "man_mechanic_medium_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffd\u200d\ud83d\udd2c": [
+    "man_scientist_medium_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffd\u200d\ud83d\ude80": [
+    "man_astronaut_medium_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffd\u200d\ud83d\ude92": [
+    "man_firefighter_medium_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffd\u200d\ud83e\udd1d\u200d\ud83d\udc68\ud83c\udffb": [
+    "men_holding_hands_medium_skin_tone_light_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffd\u200d\ud83e\udd1d\u200d\ud83d\udc68\ud83c\udffc": [
+    "men_holding_hands_medium_skin_tone_medium-light_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffd\u200d\ud83e\udd1d\u200d\ud83d\udc68\ud83c\udffe": [
+    "men_holding_hands_medium_skin_tone_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffd\u200d\ud83e\udd1d\u200d\ud83d\udc68\ud83c\udfff": [
+    "men_holding_hands_medium_skin_tone_dark_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffd\u200d\ud83e\uddaf": [
+    "man_with_white_cane_medium_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffd\u200d\ud83e\uddaf\u200d\u27a1": [
+    "man_with_white_cane_facing_right_medium_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffd\u200d\ud83e\uddaf\u200d\u27a1\ufe0f": [
+    "man_with_white_cane_facing_right_medium_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffd\u200d\ud83e\uddb0": [
+    "man_medium_skin_tone_red_hair"
+  ],
+  "\ud83d\udc68\ud83c\udffd\u200d\ud83e\uddb1": [
+    "man_medium_skin_tone_curly_hair"
+  ],
+  "\ud83d\udc68\ud83c\udffd\u200d\ud83e\uddb2": [
+    "man_medium_skin_tone_bald"
+  ],
+  "\ud83d\udc68\ud83c\udffd\u200d\ud83e\uddb3": [
+    "man_medium_skin_tone_white_hair"
+  ],
+  "\ud83d\udc68\ud83c\udffd\u200d\ud83e\uddbc": [
+    "man_in_motorized_wheelchair_medium_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffd\u200d\ud83e\uddbc\u200d\u27a1": [
+    "man_in_motorized_wheelchair_facing_right_medium_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffd\u200d\ud83e\uddbc\u200d\u27a1\ufe0f": [
+    "man_in_motorized_wheelchair_facing_right_medium_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffd\u200d\ud83e\uddbd": [
+    "man_in_manual_wheelchair_medium_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffd\u200d\ud83e\uddbd\u200d\u27a1": [
+    "man_in_manual_wheelchair_facing_right_medium_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffd\u200d\ud83e\uddbd\u200d\u27a1\ufe0f": [
+    "man_in_manual_wheelchair_facing_right_medium_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffe": [
+    "man_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffe\u200d\u2695": [
+    "man_health_worker_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffe\u200d\u2695\ufe0f": [
+    "man_health_worker_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffe\u200d\u2696": [
+    "man_judge_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffe\u200d\u2696\ufe0f": [
+    "man_judge_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffe\u200d\u2708": [
+    "man_pilot_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffe\u200d\u2708\ufe0f": [
+    "man_pilot_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffe\u200d\u2764\u200d\ud83d\udc68\ud83c\udffb": [
+    "couple_with_heart_man_man_medium-dark_skin_tone_light_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffe\u200d\u2764\u200d\ud83d\udc68\ud83c\udffc": [
+    "couple_with_heart_man_man_medium-dark_skin_tone_medium-light_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffe\u200d\u2764\u200d\ud83d\udc68\ud83c\udffd": [
+    "couple_with_heart_man_man_medium-dark_skin_tone_medium_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffe\u200d\u2764\u200d\ud83d\udc68\ud83c\udffe": [
+    "couple_with_heart_man_man_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffe\u200d\u2764\u200d\ud83d\udc68\ud83c\udfff": [
+    "couple_with_heart_man_man_medium-dark_skin_tone_dark_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffe\u200d\u2764\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udffb": [
+    "kiss_man_man_medium-dark_skin_tone_light_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffe\u200d\u2764\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udffc": [
+    "kiss_man_man_medium-dark_skin_tone_medium-light_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffe\u200d\u2764\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udffd": [
+    "kiss_man_man_medium-dark_skin_tone_medium_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffe\u200d\u2764\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udffe": [
+    "kiss_man_man_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffe\u200d\u2764\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udfff": [
+    "kiss_man_man_medium-dark_skin_tone_dark_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffe\u200d\u2764\ufe0f\u200d\ud83d\udc68\ud83c\udffb": [
+    "couple_with_heart_man_man_medium-dark_skin_tone_light_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffe\u200d\u2764\ufe0f\u200d\ud83d\udc68\ud83c\udffc": [
+    "couple_with_heart_man_man_medium-dark_skin_tone_medium-light_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffe\u200d\u2764\ufe0f\u200d\ud83d\udc68\ud83c\udffd": [
+    "couple_with_heart_man_man_medium-dark_skin_tone_medium_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffe\u200d\u2764\ufe0f\u200d\ud83d\udc68\ud83c\udffe": [
+    "couple_with_heart_man_man_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffe\u200d\u2764\ufe0f\u200d\ud83d\udc68\ud83c\udfff": [
+    "couple_with_heart_man_man_medium-dark_skin_tone_dark_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffe\u200d\u2764\ufe0f\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udffb": [
+    "kiss_man_man_medium-dark_skin_tone_light_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffe\u200d\u2764\ufe0f\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udffc": [
+    "kiss_man_man_medium-dark_skin_tone_medium-light_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffe\u200d\u2764\ufe0f\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udffd": [
+    "kiss_man_man_medium-dark_skin_tone_medium_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffe\u200d\u2764\ufe0f\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udffe": [
+    "kiss_man_man_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffe\u200d\u2764\ufe0f\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udfff": [
+    "kiss_man_man_medium-dark_skin_tone_dark_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffe\u200d\ud83c\udf3e": [
+    "man_farmer_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffe\u200d\ud83c\udf73": [
+    "man_cook_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffe\u200d\ud83c\udf7c": [
+    "man_feeding_baby_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffe\u200d\ud83c\udf93": [
+    "man_student_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffe\u200d\ud83c\udfa4": [
+    "man_singer_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffe\u200d\ud83c\udfa8": [
+    "man_artist_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffe\u200d\ud83c\udfeb": [
+    "man_teacher_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffe\u200d\ud83c\udfed": [
+    "man_factory_worker_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffe\u200d\ud83d\udcbb": [
+    "man_technologist_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffe\u200d\ud83d\udcbc": [
+    "man_office_worker_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffe\u200d\ud83d\udd27": [
+    "man_mechanic_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffe\u200d\ud83d\udd2c": [
+    "man_scientist_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffe\u200d\ud83d\ude80": [
+    "man_astronaut_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffe\u200d\ud83d\ude92": [
+    "man_firefighter_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffe\u200d\ud83e\udd1d\u200d\ud83d\udc68\ud83c\udffb": [
+    "men_holding_hands_medium-dark_skin_tone_light_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffe\u200d\ud83e\udd1d\u200d\ud83d\udc68\ud83c\udffc": [
+    "men_holding_hands_medium-dark_skin_tone_medium-light_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffe\u200d\ud83e\udd1d\u200d\ud83d\udc68\ud83c\udffd": [
+    "men_holding_hands_medium-dark_skin_tone_medium_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffe\u200d\ud83e\udd1d\u200d\ud83d\udc68\ud83c\udfff": [
+    "men_holding_hands_medium-dark_skin_tone_dark_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffe\u200d\ud83e\uddaf": [
+    "man_with_white_cane_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffe\u200d\ud83e\uddaf\u200d\u27a1": [
+    "man_with_white_cane_facing_right_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffe\u200d\ud83e\uddaf\u200d\u27a1\ufe0f": [
+    "man_with_white_cane_facing_right_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffe\u200d\ud83e\uddb0": [
+    "man_medium-dark_skin_tone_red_hair"
+  ],
+  "\ud83d\udc68\ud83c\udffe\u200d\ud83e\uddb1": [
+    "man_medium-dark_skin_tone_curly_hair"
+  ],
+  "\ud83d\udc68\ud83c\udffe\u200d\ud83e\uddb2": [
+    "man_medium-dark_skin_tone_bald"
+  ],
+  "\ud83d\udc68\ud83c\udffe\u200d\ud83e\uddb3": [
+    "man_medium-dark_skin_tone_white_hair"
+  ],
+  "\ud83d\udc68\ud83c\udffe\u200d\ud83e\uddbc": [
+    "man_in_motorized_wheelchair_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffe\u200d\ud83e\uddbc\u200d\u27a1": [
+    "man_in_motorized_wheelchair_facing_right_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffe\u200d\ud83e\uddbc\u200d\u27a1\ufe0f": [
+    "man_in_motorized_wheelchair_facing_right_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffe\u200d\ud83e\uddbd": [
+    "man_in_manual_wheelchair_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffe\u200d\ud83e\uddbd\u200d\u27a1": [
+    "man_in_manual_wheelchair_facing_right_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udffe\u200d\ud83e\uddbd\u200d\u27a1\ufe0f": [
+    "man_in_manual_wheelchair_facing_right_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udfff": [
+    "man_dark_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udfff\u200d\u2695": [
+    "man_health_worker_dark_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udfff\u200d\u2695\ufe0f": [
+    "man_health_worker_dark_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udfff\u200d\u2696": [
+    "man_judge_dark_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udfff\u200d\u2696\ufe0f": [
+    "man_judge_dark_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udfff\u200d\u2708": [
+    "man_pilot_dark_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udfff\u200d\u2708\ufe0f": [
+    "man_pilot_dark_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udfff\u200d\u2764\u200d\ud83d\udc68\ud83c\udffb": [
+    "couple_with_heart_man_man_dark_skin_tone_light_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udfff\u200d\u2764\u200d\ud83d\udc68\ud83c\udffc": [
+    "couple_with_heart_man_man_dark_skin_tone_medium-light_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udfff\u200d\u2764\u200d\ud83d\udc68\ud83c\udffd": [
+    "couple_with_heart_man_man_dark_skin_tone_medium_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udfff\u200d\u2764\u200d\ud83d\udc68\ud83c\udffe": [
+    "couple_with_heart_man_man_dark_skin_tone_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udfff\u200d\u2764\u200d\ud83d\udc68\ud83c\udfff": [
+    "couple_with_heart_man_man_dark_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udfff\u200d\u2764\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udffb": [
+    "kiss_man_man_dark_skin_tone_light_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udfff\u200d\u2764\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udffc": [
+    "kiss_man_man_dark_skin_tone_medium-light_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udfff\u200d\u2764\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udffd": [
+    "kiss_man_man_dark_skin_tone_medium_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udfff\u200d\u2764\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udffe": [
+    "kiss_man_man_dark_skin_tone_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udfff\u200d\u2764\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udfff": [
+    "kiss_man_man_dark_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udfff\u200d\u2764\ufe0f\u200d\ud83d\udc68\ud83c\udffb": [
+    "couple_with_heart_man_man_dark_skin_tone_light_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udfff\u200d\u2764\ufe0f\u200d\ud83d\udc68\ud83c\udffc": [
+    "couple_with_heart_man_man_dark_skin_tone_medium-light_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udfff\u200d\u2764\ufe0f\u200d\ud83d\udc68\ud83c\udffd": [
+    "couple_with_heart_man_man_dark_skin_tone_medium_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udfff\u200d\u2764\ufe0f\u200d\ud83d\udc68\ud83c\udffe": [
+    "couple_with_heart_man_man_dark_skin_tone_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udfff\u200d\u2764\ufe0f\u200d\ud83d\udc68\ud83c\udfff": [
+    "couple_with_heart_man_man_dark_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udfff\u200d\u2764\ufe0f\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udffb": [
+    "kiss_man_man_dark_skin_tone_light_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udfff\u200d\u2764\ufe0f\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udffc": [
+    "kiss_man_man_dark_skin_tone_medium-light_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udfff\u200d\u2764\ufe0f\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udffd": [
+    "kiss_man_man_dark_skin_tone_medium_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udfff\u200d\u2764\ufe0f\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udffe": [
+    "kiss_man_man_dark_skin_tone_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udfff\u200d\u2764\ufe0f\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udfff": [
+    "kiss_man_man_dark_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udfff\u200d\ud83c\udf3e": [
+    "man_farmer_dark_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udfff\u200d\ud83c\udf73": [
+    "man_cook_dark_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udfff\u200d\ud83c\udf7c": [
+    "man_feeding_baby_dark_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udfff\u200d\ud83c\udf93": [
+    "man_student_dark_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udfff\u200d\ud83c\udfa4": [
+    "man_singer_dark_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udfff\u200d\ud83c\udfa8": [
+    "man_artist_dark_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udfff\u200d\ud83c\udfeb": [
+    "man_teacher_dark_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udfff\u200d\ud83c\udfed": [
+    "man_factory_worker_dark_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udfff\u200d\ud83d\udcbb": [
+    "man_technologist_dark_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udfff\u200d\ud83d\udcbc": [
+    "man_office_worker_dark_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udfff\u200d\ud83d\udd27": [
+    "man_mechanic_dark_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udfff\u200d\ud83d\udd2c": [
+    "man_scientist_dark_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udfff\u200d\ud83d\ude80": [
+    "man_astronaut_dark_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udfff\u200d\ud83d\ude92": [
+    "man_firefighter_dark_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udfff\u200d\ud83e\udd1d\u200d\ud83d\udc68\ud83c\udffb": [
+    "men_holding_hands_dark_skin_tone_light_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udfff\u200d\ud83e\udd1d\u200d\ud83d\udc68\ud83c\udffc": [
+    "men_holding_hands_dark_skin_tone_medium-light_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udfff\u200d\ud83e\udd1d\u200d\ud83d\udc68\ud83c\udffd": [
+    "men_holding_hands_dark_skin_tone_medium_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udfff\u200d\ud83e\udd1d\u200d\ud83d\udc68\ud83c\udffe": [
+    "men_holding_hands_dark_skin_tone_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udfff\u200d\ud83e\uddaf": [
+    "man_with_white_cane_dark_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udfff\u200d\ud83e\uddaf\u200d\u27a1": [
+    "man_with_white_cane_facing_right_dark_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udfff\u200d\ud83e\uddaf\u200d\u27a1\ufe0f": [
+    "man_with_white_cane_facing_right_dark_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udfff\u200d\ud83e\uddb0": [
+    "man_dark_skin_tone_red_hair"
+  ],
+  "\ud83d\udc68\ud83c\udfff\u200d\ud83e\uddb1": [
+    "man_dark_skin_tone_curly_hair"
+  ],
+  "\ud83d\udc68\ud83c\udfff\u200d\ud83e\uddb2": [
+    "man_dark_skin_tone_bald"
+  ],
+  "\ud83d\udc68\ud83c\udfff\u200d\ud83e\uddb3": [
+    "man_dark_skin_tone_white_hair"
+  ],
+  "\ud83d\udc68\ud83c\udfff\u200d\ud83e\uddbc": [
+    "man_in_motorized_wheelchair_dark_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udfff\u200d\ud83e\uddbc\u200d\u27a1": [
+    "man_in_motorized_wheelchair_facing_right_dark_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udfff\u200d\ud83e\uddbc\u200d\u27a1\ufe0f": [
+    "man_in_motorized_wheelchair_facing_right_dark_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udfff\u200d\ud83e\uddbd": [
+    "man_in_manual_wheelchair_dark_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udfff\u200d\ud83e\uddbd\u200d\u27a1": [
+    "man_in_manual_wheelchair_facing_right_dark_skin_tone"
+  ],
+  "\ud83d\udc68\ud83c\udfff\u200d\ud83e\uddbd\u200d\u27a1\ufe0f": [
+    "man_in_manual_wheelchair_facing_right_dark_skin_tone"
+  ],
+  "\ud83d\udc69": [
+    "woman"
+  ],
+  "\ud83d\udc69\u200d\u2695": [
+    "woman_health_worker"
+  ],
+  "\ud83d\udc69\u200d\u2695\ufe0f": [
+    "woman_health_worker"
+  ],
+  "\ud83d\udc69\u200d\u2696": [
+    "woman_judge"
+  ],
+  "\ud83d\udc69\u200d\u2696\ufe0f": [
+    "woman_judge"
+  ],
+  "\ud83d\udc69\u200d\u2708": [
+    "woman_pilot"
+  ],
+  "\ud83d\udc69\u200d\u2708\ufe0f": [
+    "woman_pilot"
+  ],
+  "\ud83d\udc69\u200d\u2764\u200d\ud83d\udc68": [
+    "couple_with_heart_woman_man"
+  ],
+  "\ud83d\udc69\u200d\u2764\u200d\ud83d\udc69": [
+    "couple_with_heart_woman_woman"
+  ],
+  "\ud83d\udc69\u200d\u2764\u200d\ud83d\udc8b\u200d\ud83d\udc68": [
+    "kiss_woman_man",
+    "couplekiss_man_woman"
+  ],
+  "\ud83d\udc69\u200d\u2764\u200d\ud83d\udc8b\u200d\ud83d\udc69": [
+    "kiss_woman_woman",
+    "couplekiss_woman_woman"
+  ],
+  "\ud83d\udc69\u200d\u2764\ufe0f\u200d\ud83d\udc68": [
+    "couple_with_heart_woman_man"
+  ],
+  "\ud83d\udc69\u200d\u2764\ufe0f\u200d\ud83d\udc69": [
+    "couple_with_heart_woman_woman"
+  ],
+  "\ud83d\udc69\u200d\u2764\ufe0f\u200d\ud83d\udc8b\u200d\ud83d\udc68": [
+    "kiss_woman_man",
+    "couplekiss_man_woman"
+  ],
+  "\ud83d\udc69\u200d\u2764\ufe0f\u200d\ud83d\udc8b\u200d\ud83d\udc69": [
+    "kiss_woman_woman",
+    "couplekiss_woman_woman"
+  ],
+  "\ud83d\udc69\u200d\ud83c\udf3e": [
+    "woman_farmer"
+  ],
+  "\ud83d\udc69\u200d\ud83c\udf73": [
+    "woman_cook"
+  ],
+  "\ud83d\udc69\u200d\ud83c\udf7c": [
+    "woman_feeding_baby"
+  ],
+  "\ud83d\udc69\u200d\ud83c\udf93": [
+    "woman_student"
+  ],
+  "\ud83d\udc69\u200d\ud83c\udfa4": [
+    "woman_singer"
+  ],
+  "\ud83d\udc69\u200d\ud83c\udfa8": [
+    "woman_artist"
+  ],
+  "\ud83d\udc69\u200d\ud83c\udfeb": [
+    "woman_teacher"
+  ],
+  "\ud83d\udc69\u200d\ud83c\udfed": [
+    "woman_factory_worker"
+  ],
+  "\ud83d\udc69\u200d\ud83d\udc66": [
+    "family_woman_boy"
+  ],
+  "\ud83d\udc69\u200d\ud83d\udc66\u200d\ud83d\udc66": [
+    "family_woman_boy_boy"
+  ],
+  "\ud83d\udc69\u200d\ud83d\udc67": [
+    "family_woman_girl"
+  ],
+  "\ud83d\udc69\u200d\ud83d\udc67\u200d\ud83d\udc66": [
+    "family_woman_girl_boy"
+  ],
+  "\ud83d\udc69\u200d\ud83d\udc67\u200d\ud83d\udc67": [
+    "family_woman_girl_girl"
+  ],
+  "\ud83d\udc69\u200d\ud83d\udc69\u200d\ud83d\udc66": [
+    "family_woman_woman_boy"
+  ],
+  "\ud83d\udc69\u200d\ud83d\udc69\u200d\ud83d\udc66\u200d\ud83d\udc66": [
+    "family_woman_woman_boy_boy"
+  ],
+  "\ud83d\udc69\u200d\ud83d\udc69\u200d\ud83d\udc67": [
+    "family_woman_woman_girl"
+  ],
+  "\ud83d\udc69\u200d\ud83d\udc69\u200d\ud83d\udc67\u200d\ud83d\udc66": [
+    "family_woman_woman_girl_boy"
+  ],
+  "\ud83d\udc69\u200d\ud83d\udc69\u200d\ud83d\udc67\u200d\ud83d\udc67": [
+    "family_woman_woman_girl_girl"
+  ],
+  "\ud83d\udc69\u200d\ud83d\udcbb": [
+    "woman_technologist"
+  ],
+  "\ud83d\udc69\u200d\ud83d\udcbc": [
+    "woman_office_worker"
+  ],
+  "\ud83d\udc69\u200d\ud83d\udd27": [
+    "woman_mechanic"
+  ],
+  "\ud83d\udc69\u200d\ud83d\udd2c": [
+    "woman_scientist"
+  ],
+  "\ud83d\udc69\u200d\ud83d\ude80": [
+    "woman_astronaut"
+  ],
+  "\ud83d\udc69\u200d\ud83d\ude92": [
+    "woman_firefighter"
+  ],
+  "\ud83d\udc69\u200d\ud83e\uddaf": [
+    "woman_with_white_cane",
+    "woman_with_probing_cane"
+  ],
+  "\ud83d\udc69\u200d\ud83e\uddaf\u200d\u27a1": [
+    "woman_with_white_cane_facing_right"
+  ],
+  "\ud83d\udc69\u200d\ud83e\uddaf\u200d\u27a1\ufe0f": [
+    "woman_with_white_cane_facing_right"
+  ],
+  "\ud83d\udc69\u200d\ud83e\uddb0": [
+    "woman_red_hair",
+    "red_haired_woman"
+  ],
+  "\ud83d\udc69\u200d\ud83e\uddb1": [
+    "woman_curly_hair",
+    "curly_haired_woman"
+  ],
+  "\ud83d\udc69\u200d\ud83e\uddb2": [
+    "woman_bald",
+    "bald_woman"
+  ],
+  "\ud83d\udc69\u200d\ud83e\uddb3": [
+    "woman_white_hair",
+    "white_haired_woman"
+  ],
+  "\ud83d\udc69\u200d\ud83e\uddbc": [
+    "woman_in_motorized_wheelchair"
+  ],
+  "\ud83d\udc69\u200d\ud83e\uddbc\u200d\u27a1": [
+    "woman_in_motorized_wheelchair_facing_right"
+  ],
+  "\ud83d\udc69\u200d\ud83e\uddbc\u200d\u27a1\ufe0f": [
+    "woman_in_motorized_wheelchair_facing_right"
+  ],
+  "\ud83d\udc69\u200d\ud83e\uddbd": [
+    "woman_in_manual_wheelchair"
+  ],
+  "\ud83d\udc69\u200d\ud83e\uddbd\u200d\u27a1": [
+    "woman_in_manual_wheelchair_facing_right"
+  ],
+  "\ud83d\udc69\u200d\ud83e\uddbd\u200d\u27a1\ufe0f": [
+    "woman_in_manual_wheelchair_facing_right"
+  ],
+  "\ud83d\udc69\ud83c\udffb": [
+    "woman_light_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffb\u200d\u2695": [
+    "woman_health_worker_light_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffb\u200d\u2695\ufe0f": [
+    "woman_health_worker_light_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffb\u200d\u2696": [
+    "woman_judge_light_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffb\u200d\u2696\ufe0f": [
+    "woman_judge_light_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffb\u200d\u2708": [
+    "woman_pilot_light_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffb\u200d\u2708\ufe0f": [
+    "woman_pilot_light_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffb\u200d\u2764\u200d\ud83d\udc68\ud83c\udffb": [
+    "couple_with_heart_woman_man_light_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffb\u200d\u2764\u200d\ud83d\udc68\ud83c\udffc": [
+    "couple_with_heart_woman_man_light_skin_tone_medium-light_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffb\u200d\u2764\u200d\ud83d\udc68\ud83c\udffd": [
+    "couple_with_heart_woman_man_light_skin_tone_medium_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffb\u200d\u2764\u200d\ud83d\udc68\ud83c\udffe": [
+    "couple_with_heart_woman_man_light_skin_tone_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffb\u200d\u2764\u200d\ud83d\udc68\ud83c\udfff": [
+    "couple_with_heart_woman_man_light_skin_tone_dark_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffb\u200d\u2764\u200d\ud83d\udc69\ud83c\udffb": [
+    "couple_with_heart_woman_woman_light_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffb\u200d\u2764\u200d\ud83d\udc69\ud83c\udffc": [
+    "couple_with_heart_woman_woman_light_skin_tone_medium-light_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffb\u200d\u2764\u200d\ud83d\udc69\ud83c\udffd": [
+    "couple_with_heart_woman_woman_light_skin_tone_medium_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffb\u200d\u2764\u200d\ud83d\udc69\ud83c\udffe": [
+    "couple_with_heart_woman_woman_light_skin_tone_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffb\u200d\u2764\u200d\ud83d\udc69\ud83c\udfff": [
+    "couple_with_heart_woman_woman_light_skin_tone_dark_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffb\u200d\u2764\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udffb": [
+    "kiss_woman_man_light_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffb\u200d\u2764\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udffc": [
+    "kiss_woman_man_light_skin_tone_medium-light_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffb\u200d\u2764\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udffd": [
+    "kiss_woman_man_light_skin_tone_medium_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffb\u200d\u2764\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udffe": [
+    "kiss_woman_man_light_skin_tone_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffb\u200d\u2764\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udfff": [
+    "kiss_woman_man_light_skin_tone_dark_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffb\u200d\u2764\u200d\ud83d\udc8b\u200d\ud83d\udc69\ud83c\udffb": [
+    "kiss_woman_woman_light_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffb\u200d\u2764\u200d\ud83d\udc8b\u200d\ud83d\udc69\ud83c\udffc": [
+    "kiss_woman_woman_light_skin_tone_medium-light_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffb\u200d\u2764\u200d\ud83d\udc8b\u200d\ud83d\udc69\ud83c\udffd": [
+    "kiss_woman_woman_light_skin_tone_medium_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffb\u200d\u2764\u200d\ud83d\udc8b\u200d\ud83d\udc69\ud83c\udffe": [
+    "kiss_woman_woman_light_skin_tone_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffb\u200d\u2764\u200d\ud83d\udc8b\u200d\ud83d\udc69\ud83c\udfff": [
+    "kiss_woman_woman_light_skin_tone_dark_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffb\u200d\u2764\ufe0f\u200d\ud83d\udc68\ud83c\udffb": [
+    "couple_with_heart_woman_man_light_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffb\u200d\u2764\ufe0f\u200d\ud83d\udc68\ud83c\udffc": [
+    "couple_with_heart_woman_man_light_skin_tone_medium-light_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffb\u200d\u2764\ufe0f\u200d\ud83d\udc68\ud83c\udffd": [
+    "couple_with_heart_woman_man_light_skin_tone_medium_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffb\u200d\u2764\ufe0f\u200d\ud83d\udc68\ud83c\udffe": [
+    "couple_with_heart_woman_man_light_skin_tone_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffb\u200d\u2764\ufe0f\u200d\ud83d\udc68\ud83c\udfff": [
+    "couple_with_heart_woman_man_light_skin_tone_dark_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffb\u200d\u2764\ufe0f\u200d\ud83d\udc69\ud83c\udffb": [
+    "couple_with_heart_woman_woman_light_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffb\u200d\u2764\ufe0f\u200d\ud83d\udc69\ud83c\udffc": [
+    "couple_with_heart_woman_woman_light_skin_tone_medium-light_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffb\u200d\u2764\ufe0f\u200d\ud83d\udc69\ud83c\udffd": [
+    "couple_with_heart_woman_woman_light_skin_tone_medium_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffb\u200d\u2764\ufe0f\u200d\ud83d\udc69\ud83c\udffe": [
+    "couple_with_heart_woman_woman_light_skin_tone_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffb\u200d\u2764\ufe0f\u200d\ud83d\udc69\ud83c\udfff": [
+    "couple_with_heart_woman_woman_light_skin_tone_dark_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffb\u200d\u2764\ufe0f\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udffb": [
+    "kiss_woman_man_light_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffb\u200d\u2764\ufe0f\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udffc": [
+    "kiss_woman_man_light_skin_tone_medium-light_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffb\u200d\u2764\ufe0f\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udffd": [
+    "kiss_woman_man_light_skin_tone_medium_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffb\u200d\u2764\ufe0f\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udffe": [
+    "kiss_woman_man_light_skin_tone_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffb\u200d\u2764\ufe0f\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udfff": [
+    "kiss_woman_man_light_skin_tone_dark_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffb\u200d\u2764\ufe0f\u200d\ud83d\udc8b\u200d\ud83d\udc69\ud83c\udffb": [
+    "kiss_woman_woman_light_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffb\u200d\u2764\ufe0f\u200d\ud83d\udc8b\u200d\ud83d\udc69\ud83c\udffc": [
+    "kiss_woman_woman_light_skin_tone_medium-light_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffb\u200d\u2764\ufe0f\u200d\ud83d\udc8b\u200d\ud83d\udc69\ud83c\udffd": [
+    "kiss_woman_woman_light_skin_tone_medium_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffb\u200d\u2764\ufe0f\u200d\ud83d\udc8b\u200d\ud83d\udc69\ud83c\udffe": [
+    "kiss_woman_woman_light_skin_tone_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffb\u200d\u2764\ufe0f\u200d\ud83d\udc8b\u200d\ud83d\udc69\ud83c\udfff": [
+    "kiss_woman_woman_light_skin_tone_dark_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffb\u200d\ud83c\udf3e": [
+    "woman_farmer_light_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffb\u200d\ud83c\udf73": [
+    "woman_cook_light_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffb\u200d\ud83c\udf7c": [
+    "woman_feeding_baby_light_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffb\u200d\ud83c\udf93": [
+    "woman_student_light_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffb\u200d\ud83c\udfa4": [
+    "woman_singer_light_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffb\u200d\ud83c\udfa8": [
+    "woman_artist_light_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffb\u200d\ud83c\udfeb": [
+    "woman_teacher_light_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffb\u200d\ud83c\udfed": [
+    "woman_factory_worker_light_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffb\u200d\ud83d\udcbb": [
+    "woman_technologist_light_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffb\u200d\ud83d\udcbc": [
+    "woman_office_worker_light_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffb\u200d\ud83d\udd27": [
+    "woman_mechanic_light_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffb\u200d\ud83d\udd2c": [
+    "woman_scientist_light_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffb\u200d\ud83d\ude80": [
+    "woman_astronaut_light_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffb\u200d\ud83d\ude92": [
+    "woman_firefighter_light_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffb\u200d\ud83e\udd1d\u200d\ud83d\udc68\ud83c\udffc": [
+    "woman_and_man_holding_hands_light_skin_tone_medium-light_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffb\u200d\ud83e\udd1d\u200d\ud83d\udc68\ud83c\udffd": [
+    "woman_and_man_holding_hands_light_skin_tone_medium_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffb\u200d\ud83e\udd1d\u200d\ud83d\udc68\ud83c\udffe": [
+    "woman_and_man_holding_hands_light_skin_tone_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffb\u200d\ud83e\udd1d\u200d\ud83d\udc68\ud83c\udfff": [
+    "woman_and_man_holding_hands_light_skin_tone_dark_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffb\u200d\ud83e\udd1d\u200d\ud83d\udc69\ud83c\udffc": [
+    "women_holding_hands_light_skin_tone_medium-light_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffb\u200d\ud83e\udd1d\u200d\ud83d\udc69\ud83c\udffd": [
+    "women_holding_hands_light_skin_tone_medium_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffb\u200d\ud83e\udd1d\u200d\ud83d\udc69\ud83c\udffe": [
+    "women_holding_hands_light_skin_tone_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffb\u200d\ud83e\udd1d\u200d\ud83d\udc69\ud83c\udfff": [
+    "women_holding_hands_light_skin_tone_dark_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffb\u200d\ud83e\uddaf": [
+    "woman_with_white_cane_light_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffb\u200d\ud83e\uddaf\u200d\u27a1": [
+    "woman_with_white_cane_facing_right_light_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffb\u200d\ud83e\uddaf\u200d\u27a1\ufe0f": [
+    "woman_with_white_cane_facing_right_light_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffb\u200d\ud83e\uddb0": [
+    "woman_light_skin_tone_red_hair"
+  ],
+  "\ud83d\udc69\ud83c\udffb\u200d\ud83e\uddb1": [
+    "woman_light_skin_tone_curly_hair"
+  ],
+  "\ud83d\udc69\ud83c\udffb\u200d\ud83e\uddb2": [
+    "woman_light_skin_tone_bald"
+  ],
+  "\ud83d\udc69\ud83c\udffb\u200d\ud83e\uddb3": [
+    "woman_light_skin_tone_white_hair"
+  ],
+  "\ud83d\udc69\ud83c\udffb\u200d\ud83e\uddbc": [
+    "woman_in_motorized_wheelchair_light_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffb\u200d\ud83e\uddbc\u200d\u27a1": [
+    "woman_in_motorized_wheelchair_facing_right_light_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffb\u200d\ud83e\uddbc\u200d\u27a1\ufe0f": [
+    "woman_in_motorized_wheelchair_facing_right_light_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffb\u200d\ud83e\uddbd": [
+    "woman_in_manual_wheelchair_light_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffb\u200d\ud83e\uddbd\u200d\u27a1": [
+    "woman_in_manual_wheelchair_facing_right_light_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffb\u200d\ud83e\uddbd\u200d\u27a1\ufe0f": [
+    "woman_in_manual_wheelchair_facing_right_light_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffc": [
+    "woman_medium-light_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffc\u200d\u2695": [
+    "woman_health_worker_medium-light_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffc\u200d\u2695\ufe0f": [
+    "woman_health_worker_medium-light_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffc\u200d\u2696": [
+    "woman_judge_medium-light_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffc\u200d\u2696\ufe0f": [
+    "woman_judge_medium-light_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffc\u200d\u2708": [
+    "woman_pilot_medium-light_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffc\u200d\u2708\ufe0f": [
+    "woman_pilot_medium-light_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffc\u200d\u2764\u200d\ud83d\udc68\ud83c\udffb": [
+    "couple_with_heart_woman_man_medium-light_skin_tone_light_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffc\u200d\u2764\u200d\ud83d\udc68\ud83c\udffc": [
+    "couple_with_heart_woman_man_medium-light_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffc\u200d\u2764\u200d\ud83d\udc68\ud83c\udffd": [
+    "couple_with_heart_woman_man_medium-light_skin_tone_medium_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffc\u200d\u2764\u200d\ud83d\udc68\ud83c\udffe": [
+    "couple_with_heart_woman_man_medium-light_skin_tone_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffc\u200d\u2764\u200d\ud83d\udc68\ud83c\udfff": [
+    "couple_with_heart_woman_man_medium-light_skin_tone_dark_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffc\u200d\u2764\u200d\ud83d\udc69\ud83c\udffb": [
+    "couple_with_heart_woman_woman_medium-light_skin_tone_light_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffc\u200d\u2764\u200d\ud83d\udc69\ud83c\udffc": [
+    "couple_with_heart_woman_woman_medium-light_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffc\u200d\u2764\u200d\ud83d\udc69\ud83c\udffd": [
+    "couple_with_heart_woman_woman_medium-light_skin_tone_medium_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffc\u200d\u2764\u200d\ud83d\udc69\ud83c\udffe": [
+    "couple_with_heart_woman_woman_medium-light_skin_tone_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffc\u200d\u2764\u200d\ud83d\udc69\ud83c\udfff": [
+    "couple_with_heart_woman_woman_medium-light_skin_tone_dark_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffc\u200d\u2764\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udffb": [
+    "kiss_woman_man_medium-light_skin_tone_light_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffc\u200d\u2764\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udffc": [
+    "kiss_woman_man_medium-light_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffc\u200d\u2764\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udffd": [
+    "kiss_woman_man_medium-light_skin_tone_medium_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffc\u200d\u2764\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udffe": [
+    "kiss_woman_man_medium-light_skin_tone_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffc\u200d\u2764\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udfff": [
+    "kiss_woman_man_medium-light_skin_tone_dark_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffc\u200d\u2764\u200d\ud83d\udc8b\u200d\ud83d\udc69\ud83c\udffb": [
+    "kiss_woman_woman_medium-light_skin_tone_light_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffc\u200d\u2764\u200d\ud83d\udc8b\u200d\ud83d\udc69\ud83c\udffc": [
+    "kiss_woman_woman_medium-light_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffc\u200d\u2764\u200d\ud83d\udc8b\u200d\ud83d\udc69\ud83c\udffd": [
+    "kiss_woman_woman_medium-light_skin_tone_medium_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffc\u200d\u2764\u200d\ud83d\udc8b\u200d\ud83d\udc69\ud83c\udffe": [
+    "kiss_woman_woman_medium-light_skin_tone_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffc\u200d\u2764\u200d\ud83d\udc8b\u200d\ud83d\udc69\ud83c\udfff": [
+    "kiss_woman_woman_medium-light_skin_tone_dark_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffc\u200d\u2764\ufe0f\u200d\ud83d\udc68\ud83c\udffb": [
+    "couple_with_heart_woman_man_medium-light_skin_tone_light_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffc\u200d\u2764\ufe0f\u200d\ud83d\udc68\ud83c\udffc": [
+    "couple_with_heart_woman_man_medium-light_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffc\u200d\u2764\ufe0f\u200d\ud83d\udc68\ud83c\udffd": [
+    "couple_with_heart_woman_man_medium-light_skin_tone_medium_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffc\u200d\u2764\ufe0f\u200d\ud83d\udc68\ud83c\udffe": [
+    "couple_with_heart_woman_man_medium-light_skin_tone_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffc\u200d\u2764\ufe0f\u200d\ud83d\udc68\ud83c\udfff": [
+    "couple_with_heart_woman_man_medium-light_skin_tone_dark_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffc\u200d\u2764\ufe0f\u200d\ud83d\udc69\ud83c\udffb": [
+    "couple_with_heart_woman_woman_medium-light_skin_tone_light_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffc\u200d\u2764\ufe0f\u200d\ud83d\udc69\ud83c\udffc": [
+    "couple_with_heart_woman_woman_medium-light_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffc\u200d\u2764\ufe0f\u200d\ud83d\udc69\ud83c\udffd": [
+    "couple_with_heart_woman_woman_medium-light_skin_tone_medium_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffc\u200d\u2764\ufe0f\u200d\ud83d\udc69\ud83c\udffe": [
+    "couple_with_heart_woman_woman_medium-light_skin_tone_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffc\u200d\u2764\ufe0f\u200d\ud83d\udc69\ud83c\udfff": [
+    "couple_with_heart_woman_woman_medium-light_skin_tone_dark_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffc\u200d\u2764\ufe0f\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udffb": [
+    "kiss_woman_man_medium-light_skin_tone_light_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffc\u200d\u2764\ufe0f\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udffc": [
+    "kiss_woman_man_medium-light_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffc\u200d\u2764\ufe0f\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udffd": [
+    "kiss_woman_man_medium-light_skin_tone_medium_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffc\u200d\u2764\ufe0f\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udffe": [
+    "kiss_woman_man_medium-light_skin_tone_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffc\u200d\u2764\ufe0f\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udfff": [
+    "kiss_woman_man_medium-light_skin_tone_dark_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffc\u200d\u2764\ufe0f\u200d\ud83d\udc8b\u200d\ud83d\udc69\ud83c\udffb": [
+    "kiss_woman_woman_medium-light_skin_tone_light_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffc\u200d\u2764\ufe0f\u200d\ud83d\udc8b\u200d\ud83d\udc69\ud83c\udffc": [
+    "kiss_woman_woman_medium-light_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffc\u200d\u2764\ufe0f\u200d\ud83d\udc8b\u200d\ud83d\udc69\ud83c\udffd": [
+    "kiss_woman_woman_medium-light_skin_tone_medium_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffc\u200d\u2764\ufe0f\u200d\ud83d\udc8b\u200d\ud83d\udc69\ud83c\udffe": [
+    "kiss_woman_woman_medium-light_skin_tone_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffc\u200d\u2764\ufe0f\u200d\ud83d\udc8b\u200d\ud83d\udc69\ud83c\udfff": [
+    "kiss_woman_woman_medium-light_skin_tone_dark_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffc\u200d\ud83c\udf3e": [
+    "woman_farmer_medium-light_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffc\u200d\ud83c\udf73": [
+    "woman_cook_medium-light_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffc\u200d\ud83c\udf7c": [
+    "woman_feeding_baby_medium-light_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffc\u200d\ud83c\udf93": [
+    "woman_student_medium-light_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffc\u200d\ud83c\udfa4": [
+    "woman_singer_medium-light_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffc\u200d\ud83c\udfa8": [
+    "woman_artist_medium-light_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffc\u200d\ud83c\udfeb": [
+    "woman_teacher_medium-light_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffc\u200d\ud83c\udfed": [
+    "woman_factory_worker_medium-light_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffc\u200d\ud83d\udcbb": [
+    "woman_technologist_medium-light_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffc\u200d\ud83d\udcbc": [
+    "woman_office_worker_medium-light_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffc\u200d\ud83d\udd27": [
+    "woman_mechanic_medium-light_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffc\u200d\ud83d\udd2c": [
+    "woman_scientist_medium-light_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffc\u200d\ud83d\ude80": [
+    "woman_astronaut_medium-light_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffc\u200d\ud83d\ude92": [
+    "woman_firefighter_medium-light_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffc\u200d\ud83e\udd1d\u200d\ud83d\udc68\ud83c\udffb": [
+    "woman_and_man_holding_hands_medium-light_skin_tone_light_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffc\u200d\ud83e\udd1d\u200d\ud83d\udc68\ud83c\udffd": [
+    "woman_and_man_holding_hands_medium-light_skin_tone_medium_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffc\u200d\ud83e\udd1d\u200d\ud83d\udc68\ud83c\udffe": [
+    "woman_and_man_holding_hands_medium-light_skin_tone_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffc\u200d\ud83e\udd1d\u200d\ud83d\udc68\ud83c\udfff": [
+    "woman_and_man_holding_hands_medium-light_skin_tone_dark_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffc\u200d\ud83e\udd1d\u200d\ud83d\udc69\ud83c\udffb": [
+    "women_holding_hands_medium-light_skin_tone_light_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffc\u200d\ud83e\udd1d\u200d\ud83d\udc69\ud83c\udffd": [
+    "women_holding_hands_medium-light_skin_tone_medium_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffc\u200d\ud83e\udd1d\u200d\ud83d\udc69\ud83c\udffe": [
+    "women_holding_hands_medium-light_skin_tone_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffc\u200d\ud83e\udd1d\u200d\ud83d\udc69\ud83c\udfff": [
+    "women_holding_hands_medium-light_skin_tone_dark_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffc\u200d\ud83e\uddaf": [
+    "woman_with_white_cane_medium-light_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffc\u200d\ud83e\uddaf\u200d\u27a1": [
+    "woman_with_white_cane_facing_right_medium-light_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffc\u200d\ud83e\uddaf\u200d\u27a1\ufe0f": [
+    "woman_with_white_cane_facing_right_medium-light_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffc\u200d\ud83e\uddb0": [
+    "woman_medium-light_skin_tone_red_hair"
+  ],
+  "\ud83d\udc69\ud83c\udffc\u200d\ud83e\uddb1": [
+    "woman_medium-light_skin_tone_curly_hair"
+  ],
+  "\ud83d\udc69\ud83c\udffc\u200d\ud83e\uddb2": [
+    "woman_medium-light_skin_tone_bald"
+  ],
+  "\ud83d\udc69\ud83c\udffc\u200d\ud83e\uddb3": [
+    "woman_medium-light_skin_tone_white_hair"
+  ],
+  "\ud83d\udc69\ud83c\udffc\u200d\ud83e\uddbc": [
+    "woman_in_motorized_wheelchair_medium-light_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffc\u200d\ud83e\uddbc\u200d\u27a1": [
+    "woman_in_motorized_wheelchair_facing_right_medium-light_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffc\u200d\ud83e\uddbc\u200d\u27a1\ufe0f": [
+    "woman_in_motorized_wheelchair_facing_right_medium-light_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffc\u200d\ud83e\uddbd": [
+    "woman_in_manual_wheelchair_medium-light_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffc\u200d\ud83e\uddbd\u200d\u27a1": [
+    "woman_in_manual_wheelchair_facing_right_medium-light_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffc\u200d\ud83e\uddbd\u200d\u27a1\ufe0f": [
+    "woman_in_manual_wheelchair_facing_right_medium-light_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffd": [
+    "woman_medium_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffd\u200d\u2695": [
+    "woman_health_worker_medium_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffd\u200d\u2695\ufe0f": [
+    "woman_health_worker_medium_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffd\u200d\u2696": [
+    "woman_judge_medium_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffd\u200d\u2696\ufe0f": [
+    "woman_judge_medium_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffd\u200d\u2708": [
+    "woman_pilot_medium_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffd\u200d\u2708\ufe0f": [
+    "woman_pilot_medium_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffd\u200d\u2764\u200d\ud83d\udc68\ud83c\udffb": [
+    "couple_with_heart_woman_man_medium_skin_tone_light_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffd\u200d\u2764\u200d\ud83d\udc68\ud83c\udffc": [
+    "couple_with_heart_woman_man_medium_skin_tone_medium-light_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffd\u200d\u2764\u200d\ud83d\udc68\ud83c\udffd": [
+    "couple_with_heart_woman_man_medium_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffd\u200d\u2764\u200d\ud83d\udc68\ud83c\udffe": [
+    "couple_with_heart_woman_man_medium_skin_tone_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffd\u200d\u2764\u200d\ud83d\udc68\ud83c\udfff": [
+    "couple_with_heart_woman_man_medium_skin_tone_dark_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffd\u200d\u2764\u200d\ud83d\udc69\ud83c\udffb": [
+    "couple_with_heart_woman_woman_medium_skin_tone_light_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffd\u200d\u2764\u200d\ud83d\udc69\ud83c\udffc": [
+    "couple_with_heart_woman_woman_medium_skin_tone_medium-light_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffd\u200d\u2764\u200d\ud83d\udc69\ud83c\udffd": [
+    "couple_with_heart_woman_woman_medium_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffd\u200d\u2764\u200d\ud83d\udc69\ud83c\udffe": [
+    "couple_with_heart_woman_woman_medium_skin_tone_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffd\u200d\u2764\u200d\ud83d\udc69\ud83c\udfff": [
+    "couple_with_heart_woman_woman_medium_skin_tone_dark_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffd\u200d\u2764\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udffb": [
+    "kiss_woman_man_medium_skin_tone_light_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffd\u200d\u2764\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udffc": [
+    "kiss_woman_man_medium_skin_tone_medium-light_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffd\u200d\u2764\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udffd": [
+    "kiss_woman_man_medium_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffd\u200d\u2764\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udffe": [
+    "kiss_woman_man_medium_skin_tone_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffd\u200d\u2764\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udfff": [
+    "kiss_woman_man_medium_skin_tone_dark_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffd\u200d\u2764\u200d\ud83d\udc8b\u200d\ud83d\udc69\ud83c\udffb": [
+    "kiss_woman_woman_medium_skin_tone_light_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffd\u200d\u2764\u200d\ud83d\udc8b\u200d\ud83d\udc69\ud83c\udffc": [
+    "kiss_woman_woman_medium_skin_tone_medium-light_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffd\u200d\u2764\u200d\ud83d\udc8b\u200d\ud83d\udc69\ud83c\udffd": [
+    "kiss_woman_woman_medium_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffd\u200d\u2764\u200d\ud83d\udc8b\u200d\ud83d\udc69\ud83c\udffe": [
+    "kiss_woman_woman_medium_skin_tone_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffd\u200d\u2764\u200d\ud83d\udc8b\u200d\ud83d\udc69\ud83c\udfff": [
+    "kiss_woman_woman_medium_skin_tone_dark_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffd\u200d\u2764\ufe0f\u200d\ud83d\udc68\ud83c\udffb": [
+    "couple_with_heart_woman_man_medium_skin_tone_light_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffd\u200d\u2764\ufe0f\u200d\ud83d\udc68\ud83c\udffc": [
+    "couple_with_heart_woman_man_medium_skin_tone_medium-light_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffd\u200d\u2764\ufe0f\u200d\ud83d\udc68\ud83c\udffd": [
+    "couple_with_heart_woman_man_medium_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffd\u200d\u2764\ufe0f\u200d\ud83d\udc68\ud83c\udffe": [
+    "couple_with_heart_woman_man_medium_skin_tone_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffd\u200d\u2764\ufe0f\u200d\ud83d\udc68\ud83c\udfff": [
+    "couple_with_heart_woman_man_medium_skin_tone_dark_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffd\u200d\u2764\ufe0f\u200d\ud83d\udc69\ud83c\udffb": [
+    "couple_with_heart_woman_woman_medium_skin_tone_light_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffd\u200d\u2764\ufe0f\u200d\ud83d\udc69\ud83c\udffc": [
+    "couple_with_heart_woman_woman_medium_skin_tone_medium-light_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffd\u200d\u2764\ufe0f\u200d\ud83d\udc69\ud83c\udffd": [
+    "couple_with_heart_woman_woman_medium_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffd\u200d\u2764\ufe0f\u200d\ud83d\udc69\ud83c\udffe": [
+    "couple_with_heart_woman_woman_medium_skin_tone_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffd\u200d\u2764\ufe0f\u200d\ud83d\udc69\ud83c\udfff": [
+    "couple_with_heart_woman_woman_medium_skin_tone_dark_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffd\u200d\u2764\ufe0f\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udffb": [
+    "kiss_woman_man_medium_skin_tone_light_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffd\u200d\u2764\ufe0f\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udffc": [
+    "kiss_woman_man_medium_skin_tone_medium-light_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffd\u200d\u2764\ufe0f\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udffd": [
+    "kiss_woman_man_medium_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffd\u200d\u2764\ufe0f\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udffe": [
+    "kiss_woman_man_medium_skin_tone_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffd\u200d\u2764\ufe0f\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udfff": [
+    "kiss_woman_man_medium_skin_tone_dark_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffd\u200d\u2764\ufe0f\u200d\ud83d\udc8b\u200d\ud83d\udc69\ud83c\udffb": [
+    "kiss_woman_woman_medium_skin_tone_light_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffd\u200d\u2764\ufe0f\u200d\ud83d\udc8b\u200d\ud83d\udc69\ud83c\udffc": [
+    "kiss_woman_woman_medium_skin_tone_medium-light_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffd\u200d\u2764\ufe0f\u200d\ud83d\udc8b\u200d\ud83d\udc69\ud83c\udffd": [
+    "kiss_woman_woman_medium_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffd\u200d\u2764\ufe0f\u200d\ud83d\udc8b\u200d\ud83d\udc69\ud83c\udffe": [
+    "kiss_woman_woman_medium_skin_tone_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffd\u200d\u2764\ufe0f\u200d\ud83d\udc8b\u200d\ud83d\udc69\ud83c\udfff": [
+    "kiss_woman_woman_medium_skin_tone_dark_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffd\u200d\ud83c\udf3e": [
+    "woman_farmer_medium_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffd\u200d\ud83c\udf73": [
+    "woman_cook_medium_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffd\u200d\ud83c\udf7c": [
+    "woman_feeding_baby_medium_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffd\u200d\ud83c\udf93": [
+    "woman_student_medium_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffd\u200d\ud83c\udfa4": [
+    "woman_singer_medium_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffd\u200d\ud83c\udfa8": [
+    "woman_artist_medium_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffd\u200d\ud83c\udfeb": [
+    "woman_teacher_medium_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffd\u200d\ud83c\udfed": [
+    "woman_factory_worker_medium_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffd\u200d\ud83d\udcbb": [
+    "woman_technologist_medium_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffd\u200d\ud83d\udcbc": [
+    "woman_office_worker_medium_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffd\u200d\ud83d\udd27": [
+    "woman_mechanic_medium_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffd\u200d\ud83d\udd2c": [
+    "woman_scientist_medium_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffd\u200d\ud83d\ude80": [
+    "woman_astronaut_medium_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffd\u200d\ud83d\ude92": [
+    "woman_firefighter_medium_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffd\u200d\ud83e\udd1d\u200d\ud83d\udc68\ud83c\udffb": [
+    "woman_and_man_holding_hands_medium_skin_tone_light_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffd\u200d\ud83e\udd1d\u200d\ud83d\udc68\ud83c\udffc": [
+    "woman_and_man_holding_hands_medium_skin_tone_medium-light_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffd\u200d\ud83e\udd1d\u200d\ud83d\udc68\ud83c\udffe": [
+    "woman_and_man_holding_hands_medium_skin_tone_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffd\u200d\ud83e\udd1d\u200d\ud83d\udc68\ud83c\udfff": [
+    "woman_and_man_holding_hands_medium_skin_tone_dark_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffd\u200d\ud83e\udd1d\u200d\ud83d\udc69\ud83c\udffb": [
+    "women_holding_hands_medium_skin_tone_light_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffd\u200d\ud83e\udd1d\u200d\ud83d\udc69\ud83c\udffc": [
+    "women_holding_hands_medium_skin_tone_medium-light_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffd\u200d\ud83e\udd1d\u200d\ud83d\udc69\ud83c\udffe": [
+    "women_holding_hands_medium_skin_tone_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffd\u200d\ud83e\udd1d\u200d\ud83d\udc69\ud83c\udfff": [
+    "women_holding_hands_medium_skin_tone_dark_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffd\u200d\ud83e\uddaf": [
+    "woman_with_white_cane_medium_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffd\u200d\ud83e\uddaf\u200d\u27a1": [
+    "woman_with_white_cane_facing_right_medium_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffd\u200d\ud83e\uddaf\u200d\u27a1\ufe0f": [
+    "woman_with_white_cane_facing_right_medium_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffd\u200d\ud83e\uddb0": [
+    "woman_medium_skin_tone_red_hair"
+  ],
+  "\ud83d\udc69\ud83c\udffd\u200d\ud83e\uddb1": [
+    "woman_medium_skin_tone_curly_hair"
+  ],
+  "\ud83d\udc69\ud83c\udffd\u200d\ud83e\uddb2": [
+    "woman_medium_skin_tone_bald"
+  ],
+  "\ud83d\udc69\ud83c\udffd\u200d\ud83e\uddb3": [
+    "woman_medium_skin_tone_white_hair"
+  ],
+  "\ud83d\udc69\ud83c\udffd\u200d\ud83e\uddbc": [
+    "woman_in_motorized_wheelchair_medium_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffd\u200d\ud83e\uddbc\u200d\u27a1": [
+    "woman_in_motorized_wheelchair_facing_right_medium_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffd\u200d\ud83e\uddbc\u200d\u27a1\ufe0f": [
+    "woman_in_motorized_wheelchair_facing_right_medium_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffd\u200d\ud83e\uddbd": [
+    "woman_in_manual_wheelchair_medium_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffd\u200d\ud83e\uddbd\u200d\u27a1": [
+    "woman_in_manual_wheelchair_facing_right_medium_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffd\u200d\ud83e\uddbd\u200d\u27a1\ufe0f": [
+    "woman_in_manual_wheelchair_facing_right_medium_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffe": [
+    "woman_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffe\u200d\u2695": [
+    "woman_health_worker_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffe\u200d\u2695\ufe0f": [
+    "woman_health_worker_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffe\u200d\u2696": [
+    "woman_judge_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffe\u200d\u2696\ufe0f": [
+    "woman_judge_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffe\u200d\u2708": [
+    "woman_pilot_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffe\u200d\u2708\ufe0f": [
+    "woman_pilot_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffe\u200d\u2764\u200d\ud83d\udc68\ud83c\udffb": [
+    "couple_with_heart_woman_man_medium-dark_skin_tone_light_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffe\u200d\u2764\u200d\ud83d\udc68\ud83c\udffc": [
+    "couple_with_heart_woman_man_medium-dark_skin_tone_medium-light_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffe\u200d\u2764\u200d\ud83d\udc68\ud83c\udffd": [
+    "couple_with_heart_woman_man_medium-dark_skin_tone_medium_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffe\u200d\u2764\u200d\ud83d\udc68\ud83c\udffe": [
+    "couple_with_heart_woman_man_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffe\u200d\u2764\u200d\ud83d\udc68\ud83c\udfff": [
+    "couple_with_heart_woman_man_medium-dark_skin_tone_dark_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffe\u200d\u2764\u200d\ud83d\udc69\ud83c\udffb": [
+    "couple_with_heart_woman_woman_medium-dark_skin_tone_light_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffe\u200d\u2764\u200d\ud83d\udc69\ud83c\udffc": [
+    "couple_with_heart_woman_woman_medium-dark_skin_tone_medium-light_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffe\u200d\u2764\u200d\ud83d\udc69\ud83c\udffd": [
+    "couple_with_heart_woman_woman_medium-dark_skin_tone_medium_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffe\u200d\u2764\u200d\ud83d\udc69\ud83c\udffe": [
+    "couple_with_heart_woman_woman_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffe\u200d\u2764\u200d\ud83d\udc69\ud83c\udfff": [
+    "couple_with_heart_woman_woman_medium-dark_skin_tone_dark_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffe\u200d\u2764\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udffb": [
+    "kiss_woman_man_medium-dark_skin_tone_light_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffe\u200d\u2764\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udffc": [
+    "kiss_woman_man_medium-dark_skin_tone_medium-light_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffe\u200d\u2764\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udffd": [
+    "kiss_woman_man_medium-dark_skin_tone_medium_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffe\u200d\u2764\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udffe": [
+    "kiss_woman_man_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffe\u200d\u2764\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udfff": [
+    "kiss_woman_man_medium-dark_skin_tone_dark_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffe\u200d\u2764\u200d\ud83d\udc8b\u200d\ud83d\udc69\ud83c\udffb": [
+    "kiss_woman_woman_medium-dark_skin_tone_light_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffe\u200d\u2764\u200d\ud83d\udc8b\u200d\ud83d\udc69\ud83c\udffc": [
+    "kiss_woman_woman_medium-dark_skin_tone_medium-light_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffe\u200d\u2764\u200d\ud83d\udc8b\u200d\ud83d\udc69\ud83c\udffd": [
+    "kiss_woman_woman_medium-dark_skin_tone_medium_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffe\u200d\u2764\u200d\ud83d\udc8b\u200d\ud83d\udc69\ud83c\udffe": [
+    "kiss_woman_woman_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffe\u200d\u2764\u200d\ud83d\udc8b\u200d\ud83d\udc69\ud83c\udfff": [
+    "kiss_woman_woman_medium-dark_skin_tone_dark_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffe\u200d\u2764\ufe0f\u200d\ud83d\udc68\ud83c\udffb": [
+    "couple_with_heart_woman_man_medium-dark_skin_tone_light_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffe\u200d\u2764\ufe0f\u200d\ud83d\udc68\ud83c\udffc": [
+    "couple_with_heart_woman_man_medium-dark_skin_tone_medium-light_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffe\u200d\u2764\ufe0f\u200d\ud83d\udc68\ud83c\udffd": [
+    "couple_with_heart_woman_man_medium-dark_skin_tone_medium_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffe\u200d\u2764\ufe0f\u200d\ud83d\udc68\ud83c\udffe": [
+    "couple_with_heart_woman_man_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffe\u200d\u2764\ufe0f\u200d\ud83d\udc68\ud83c\udfff": [
+    "couple_with_heart_woman_man_medium-dark_skin_tone_dark_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffe\u200d\u2764\ufe0f\u200d\ud83d\udc69\ud83c\udffb": [
+    "couple_with_heart_woman_woman_medium-dark_skin_tone_light_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffe\u200d\u2764\ufe0f\u200d\ud83d\udc69\ud83c\udffc": [
+    "couple_with_heart_woman_woman_medium-dark_skin_tone_medium-light_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffe\u200d\u2764\ufe0f\u200d\ud83d\udc69\ud83c\udffd": [
+    "couple_with_heart_woman_woman_medium-dark_skin_tone_medium_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffe\u200d\u2764\ufe0f\u200d\ud83d\udc69\ud83c\udffe": [
+    "couple_with_heart_woman_woman_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffe\u200d\u2764\ufe0f\u200d\ud83d\udc69\ud83c\udfff": [
+    "couple_with_heart_woman_woman_medium-dark_skin_tone_dark_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffe\u200d\u2764\ufe0f\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udffb": [
+    "kiss_woman_man_medium-dark_skin_tone_light_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffe\u200d\u2764\ufe0f\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udffc": [
+    "kiss_woman_man_medium-dark_skin_tone_medium-light_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffe\u200d\u2764\ufe0f\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udffd": [
+    "kiss_woman_man_medium-dark_skin_tone_medium_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffe\u200d\u2764\ufe0f\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udffe": [
+    "kiss_woman_man_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffe\u200d\u2764\ufe0f\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udfff": [
+    "kiss_woman_man_medium-dark_skin_tone_dark_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffe\u200d\u2764\ufe0f\u200d\ud83d\udc8b\u200d\ud83d\udc69\ud83c\udffb": [
+    "kiss_woman_woman_medium-dark_skin_tone_light_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffe\u200d\u2764\ufe0f\u200d\ud83d\udc8b\u200d\ud83d\udc69\ud83c\udffc": [
+    "kiss_woman_woman_medium-dark_skin_tone_medium-light_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffe\u200d\u2764\ufe0f\u200d\ud83d\udc8b\u200d\ud83d\udc69\ud83c\udffd": [
+    "kiss_woman_woman_medium-dark_skin_tone_medium_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffe\u200d\u2764\ufe0f\u200d\ud83d\udc8b\u200d\ud83d\udc69\ud83c\udffe": [
+    "kiss_woman_woman_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffe\u200d\u2764\ufe0f\u200d\ud83d\udc8b\u200d\ud83d\udc69\ud83c\udfff": [
+    "kiss_woman_woman_medium-dark_skin_tone_dark_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffe\u200d\ud83c\udf3e": [
+    "woman_farmer_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffe\u200d\ud83c\udf73": [
+    "woman_cook_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffe\u200d\ud83c\udf7c": [
+    "woman_feeding_baby_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffe\u200d\ud83c\udf93": [
+    "woman_student_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffe\u200d\ud83c\udfa4": [
+    "woman_singer_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffe\u200d\ud83c\udfa8": [
+    "woman_artist_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffe\u200d\ud83c\udfeb": [
+    "woman_teacher_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffe\u200d\ud83c\udfed": [
+    "woman_factory_worker_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffe\u200d\ud83d\udcbb": [
+    "woman_technologist_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffe\u200d\ud83d\udcbc": [
+    "woman_office_worker_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffe\u200d\ud83d\udd27": [
+    "woman_mechanic_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffe\u200d\ud83d\udd2c": [
+    "woman_scientist_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffe\u200d\ud83d\ude80": [
+    "woman_astronaut_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffe\u200d\ud83d\ude92": [
+    "woman_firefighter_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffe\u200d\ud83e\udd1d\u200d\ud83d\udc68\ud83c\udffb": [
+    "woman_and_man_holding_hands_medium-dark_skin_tone_light_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffe\u200d\ud83e\udd1d\u200d\ud83d\udc68\ud83c\udffc": [
+    "woman_and_man_holding_hands_medium-dark_skin_tone_medium-light_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffe\u200d\ud83e\udd1d\u200d\ud83d\udc68\ud83c\udffd": [
+    "woman_and_man_holding_hands_medium-dark_skin_tone_medium_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffe\u200d\ud83e\udd1d\u200d\ud83d\udc68\ud83c\udfff": [
+    "woman_and_man_holding_hands_medium-dark_skin_tone_dark_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffe\u200d\ud83e\udd1d\u200d\ud83d\udc69\ud83c\udffb": [
+    "women_holding_hands_medium-dark_skin_tone_light_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffe\u200d\ud83e\udd1d\u200d\ud83d\udc69\ud83c\udffc": [
+    "women_holding_hands_medium-dark_skin_tone_medium-light_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffe\u200d\ud83e\udd1d\u200d\ud83d\udc69\ud83c\udffd": [
+    "women_holding_hands_medium-dark_skin_tone_medium_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffe\u200d\ud83e\udd1d\u200d\ud83d\udc69\ud83c\udfff": [
+    "women_holding_hands_medium-dark_skin_tone_dark_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffe\u200d\ud83e\uddaf": [
+    "woman_with_white_cane_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffe\u200d\ud83e\uddaf\u200d\u27a1": [
+    "woman_with_white_cane_facing_right_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffe\u200d\ud83e\uddaf\u200d\u27a1\ufe0f": [
+    "woman_with_white_cane_facing_right_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffe\u200d\ud83e\uddb0": [
+    "woman_medium-dark_skin_tone_red_hair"
+  ],
+  "\ud83d\udc69\ud83c\udffe\u200d\ud83e\uddb1": [
+    "woman_medium-dark_skin_tone_curly_hair"
+  ],
+  "\ud83d\udc69\ud83c\udffe\u200d\ud83e\uddb2": [
+    "woman_medium-dark_skin_tone_bald"
+  ],
+  "\ud83d\udc69\ud83c\udffe\u200d\ud83e\uddb3": [
+    "woman_medium-dark_skin_tone_white_hair"
+  ],
+  "\ud83d\udc69\ud83c\udffe\u200d\ud83e\uddbc": [
+    "woman_in_motorized_wheelchair_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffe\u200d\ud83e\uddbc\u200d\u27a1": [
+    "woman_in_motorized_wheelchair_facing_right_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffe\u200d\ud83e\uddbc\u200d\u27a1\ufe0f": [
+    "woman_in_motorized_wheelchair_facing_right_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffe\u200d\ud83e\uddbd": [
+    "woman_in_manual_wheelchair_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffe\u200d\ud83e\uddbd\u200d\u27a1": [
+    "woman_in_manual_wheelchair_facing_right_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udffe\u200d\ud83e\uddbd\u200d\u27a1\ufe0f": [
+    "woman_in_manual_wheelchair_facing_right_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udfff": [
+    "woman_dark_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udfff\u200d\u2695": [
+    "woman_health_worker_dark_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udfff\u200d\u2695\ufe0f": [
+    "woman_health_worker_dark_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udfff\u200d\u2696": [
+    "woman_judge_dark_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udfff\u200d\u2696\ufe0f": [
+    "woman_judge_dark_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udfff\u200d\u2708": [
+    "woman_pilot_dark_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udfff\u200d\u2708\ufe0f": [
+    "woman_pilot_dark_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udfff\u200d\u2764\u200d\ud83d\udc68\ud83c\udffb": [
+    "couple_with_heart_woman_man_dark_skin_tone_light_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udfff\u200d\u2764\u200d\ud83d\udc68\ud83c\udffc": [
+    "couple_with_heart_woman_man_dark_skin_tone_medium-light_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udfff\u200d\u2764\u200d\ud83d\udc68\ud83c\udffd": [
+    "couple_with_heart_woman_man_dark_skin_tone_medium_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udfff\u200d\u2764\u200d\ud83d\udc68\ud83c\udffe": [
+    "couple_with_heart_woman_man_dark_skin_tone_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udfff\u200d\u2764\u200d\ud83d\udc68\ud83c\udfff": [
+    "couple_with_heart_woman_man_dark_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udfff\u200d\u2764\u200d\ud83d\udc69\ud83c\udffb": [
+    "couple_with_heart_woman_woman_dark_skin_tone_light_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udfff\u200d\u2764\u200d\ud83d\udc69\ud83c\udffc": [
+    "couple_with_heart_woman_woman_dark_skin_tone_medium-light_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udfff\u200d\u2764\u200d\ud83d\udc69\ud83c\udffd": [
+    "couple_with_heart_woman_woman_dark_skin_tone_medium_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udfff\u200d\u2764\u200d\ud83d\udc69\ud83c\udffe": [
+    "couple_with_heart_woman_woman_dark_skin_tone_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udfff\u200d\u2764\u200d\ud83d\udc69\ud83c\udfff": [
+    "couple_with_heart_woman_woman_dark_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udfff\u200d\u2764\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udffb": [
+    "kiss_woman_man_dark_skin_tone_light_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udfff\u200d\u2764\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udffc": [
+    "kiss_woman_man_dark_skin_tone_medium-light_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udfff\u200d\u2764\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udffd": [
+    "kiss_woman_man_dark_skin_tone_medium_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udfff\u200d\u2764\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udffe": [
+    "kiss_woman_man_dark_skin_tone_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udfff\u200d\u2764\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udfff": [
+    "kiss_woman_man_dark_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udfff\u200d\u2764\u200d\ud83d\udc8b\u200d\ud83d\udc69\ud83c\udffb": [
+    "kiss_woman_woman_dark_skin_tone_light_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udfff\u200d\u2764\u200d\ud83d\udc8b\u200d\ud83d\udc69\ud83c\udffc": [
+    "kiss_woman_woman_dark_skin_tone_medium-light_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udfff\u200d\u2764\u200d\ud83d\udc8b\u200d\ud83d\udc69\ud83c\udffd": [
+    "kiss_woman_woman_dark_skin_tone_medium_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udfff\u200d\u2764\u200d\ud83d\udc8b\u200d\ud83d\udc69\ud83c\udffe": [
+    "kiss_woman_woman_dark_skin_tone_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udfff\u200d\u2764\u200d\ud83d\udc8b\u200d\ud83d\udc69\ud83c\udfff": [
+    "kiss_woman_woman_dark_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udfff\u200d\u2764\ufe0f\u200d\ud83d\udc68\ud83c\udffb": [
+    "couple_with_heart_woman_man_dark_skin_tone_light_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udfff\u200d\u2764\ufe0f\u200d\ud83d\udc68\ud83c\udffc": [
+    "couple_with_heart_woman_man_dark_skin_tone_medium-light_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udfff\u200d\u2764\ufe0f\u200d\ud83d\udc68\ud83c\udffd": [
+    "couple_with_heart_woman_man_dark_skin_tone_medium_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udfff\u200d\u2764\ufe0f\u200d\ud83d\udc68\ud83c\udffe": [
+    "couple_with_heart_woman_man_dark_skin_tone_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udfff\u200d\u2764\ufe0f\u200d\ud83d\udc68\ud83c\udfff": [
+    "couple_with_heart_woman_man_dark_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udfff\u200d\u2764\ufe0f\u200d\ud83d\udc69\ud83c\udffb": [
+    "couple_with_heart_woman_woman_dark_skin_tone_light_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udfff\u200d\u2764\ufe0f\u200d\ud83d\udc69\ud83c\udffc": [
+    "couple_with_heart_woman_woman_dark_skin_tone_medium-light_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udfff\u200d\u2764\ufe0f\u200d\ud83d\udc69\ud83c\udffd": [
+    "couple_with_heart_woman_woman_dark_skin_tone_medium_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udfff\u200d\u2764\ufe0f\u200d\ud83d\udc69\ud83c\udffe": [
+    "couple_with_heart_woman_woman_dark_skin_tone_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udfff\u200d\u2764\ufe0f\u200d\ud83d\udc69\ud83c\udfff": [
+    "couple_with_heart_woman_woman_dark_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udfff\u200d\u2764\ufe0f\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udffb": [
+    "kiss_woman_man_dark_skin_tone_light_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udfff\u200d\u2764\ufe0f\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udffc": [
+    "kiss_woman_man_dark_skin_tone_medium-light_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udfff\u200d\u2764\ufe0f\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udffd": [
+    "kiss_woman_man_dark_skin_tone_medium_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udfff\u200d\u2764\ufe0f\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udffe": [
+    "kiss_woman_man_dark_skin_tone_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udfff\u200d\u2764\ufe0f\u200d\ud83d\udc8b\u200d\ud83d\udc68\ud83c\udfff": [
+    "kiss_woman_man_dark_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udfff\u200d\u2764\ufe0f\u200d\ud83d\udc8b\u200d\ud83d\udc69\ud83c\udffb": [
+    "kiss_woman_woman_dark_skin_tone_light_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udfff\u200d\u2764\ufe0f\u200d\ud83d\udc8b\u200d\ud83d\udc69\ud83c\udffc": [
+    "kiss_woman_woman_dark_skin_tone_medium-light_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udfff\u200d\u2764\ufe0f\u200d\ud83d\udc8b\u200d\ud83d\udc69\ud83c\udffd": [
+    "kiss_woman_woman_dark_skin_tone_medium_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udfff\u200d\u2764\ufe0f\u200d\ud83d\udc8b\u200d\ud83d\udc69\ud83c\udffe": [
+    "kiss_woman_woman_dark_skin_tone_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udfff\u200d\u2764\ufe0f\u200d\ud83d\udc8b\u200d\ud83d\udc69\ud83c\udfff": [
+    "kiss_woman_woman_dark_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udfff\u200d\ud83c\udf3e": [
+    "woman_farmer_dark_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udfff\u200d\ud83c\udf73": [
+    "woman_cook_dark_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udfff\u200d\ud83c\udf7c": [
+    "woman_feeding_baby_dark_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udfff\u200d\ud83c\udf93": [
+    "woman_student_dark_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udfff\u200d\ud83c\udfa4": [
+    "woman_singer_dark_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udfff\u200d\ud83c\udfa8": [
+    "woman_artist_dark_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udfff\u200d\ud83c\udfeb": [
+    "woman_teacher_dark_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udfff\u200d\ud83c\udfed": [
+    "woman_factory_worker_dark_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udfff\u200d\ud83d\udcbb": [
+    "woman_technologist_dark_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udfff\u200d\ud83d\udcbc": [
+    "woman_office_worker_dark_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udfff\u200d\ud83d\udd27": [
+    "woman_mechanic_dark_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udfff\u200d\ud83d\udd2c": [
+    "woman_scientist_dark_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udfff\u200d\ud83d\ude80": [
+    "woman_astronaut_dark_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udfff\u200d\ud83d\ude92": [
+    "woman_firefighter_dark_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udfff\u200d\ud83e\udd1d\u200d\ud83d\udc68\ud83c\udffb": [
+    "woman_and_man_holding_hands_dark_skin_tone_light_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udfff\u200d\ud83e\udd1d\u200d\ud83d\udc68\ud83c\udffc": [
+    "woman_and_man_holding_hands_dark_skin_tone_medium-light_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udfff\u200d\ud83e\udd1d\u200d\ud83d\udc68\ud83c\udffd": [
+    "woman_and_man_holding_hands_dark_skin_tone_medium_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udfff\u200d\ud83e\udd1d\u200d\ud83d\udc68\ud83c\udffe": [
+    "woman_and_man_holding_hands_dark_skin_tone_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udfff\u200d\ud83e\udd1d\u200d\ud83d\udc69\ud83c\udffb": [
+    "women_holding_hands_dark_skin_tone_light_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udfff\u200d\ud83e\udd1d\u200d\ud83d\udc69\ud83c\udffc": [
+    "women_holding_hands_dark_skin_tone_medium-light_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udfff\u200d\ud83e\udd1d\u200d\ud83d\udc69\ud83c\udffd": [
+    "women_holding_hands_dark_skin_tone_medium_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udfff\u200d\ud83e\udd1d\u200d\ud83d\udc69\ud83c\udffe": [
+    "women_holding_hands_dark_skin_tone_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udfff\u200d\ud83e\uddaf": [
+    "woman_with_white_cane_dark_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udfff\u200d\ud83e\uddaf\u200d\u27a1": [
+    "woman_with_white_cane_facing_right_dark_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udfff\u200d\ud83e\uddaf\u200d\u27a1\ufe0f": [
+    "woman_with_white_cane_facing_right_dark_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udfff\u200d\ud83e\uddb0": [
+    "woman_dark_skin_tone_red_hair"
+  ],
+  "\ud83d\udc69\ud83c\udfff\u200d\ud83e\uddb1": [
+    "woman_dark_skin_tone_curly_hair"
+  ],
+  "\ud83d\udc69\ud83c\udfff\u200d\ud83e\uddb2": [
+    "woman_dark_skin_tone_bald"
+  ],
+  "\ud83d\udc69\ud83c\udfff\u200d\ud83e\uddb3": [
+    "woman_dark_skin_tone_white_hair"
+  ],
+  "\ud83d\udc69\ud83c\udfff\u200d\ud83e\uddbc": [
+    "woman_in_motorized_wheelchair_dark_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udfff\u200d\ud83e\uddbc\u200d\u27a1": [
+    "woman_in_motorized_wheelchair_facing_right_dark_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udfff\u200d\ud83e\uddbc\u200d\u27a1\ufe0f": [
+    "woman_in_motorized_wheelchair_facing_right_dark_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udfff\u200d\ud83e\uddbd": [
+    "woman_in_manual_wheelchair_dark_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udfff\u200d\ud83e\uddbd\u200d\u27a1": [
+    "woman_in_manual_wheelchair_facing_right_dark_skin_tone"
+  ],
+  "\ud83d\udc69\ud83c\udfff\u200d\ud83e\uddbd\u200d\u27a1\ufe0f": [
+    "woman_in_manual_wheelchair_facing_right_dark_skin_tone"
+  ],
+  "\ud83d\udc6a": [
+    "family"
+  ],
+  "\ud83d\udc6b": [
+    "woman_and_man_holding_hands",
+    "couple"
+  ],
+  "\ud83d\udc6b\ud83c\udffb": [
+    "woman_and_man_holding_hands_light_skin_tone"
+  ],
+  "\ud83d\udc6b\ud83c\udffc": [
+    "woman_and_man_holding_hands_medium-light_skin_tone"
+  ],
+  "\ud83d\udc6b\ud83c\udffd": [
+    "woman_and_man_holding_hands_medium_skin_tone"
+  ],
+  "\ud83d\udc6b\ud83c\udffe": [
+    "woman_and_man_holding_hands_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc6b\ud83c\udfff": [
+    "woman_and_man_holding_hands_dark_skin_tone"
+  ],
+  "\ud83d\udc6c": [
+    "men_holding_hands",
+    "two_men_holding_hands"
+  ],
+  "\ud83d\udc6c\ud83c\udffb": [
+    "men_holding_hands_light_skin_tone"
+  ],
+  "\ud83d\udc6c\ud83c\udffc": [
+    "men_holding_hands_medium-light_skin_tone"
+  ],
+  "\ud83d\udc6c\ud83c\udffd": [
+    "men_holding_hands_medium_skin_tone"
+  ],
+  "\ud83d\udc6c\ud83c\udffe": [
+    "men_holding_hands_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc6c\ud83c\udfff": [
+    "men_holding_hands_dark_skin_tone"
+  ],
+  "\ud83d\udc6d": [
+    "women_holding_hands",
+    "two_women_holding_hands"
+  ],
+  "\ud83d\udc6d\ud83c\udffb": [
+    "women_holding_hands_light_skin_tone"
+  ],
+  "\ud83d\udc6d\ud83c\udffc": [
+    "women_holding_hands_medium-light_skin_tone"
+  ],
+  "\ud83d\udc6d\ud83c\udffd": [
+    "women_holding_hands_medium_skin_tone"
+  ],
+  "\ud83d\udc6d\ud83c\udffe": [
+    "women_holding_hands_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc6d\ud83c\udfff": [
+    "women_holding_hands_dark_skin_tone"
+  ],
+  "\ud83d\udc6e": [
+    "police_officer",
+    "cop"
+  ],
+  "\ud83d\udc6e\u200d\u2640": [
+    "woman_police_officer",
+    "policewoman"
+  ],
+  "\ud83d\udc6e\u200d\u2640\ufe0f": [
+    "woman_police_officer",
+    "policewoman"
+  ],
+  "\ud83d\udc6e\u200d\u2642": [
+    "man_police_officer",
+    "policeman"
+  ],
+  "\ud83d\udc6e\u200d\u2642\ufe0f": [
+    "man_police_officer",
+    "policeman"
+  ],
+  "\ud83d\udc6e\ud83c\udffb": [
+    "police_officer_light_skin_tone"
+  ],
+  "\ud83d\udc6e\ud83c\udffb\u200d\u2640": [
+    "woman_police_officer_light_skin_tone"
+  ],
+  "\ud83d\udc6e\ud83c\udffb\u200d\u2640\ufe0f": [
+    "woman_police_officer_light_skin_tone"
+  ],
+  "\ud83d\udc6e\ud83c\udffb\u200d\u2642": [
+    "man_police_officer_light_skin_tone"
+  ],
+  "\ud83d\udc6e\ud83c\udffb\u200d\u2642\ufe0f": [
+    "man_police_officer_light_skin_tone"
+  ],
+  "\ud83d\udc6e\ud83c\udffc": [
+    "police_officer_medium-light_skin_tone"
+  ],
+  "\ud83d\udc6e\ud83c\udffc\u200d\u2640": [
+    "woman_police_officer_medium-light_skin_tone"
+  ],
+  "\ud83d\udc6e\ud83c\udffc\u200d\u2640\ufe0f": [
+    "woman_police_officer_medium-light_skin_tone"
+  ],
+  "\ud83d\udc6e\ud83c\udffc\u200d\u2642": [
+    "man_police_officer_medium-light_skin_tone"
+  ],
+  "\ud83d\udc6e\ud83c\udffc\u200d\u2642\ufe0f": [
+    "man_police_officer_medium-light_skin_tone"
+  ],
+  "\ud83d\udc6e\ud83c\udffd": [
+    "police_officer_medium_skin_tone"
+  ],
+  "\ud83d\udc6e\ud83c\udffd\u200d\u2640": [
+    "woman_police_officer_medium_skin_tone"
+  ],
+  "\ud83d\udc6e\ud83c\udffd\u200d\u2640\ufe0f": [
+    "woman_police_officer_medium_skin_tone"
+  ],
+  "\ud83d\udc6e\ud83c\udffd\u200d\u2642": [
+    "man_police_officer_medium_skin_tone"
+  ],
+  "\ud83d\udc6e\ud83c\udffd\u200d\u2642\ufe0f": [
+    "man_police_officer_medium_skin_tone"
+  ],
+  "\ud83d\udc6e\ud83c\udffe": [
+    "police_officer_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc6e\ud83c\udffe\u200d\u2640": [
+    "woman_police_officer_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc6e\ud83c\udffe\u200d\u2640\ufe0f": [
+    "woman_police_officer_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc6e\ud83c\udffe\u200d\u2642": [
+    "man_police_officer_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc6e\ud83c\udffe\u200d\u2642\ufe0f": [
+    "man_police_officer_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc6e\ud83c\udfff": [
+    "police_officer_dark_skin_tone"
+  ],
+  "\ud83d\udc6e\ud83c\udfff\u200d\u2640": [
+    "woman_police_officer_dark_skin_tone"
+  ],
+  "\ud83d\udc6e\ud83c\udfff\u200d\u2640\ufe0f": [
+    "woman_police_officer_dark_skin_tone"
+  ],
+  "\ud83d\udc6e\ud83c\udfff\u200d\u2642": [
+    "man_police_officer_dark_skin_tone"
+  ],
+  "\ud83d\udc6e\ud83c\udfff\u200d\u2642\ufe0f": [
+    "man_police_officer_dark_skin_tone"
+  ],
+  "\ud83d\udc6f": [
+    "people_with_bunny_ears",
+    "dancers"
+  ],
+  "\ud83d\udc6f\u200d\u2640": [
+    "women_with_bunny_ears",
+    "dancing_women"
+  ],
+  "\ud83d\udc6f\u200d\u2640\ufe0f": [
+    "women_with_bunny_ears",
+    "dancing_women"
+  ],
+  "\ud83d\udc6f\u200d\u2642": [
+    "men_with_bunny_ears",
+    "dancing_men"
+  ],
+  "\ud83d\udc6f\u200d\u2642\ufe0f": [
+    "men_with_bunny_ears",
+    "dancing_men"
+  ],
+  "\ud83d\udc70": [
+    "person_with_veil"
+  ],
+  "\ud83d\udc70\u200d\u2640": [
+    "woman_with_veil",
+    "bride_with_veil"
+  ],
+  "\ud83d\udc70\u200d\u2640\ufe0f": [
+    "woman_with_veil",
+    "bride_with_veil"
+  ],
+  "\ud83d\udc70\u200d\u2642": [
+    "man_with_veil"
+  ],
+  "\ud83d\udc70\u200d\u2642\ufe0f": [
+    "man_with_veil"
+  ],
+  "\ud83d\udc70\ud83c\udffb": [
+    "person_with_veil_light_skin_tone"
+  ],
+  "\ud83d\udc70\ud83c\udffb\u200d\u2640": [
+    "woman_with_veil_light_skin_tone"
+  ],
+  "\ud83d\udc70\ud83c\udffb\u200d\u2640\ufe0f": [
+    "woman_with_veil_light_skin_tone"
+  ],
+  "\ud83d\udc70\ud83c\udffb\u200d\u2642": [
+    "man_with_veil_light_skin_tone"
+  ],
+  "\ud83d\udc70\ud83c\udffb\u200d\u2642\ufe0f": [
+    "man_with_veil_light_skin_tone"
+  ],
+  "\ud83d\udc70\ud83c\udffc": [
+    "person_with_veil_medium-light_skin_tone"
+  ],
+  "\ud83d\udc70\ud83c\udffc\u200d\u2640": [
+    "woman_with_veil_medium-light_skin_tone"
+  ],
+  "\ud83d\udc70\ud83c\udffc\u200d\u2640\ufe0f": [
+    "woman_with_veil_medium-light_skin_tone"
+  ],
+  "\ud83d\udc70\ud83c\udffc\u200d\u2642": [
+    "man_with_veil_medium-light_skin_tone"
+  ],
+  "\ud83d\udc70\ud83c\udffc\u200d\u2642\ufe0f": [
+    "man_with_veil_medium-light_skin_tone"
+  ],
+  "\ud83d\udc70\ud83c\udffd": [
+    "person_with_veil_medium_skin_tone"
+  ],
+  "\ud83d\udc70\ud83c\udffd\u200d\u2640": [
+    "woman_with_veil_medium_skin_tone"
+  ],
+  "\ud83d\udc70\ud83c\udffd\u200d\u2640\ufe0f": [
+    "woman_with_veil_medium_skin_tone"
+  ],
+  "\ud83d\udc70\ud83c\udffd\u200d\u2642": [
+    "man_with_veil_medium_skin_tone"
+  ],
+  "\ud83d\udc70\ud83c\udffd\u200d\u2642\ufe0f": [
+    "man_with_veil_medium_skin_tone"
+  ],
+  "\ud83d\udc70\ud83c\udffe": [
+    "person_with_veil_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc70\ud83c\udffe\u200d\u2640": [
+    "woman_with_veil_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc70\ud83c\udffe\u200d\u2640\ufe0f": [
+    "woman_with_veil_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc70\ud83c\udffe\u200d\u2642": [
+    "man_with_veil_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc70\ud83c\udffe\u200d\u2642\ufe0f": [
+    "man_with_veil_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc70\ud83c\udfff": [
+    "person_with_veil_dark_skin_tone"
+  ],
+  "\ud83d\udc70\ud83c\udfff\u200d\u2640": [
+    "woman_with_veil_dark_skin_tone"
+  ],
+  "\ud83d\udc70\ud83c\udfff\u200d\u2640\ufe0f": [
+    "woman_with_veil_dark_skin_tone"
+  ],
+  "\ud83d\udc70\ud83c\udfff\u200d\u2642": [
+    "man_with_veil_dark_skin_tone"
+  ],
+  "\ud83d\udc70\ud83c\udfff\u200d\u2642\ufe0f": [
+    "man_with_veil_dark_skin_tone"
+  ],
+  "\ud83d\udc71": [
+    "person_blond_hair",
+    "blond_haired_person",
+    "person_with_blond_hair"
+  ],
+  "\ud83d\udc71\u200d\u2640": [
+    "woman_blond_hair",
+    "blonde_woman",
+    "blond_haired_woman"
+  ],
+  "\ud83d\udc71\u200d\u2640\ufe0f": [
+    "woman_blond_hair",
+    "blonde_woman",
+    "blond_haired_woman"
+  ],
+  "\ud83d\udc71\u200d\u2642": [
+    "man_blond_hair",
+    "blond_haired_man"
+  ],
+  "\ud83d\udc71\u200d\u2642\ufe0f": [
+    "man_blond_hair",
+    "blond_haired_man"
+  ],
+  "\ud83d\udc71\ud83c\udffb": [
+    "person_light_skin_tone_blond_hair"
+  ],
+  "\ud83d\udc71\ud83c\udffb\u200d\u2640": [
+    "woman_light_skin_tone_blond_hair"
+  ],
+  "\ud83d\udc71\ud83c\udffb\u200d\u2640\ufe0f": [
+    "woman_light_skin_tone_blond_hair"
+  ],
+  "\ud83d\udc71\ud83c\udffb\u200d\u2642": [
+    "man_light_skin_tone_blond_hair"
+  ],
+  "\ud83d\udc71\ud83c\udffb\u200d\u2642\ufe0f": [
+    "man_light_skin_tone_blond_hair"
+  ],
+  "\ud83d\udc71\ud83c\udffc": [
+    "person_medium-light_skin_tone_blond_hair"
+  ],
+  "\ud83d\udc71\ud83c\udffc\u200d\u2640": [
+    "woman_medium-light_skin_tone_blond_hair"
+  ],
+  "\ud83d\udc71\ud83c\udffc\u200d\u2640\ufe0f": [
+    "woman_medium-light_skin_tone_blond_hair"
+  ],
+  "\ud83d\udc71\ud83c\udffc\u200d\u2642": [
+    "man_medium-light_skin_tone_blond_hair"
+  ],
+  "\ud83d\udc71\ud83c\udffc\u200d\u2642\ufe0f": [
+    "man_medium-light_skin_tone_blond_hair"
+  ],
+  "\ud83d\udc71\ud83c\udffd": [
+    "person_medium_skin_tone_blond_hair"
+  ],
+  "\ud83d\udc71\ud83c\udffd\u200d\u2640": [
+    "woman_medium_skin_tone_blond_hair"
+  ],
+  "\ud83d\udc71\ud83c\udffd\u200d\u2640\ufe0f": [
+    "woman_medium_skin_tone_blond_hair"
+  ],
+  "\ud83d\udc71\ud83c\udffd\u200d\u2642": [
+    "man_medium_skin_tone_blond_hair"
+  ],
+  "\ud83d\udc71\ud83c\udffd\u200d\u2642\ufe0f": [
+    "man_medium_skin_tone_blond_hair"
+  ],
+  "\ud83d\udc71\ud83c\udffe": [
+    "person_medium-dark_skin_tone_blond_hair"
+  ],
+  "\ud83d\udc71\ud83c\udffe\u200d\u2640": [
+    "woman_medium-dark_skin_tone_blond_hair"
+  ],
+  "\ud83d\udc71\ud83c\udffe\u200d\u2640\ufe0f": [
+    "woman_medium-dark_skin_tone_blond_hair"
+  ],
+  "\ud83d\udc71\ud83c\udffe\u200d\u2642": [
+    "man_medium-dark_skin_tone_blond_hair"
+  ],
+  "\ud83d\udc71\ud83c\udffe\u200d\u2642\ufe0f": [
+    "man_medium-dark_skin_tone_blond_hair"
+  ],
+  "\ud83d\udc71\ud83c\udfff": [
+    "person_dark_skin_tone_blond_hair"
+  ],
+  "\ud83d\udc71\ud83c\udfff\u200d\u2640": [
+    "woman_dark_skin_tone_blond_hair"
+  ],
+  "\ud83d\udc71\ud83c\udfff\u200d\u2640\ufe0f": [
+    "woman_dark_skin_tone_blond_hair"
+  ],
+  "\ud83d\udc71\ud83c\udfff\u200d\u2642": [
+    "man_dark_skin_tone_blond_hair"
+  ],
+  "\ud83d\udc71\ud83c\udfff\u200d\u2642\ufe0f": [
+    "man_dark_skin_tone_blond_hair"
+  ],
+  "\ud83d\udc72": [
+    "person_with_skullcap",
+    "man_with_gua_pi_mao"
+  ],
+  "\ud83d\udc72\ud83c\udffb": [
+    "person_with_skullcap_light_skin_tone"
+  ],
+  "\ud83d\udc72\ud83c\udffc": [
+    "person_with_skullcap_medium-light_skin_tone"
+  ],
+  "\ud83d\udc72\ud83c\udffd": [
+    "person_with_skullcap_medium_skin_tone"
+  ],
+  "\ud83d\udc72\ud83c\udffe": [
+    "person_with_skullcap_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc72\ud83c\udfff": [
+    "person_with_skullcap_dark_skin_tone"
+  ],
+  "\ud83d\udc73": [
+    "person_wearing_turban",
+    "person_with_turban"
+  ],
+  "\ud83d\udc73\u200d\u2640": [
+    "woman_wearing_turban",
+    "woman_with_turban"
+  ],
+  "\ud83d\udc73\u200d\u2640\ufe0f": [
+    "woman_wearing_turban",
+    "woman_with_turban"
+  ],
+  "\ud83d\udc73\u200d\u2642": [
+    "man_wearing_turban",
+    "man_with_turban"
+  ],
+  "\ud83d\udc73\u200d\u2642\ufe0f": [
+    "man_wearing_turban",
+    "man_with_turban"
+  ],
+  "\ud83d\udc73\ud83c\udffb": [
+    "person_wearing_turban_light_skin_tone"
+  ],
+  "\ud83d\udc73\ud83c\udffb\u200d\u2640": [
+    "woman_wearing_turban_light_skin_tone"
+  ],
+  "\ud83d\udc73\ud83c\udffb\u200d\u2640\ufe0f": [
+    "woman_wearing_turban_light_skin_tone"
+  ],
+  "\ud83d\udc73\ud83c\udffb\u200d\u2642": [
+    "man_wearing_turban_light_skin_tone"
+  ],
+  "\ud83d\udc73\ud83c\udffb\u200d\u2642\ufe0f": [
+    "man_wearing_turban_light_skin_tone"
+  ],
+  "\ud83d\udc73\ud83c\udffc": [
+    "person_wearing_turban_medium-light_skin_tone"
+  ],
+  "\ud83d\udc73\ud83c\udffc\u200d\u2640": [
+    "woman_wearing_turban_medium-light_skin_tone"
+  ],
+  "\ud83d\udc73\ud83c\udffc\u200d\u2640\ufe0f": [
+    "woman_wearing_turban_medium-light_skin_tone"
+  ],
+  "\ud83d\udc73\ud83c\udffc\u200d\u2642": [
+    "man_wearing_turban_medium-light_skin_tone"
+  ],
+  "\ud83d\udc73\ud83c\udffc\u200d\u2642\ufe0f": [
+    "man_wearing_turban_medium-light_skin_tone"
+  ],
+  "\ud83d\udc73\ud83c\udffd": [
+    "person_wearing_turban_medium_skin_tone"
+  ],
+  "\ud83d\udc73\ud83c\udffd\u200d\u2640": [
+    "woman_wearing_turban_medium_skin_tone"
+  ],
+  "\ud83d\udc73\ud83c\udffd\u200d\u2640\ufe0f": [
+    "woman_wearing_turban_medium_skin_tone"
+  ],
+  "\ud83d\udc73\ud83c\udffd\u200d\u2642": [
+    "man_wearing_turban_medium_skin_tone"
+  ],
+  "\ud83d\udc73\ud83c\udffd\u200d\u2642\ufe0f": [
+    "man_wearing_turban_medium_skin_tone"
+  ],
+  "\ud83d\udc73\ud83c\udffe": [
+    "person_wearing_turban_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc73\ud83c\udffe\u200d\u2640": [
+    "woman_wearing_turban_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc73\ud83c\udffe\u200d\u2640\ufe0f": [
+    "woman_wearing_turban_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc73\ud83c\udffe\u200d\u2642": [
+    "man_wearing_turban_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc73\ud83c\udffe\u200d\u2642\ufe0f": [
+    "man_wearing_turban_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc73\ud83c\udfff": [
+    "person_wearing_turban_dark_skin_tone"
+  ],
+  "\ud83d\udc73\ud83c\udfff\u200d\u2640": [
+    "woman_wearing_turban_dark_skin_tone"
+  ],
+  "\ud83d\udc73\ud83c\udfff\u200d\u2640\ufe0f": [
+    "woman_wearing_turban_dark_skin_tone"
+  ],
+  "\ud83d\udc73\ud83c\udfff\u200d\u2642": [
+    "man_wearing_turban_dark_skin_tone"
+  ],
+  "\ud83d\udc73\ud83c\udfff\u200d\u2642\ufe0f": [
+    "man_wearing_turban_dark_skin_tone"
+  ],
+  "\ud83d\udc74": [
+    "old_man",
+    "older_man"
+  ],
+  "\ud83d\udc74\ud83c\udffb": [
+    "old_man_light_skin_tone"
+  ],
+  "\ud83d\udc74\ud83c\udffc": [
+    "old_man_medium-light_skin_tone"
+  ],
+  "\ud83d\udc74\ud83c\udffd": [
+    "old_man_medium_skin_tone"
+  ],
+  "\ud83d\udc74\ud83c\udffe": [
+    "old_man_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc74\ud83c\udfff": [
+    "old_man_dark_skin_tone"
+  ],
+  "\ud83d\udc75": [
+    "old_woman",
+    "older_woman"
+  ],
+  "\ud83d\udc75\ud83c\udffb": [
+    "old_woman_light_skin_tone"
+  ],
+  "\ud83d\udc75\ud83c\udffc": [
+    "old_woman_medium-light_skin_tone"
+  ],
+  "\ud83d\udc75\ud83c\udffd": [
+    "old_woman_medium_skin_tone"
+  ],
+  "\ud83d\udc75\ud83c\udffe": [
+    "old_woman_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc75\ud83c\udfff": [
+    "old_woman_dark_skin_tone"
+  ],
+  "\ud83d\udc76": [
+    "baby"
+  ],
+  "\ud83d\udc76\ud83c\udffb": [
+    "baby_light_skin_tone"
+  ],
+  "\ud83d\udc76\ud83c\udffc": [
+    "baby_medium-light_skin_tone"
+  ],
+  "\ud83d\udc76\ud83c\udffd": [
+    "baby_medium_skin_tone"
+  ],
+  "\ud83d\udc76\ud83c\udffe": [
+    "baby_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc76\ud83c\udfff": [
+    "baby_dark_skin_tone"
+  ],
+  "\ud83d\udc77": [
+    "construction_worker"
+  ],
+  "\ud83d\udc77\u200d\u2640": [
+    "woman_construction_worker",
+    "construction_worker_woman"
+  ],
+  "\ud83d\udc77\u200d\u2640\ufe0f": [
+    "woman_construction_worker",
+    "construction_worker_woman"
+  ],
+  "\ud83d\udc77\u200d\u2642": [
+    "man_construction_worker",
+    "construction_worker_man"
+  ],
+  "\ud83d\udc77\u200d\u2642\ufe0f": [
+    "man_construction_worker",
+    "construction_worker_man"
+  ],
+  "\ud83d\udc77\ud83c\udffb": [
+    "construction_worker_light_skin_tone"
+  ],
+  "\ud83d\udc77\ud83c\udffb\u200d\u2640": [
+    "woman_construction_worker_light_skin_tone"
+  ],
+  "\ud83d\udc77\ud83c\udffb\u200d\u2640\ufe0f": [
+    "woman_construction_worker_light_skin_tone"
+  ],
+  "\ud83d\udc77\ud83c\udffb\u200d\u2642": [
+    "man_construction_worker_light_skin_tone"
+  ],
+  "\ud83d\udc77\ud83c\udffb\u200d\u2642\ufe0f": [
+    "man_construction_worker_light_skin_tone"
+  ],
+  "\ud83d\udc77\ud83c\udffc": [
+    "construction_worker_medium-light_skin_tone"
+  ],
+  "\ud83d\udc77\ud83c\udffc\u200d\u2640": [
+    "woman_construction_worker_medium-light_skin_tone"
+  ],
+  "\ud83d\udc77\ud83c\udffc\u200d\u2640\ufe0f": [
+    "woman_construction_worker_medium-light_skin_tone"
+  ],
+  "\ud83d\udc77\ud83c\udffc\u200d\u2642": [
+    "man_construction_worker_medium-light_skin_tone"
+  ],
+  "\ud83d\udc77\ud83c\udffc\u200d\u2642\ufe0f": [
+    "man_construction_worker_medium-light_skin_tone"
+  ],
+  "\ud83d\udc77\ud83c\udffd": [
+    "construction_worker_medium_skin_tone"
+  ],
+  "\ud83d\udc77\ud83c\udffd\u200d\u2640": [
+    "woman_construction_worker_medium_skin_tone"
+  ],
+  "\ud83d\udc77\ud83c\udffd\u200d\u2640\ufe0f": [
+    "woman_construction_worker_medium_skin_tone"
+  ],
+  "\ud83d\udc77\ud83c\udffd\u200d\u2642": [
+    "man_construction_worker_medium_skin_tone"
+  ],
+  "\ud83d\udc77\ud83c\udffd\u200d\u2642\ufe0f": [
+    "man_construction_worker_medium_skin_tone"
+  ],
+  "\ud83d\udc77\ud83c\udffe": [
+    "construction_worker_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc77\ud83c\udffe\u200d\u2640": [
+    "woman_construction_worker_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc77\ud83c\udffe\u200d\u2640\ufe0f": [
+    "woman_construction_worker_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc77\ud83c\udffe\u200d\u2642": [
+    "man_construction_worker_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc77\ud83c\udffe\u200d\u2642\ufe0f": [
+    "man_construction_worker_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc77\ud83c\udfff": [
+    "construction_worker_dark_skin_tone"
+  ],
+  "\ud83d\udc77\ud83c\udfff\u200d\u2640": [
+    "woman_construction_worker_dark_skin_tone"
+  ],
+  "\ud83d\udc77\ud83c\udfff\u200d\u2640\ufe0f": [
+    "woman_construction_worker_dark_skin_tone"
+  ],
+  "\ud83d\udc77\ud83c\udfff\u200d\u2642": [
+    "man_construction_worker_dark_skin_tone"
+  ],
+  "\ud83d\udc77\ud83c\udfff\u200d\u2642\ufe0f": [
+    "man_construction_worker_dark_skin_tone"
+  ],
+  "\ud83d\udc78": [
+    "princess"
+  ],
+  "\ud83d\udc78\ud83c\udffb": [
+    "princess_light_skin_tone"
+  ],
+  "\ud83d\udc78\ud83c\udffc": [
+    "princess_medium-light_skin_tone"
+  ],
+  "\ud83d\udc78\ud83c\udffd": [
+    "princess_medium_skin_tone"
+  ],
+  "\ud83d\udc78\ud83c\udffe": [
+    "princess_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc78\ud83c\udfff": [
+    "princess_dark_skin_tone"
+  ],
+  "\ud83d\udc79": [
+    "ogre",
+    "japanese_ogre"
+  ],
+  "\ud83d\udc7a": [
+    "goblin",
+    "japanese_goblin"
+  ],
+  "\ud83d\udc7b": [
+    "ghost"
+  ],
+  "\ud83d\udc7c": [
+    "baby_angel",
+    "angel"
+  ],
+  "\ud83d\udc7c\ud83c\udffb": [
+    "baby_angel_light_skin_tone"
+  ],
+  "\ud83d\udc7c\ud83c\udffc": [
+    "baby_angel_medium-light_skin_tone"
+  ],
+  "\ud83d\udc7c\ud83c\udffd": [
+    "baby_angel_medium_skin_tone"
+  ],
+  "\ud83d\udc7c\ud83c\udffe": [
+    "baby_angel_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc7c\ud83c\udfff": [
+    "baby_angel_dark_skin_tone"
+  ],
+  "\ud83d\udc7d": [
+    "alien"
+  ],
+  "\ud83d\udc7e": [
+    "alien_monster",
+    "space_invader"
+  ],
+  "\ud83d\udc7f": [
+    "angry_face_with_horns",
+    "imp"
+  ],
+  "\ud83d\udc80": [
+    "skull"
+  ],
+  "\ud83d\udc81": [
+    "person_tipping_hand",
+    "tipping_hand_person",
+    "information_desk_person"
+  ],
+  "\ud83d\udc81\u200d\u2640": [
+    "woman_tipping_hand",
+    "sassy_woman",
+    "tipping_hand_woman"
+  ],
+  "\ud83d\udc81\u200d\u2640\ufe0f": [
+    "woman_tipping_hand",
+    "sassy_woman",
+    "tipping_hand_woman"
+  ],
+  "\ud83d\udc81\u200d\u2642": [
+    "man_tipping_hand",
+    "sassy_man",
+    "tipping_hand_man"
+  ],
+  "\ud83d\udc81\u200d\u2642\ufe0f": [
+    "man_tipping_hand",
+    "sassy_man",
+    "tipping_hand_man"
+  ],
+  "\ud83d\udc81\ud83c\udffb": [
+    "person_tipping_hand_light_skin_tone"
+  ],
+  "\ud83d\udc81\ud83c\udffb\u200d\u2640": [
+    "woman_tipping_hand_light_skin_tone"
+  ],
+  "\ud83d\udc81\ud83c\udffb\u200d\u2640\ufe0f": [
+    "woman_tipping_hand_light_skin_tone"
+  ],
+  "\ud83d\udc81\ud83c\udffb\u200d\u2642": [
+    "man_tipping_hand_light_skin_tone"
+  ],
+  "\ud83d\udc81\ud83c\udffb\u200d\u2642\ufe0f": [
+    "man_tipping_hand_light_skin_tone"
+  ],
+  "\ud83d\udc81\ud83c\udffc": [
+    "person_tipping_hand_medium-light_skin_tone"
+  ],
+  "\ud83d\udc81\ud83c\udffc\u200d\u2640": [
+    "woman_tipping_hand_medium-light_skin_tone"
+  ],
+  "\ud83d\udc81\ud83c\udffc\u200d\u2640\ufe0f": [
+    "woman_tipping_hand_medium-light_skin_tone"
+  ],
+  "\ud83d\udc81\ud83c\udffc\u200d\u2642": [
+    "man_tipping_hand_medium-light_skin_tone"
+  ],
+  "\ud83d\udc81\ud83c\udffc\u200d\u2642\ufe0f": [
+    "man_tipping_hand_medium-light_skin_tone"
+  ],
+  "\ud83d\udc81\ud83c\udffd": [
+    "person_tipping_hand_medium_skin_tone"
+  ],
+  "\ud83d\udc81\ud83c\udffd\u200d\u2640": [
+    "woman_tipping_hand_medium_skin_tone"
+  ],
+  "\ud83d\udc81\ud83c\udffd\u200d\u2640\ufe0f": [
+    "woman_tipping_hand_medium_skin_tone"
+  ],
+  "\ud83d\udc81\ud83c\udffd\u200d\u2642": [
+    "man_tipping_hand_medium_skin_tone"
+  ],
+  "\ud83d\udc81\ud83c\udffd\u200d\u2642\ufe0f": [
+    "man_tipping_hand_medium_skin_tone"
+  ],
+  "\ud83d\udc81\ud83c\udffe": [
+    "person_tipping_hand_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc81\ud83c\udffe\u200d\u2640": [
+    "woman_tipping_hand_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc81\ud83c\udffe\u200d\u2640\ufe0f": [
+    "woman_tipping_hand_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc81\ud83c\udffe\u200d\u2642": [
+    "man_tipping_hand_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc81\ud83c\udffe\u200d\u2642\ufe0f": [
+    "man_tipping_hand_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc81\ud83c\udfff": [
+    "person_tipping_hand_dark_skin_tone"
+  ],
+  "\ud83d\udc81\ud83c\udfff\u200d\u2640": [
+    "woman_tipping_hand_dark_skin_tone"
+  ],
+  "\ud83d\udc81\ud83c\udfff\u200d\u2640\ufe0f": [
+    "woman_tipping_hand_dark_skin_tone"
+  ],
+  "\ud83d\udc81\ud83c\udfff\u200d\u2642": [
+    "man_tipping_hand_dark_skin_tone"
+  ],
+  "\ud83d\udc81\ud83c\udfff\u200d\u2642\ufe0f": [
+    "man_tipping_hand_dark_skin_tone"
+  ],
+  "\ud83d\udc82": [
+    "guard"
+  ],
+  "\ud83d\udc82\u200d\u2640": [
+    "woman_guard",
+    "guardswoman"
+  ],
+  "\ud83d\udc82\u200d\u2640\ufe0f": [
+    "woman_guard",
+    "guardswoman"
+  ],
+  "\ud83d\udc82\u200d\u2642": [
+    "man_guard",
+    "guardsman"
+  ],
+  "\ud83d\udc82\u200d\u2642\ufe0f": [
+    "man_guard",
+    "guardsman"
+  ],
+  "\ud83d\udc82\ud83c\udffb": [
+    "guard_light_skin_tone"
+  ],
+  "\ud83d\udc82\ud83c\udffb\u200d\u2640": [
+    "woman_guard_light_skin_tone"
+  ],
+  "\ud83d\udc82\ud83c\udffb\u200d\u2640\ufe0f": [
+    "woman_guard_light_skin_tone"
+  ],
+  "\ud83d\udc82\ud83c\udffb\u200d\u2642": [
+    "man_guard_light_skin_tone"
+  ],
+  "\ud83d\udc82\ud83c\udffb\u200d\u2642\ufe0f": [
+    "man_guard_light_skin_tone"
+  ],
+  "\ud83d\udc82\ud83c\udffc": [
+    "guard_medium-light_skin_tone"
+  ],
+  "\ud83d\udc82\ud83c\udffc\u200d\u2640": [
+    "woman_guard_medium-light_skin_tone"
+  ],
+  "\ud83d\udc82\ud83c\udffc\u200d\u2640\ufe0f": [
+    "woman_guard_medium-light_skin_tone"
+  ],
+  "\ud83d\udc82\ud83c\udffc\u200d\u2642": [
+    "man_guard_medium-light_skin_tone"
+  ],
+  "\ud83d\udc82\ud83c\udffc\u200d\u2642\ufe0f": [
+    "man_guard_medium-light_skin_tone"
+  ],
+  "\ud83d\udc82\ud83c\udffd": [
+    "guard_medium_skin_tone"
+  ],
+  "\ud83d\udc82\ud83c\udffd\u200d\u2640": [
+    "woman_guard_medium_skin_tone"
+  ],
+  "\ud83d\udc82\ud83c\udffd\u200d\u2640\ufe0f": [
+    "woman_guard_medium_skin_tone"
+  ],
+  "\ud83d\udc82\ud83c\udffd\u200d\u2642": [
+    "man_guard_medium_skin_tone"
+  ],
+  "\ud83d\udc82\ud83c\udffd\u200d\u2642\ufe0f": [
+    "man_guard_medium_skin_tone"
+  ],
+  "\ud83d\udc82\ud83c\udffe": [
+    "guard_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc82\ud83c\udffe\u200d\u2640": [
+    "woman_guard_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc82\ud83c\udffe\u200d\u2640\ufe0f": [
+    "woman_guard_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc82\ud83c\udffe\u200d\u2642": [
+    "man_guard_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc82\ud83c\udffe\u200d\u2642\ufe0f": [
+    "man_guard_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc82\ud83c\udfff": [
+    "guard_dark_skin_tone"
+  ],
+  "\ud83d\udc82\ud83c\udfff\u200d\u2640": [
+    "woman_guard_dark_skin_tone"
+  ],
+  "\ud83d\udc82\ud83c\udfff\u200d\u2640\ufe0f": [
+    "woman_guard_dark_skin_tone"
+  ],
+  "\ud83d\udc82\ud83c\udfff\u200d\u2642": [
+    "man_guard_dark_skin_tone"
+  ],
+  "\ud83d\udc82\ud83c\udfff\u200d\u2642\ufe0f": [
+    "man_guard_dark_skin_tone"
+  ],
+  "\ud83d\udc83": [
+    "woman_dancing",
+    "dancer"
+  ],
+  "\ud83d\udc83\ud83c\udffb": [
+    "woman_dancing_light_skin_tone"
+  ],
+  "\ud83d\udc83\ud83c\udffc": [
+    "woman_dancing_medium-light_skin_tone"
+  ],
+  "\ud83d\udc83\ud83c\udffd": [
+    "woman_dancing_medium_skin_tone"
+  ],
+  "\ud83d\udc83\ud83c\udffe": [
+    "woman_dancing_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc83\ud83c\udfff": [
+    "woman_dancing_dark_skin_tone"
+  ],
+  "\ud83d\udc84": [
+    "lipstick"
+  ],
+  "\ud83d\udc85": [
+    "nail_polish",
+    "nail_care"
+  ],
+  "\ud83d\udc85\ud83c\udffb": [
+    "nail_polish_light_skin_tone"
+  ],
+  "\ud83d\udc85\ud83c\udffc": [
+    "nail_polish_medium-light_skin_tone"
+  ],
+  "\ud83d\udc85\ud83c\udffd": [
+    "nail_polish_medium_skin_tone"
+  ],
+  "\ud83d\udc85\ud83c\udffe": [
+    "nail_polish_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc85\ud83c\udfff": [
+    "nail_polish_dark_skin_tone"
+  ],
+  "\ud83d\udc86": [
+    "person_getting_massage",
+    "massage"
+  ],
+  "\ud83d\udc86\u200d\u2640": [
+    "woman_getting_massage",
+    "massage_woman"
+  ],
+  "\ud83d\udc86\u200d\u2640\ufe0f": [
+    "woman_getting_massage",
+    "massage_woman"
+  ],
+  "\ud83d\udc86\u200d\u2642": [
+    "man_getting_massage",
+    "massage_man"
+  ],
+  "\ud83d\udc86\u200d\u2642\ufe0f": [
+    "man_getting_massage",
+    "massage_man"
+  ],
+  "\ud83d\udc86\ud83c\udffb": [
+    "person_getting_massage_light_skin_tone"
+  ],
+  "\ud83d\udc86\ud83c\udffb\u200d\u2640": [
+    "woman_getting_massage_light_skin_tone"
+  ],
+  "\ud83d\udc86\ud83c\udffb\u200d\u2640\ufe0f": [
+    "woman_getting_massage_light_skin_tone"
+  ],
+  "\ud83d\udc86\ud83c\udffb\u200d\u2642": [
+    "man_getting_massage_light_skin_tone"
+  ],
+  "\ud83d\udc86\ud83c\udffb\u200d\u2642\ufe0f": [
+    "man_getting_massage_light_skin_tone"
+  ],
+  "\ud83d\udc86\ud83c\udffc": [
+    "person_getting_massage_medium-light_skin_tone"
+  ],
+  "\ud83d\udc86\ud83c\udffc\u200d\u2640": [
+    "woman_getting_massage_medium-light_skin_tone"
+  ],
+  "\ud83d\udc86\ud83c\udffc\u200d\u2640\ufe0f": [
+    "woman_getting_massage_medium-light_skin_tone"
+  ],
+  "\ud83d\udc86\ud83c\udffc\u200d\u2642": [
+    "man_getting_massage_medium-light_skin_tone"
+  ],
+  "\ud83d\udc86\ud83c\udffc\u200d\u2642\ufe0f": [
+    "man_getting_massage_medium-light_skin_tone"
+  ],
+  "\ud83d\udc86\ud83c\udffd": [
+    "person_getting_massage_medium_skin_tone"
+  ],
+  "\ud83d\udc86\ud83c\udffd\u200d\u2640": [
+    "woman_getting_massage_medium_skin_tone"
+  ],
+  "\ud83d\udc86\ud83c\udffd\u200d\u2640\ufe0f": [
+    "woman_getting_massage_medium_skin_tone"
+  ],
+  "\ud83d\udc86\ud83c\udffd\u200d\u2642": [
+    "man_getting_massage_medium_skin_tone"
+  ],
+  "\ud83d\udc86\ud83c\udffd\u200d\u2642\ufe0f": [
+    "man_getting_massage_medium_skin_tone"
+  ],
+  "\ud83d\udc86\ud83c\udffe": [
+    "person_getting_massage_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc86\ud83c\udffe\u200d\u2640": [
+    "woman_getting_massage_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc86\ud83c\udffe\u200d\u2640\ufe0f": [
+    "woman_getting_massage_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc86\ud83c\udffe\u200d\u2642": [
+    "man_getting_massage_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc86\ud83c\udffe\u200d\u2642\ufe0f": [
+    "man_getting_massage_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc86\ud83c\udfff": [
+    "person_getting_massage_dark_skin_tone"
+  ],
+  "\ud83d\udc86\ud83c\udfff\u200d\u2640": [
+    "woman_getting_massage_dark_skin_tone"
+  ],
+  "\ud83d\udc86\ud83c\udfff\u200d\u2640\ufe0f": [
+    "woman_getting_massage_dark_skin_tone"
+  ],
+  "\ud83d\udc86\ud83c\udfff\u200d\u2642": [
+    "man_getting_massage_dark_skin_tone"
+  ],
+  "\ud83d\udc86\ud83c\udfff\u200d\u2642\ufe0f": [
+    "man_getting_massage_dark_skin_tone"
+  ],
+  "\ud83d\udc87": [
+    "person_getting_haircut",
+    "haircut"
+  ],
+  "\ud83d\udc87\u200d\u2640": [
+    "woman_getting_haircut",
+    "haircut_woman"
+  ],
+  "\ud83d\udc87\u200d\u2640\ufe0f": [
+    "woman_getting_haircut",
+    "haircut_woman"
+  ],
+  "\ud83d\udc87\u200d\u2642": [
+    "man_getting_haircut",
+    "haircut_man"
+  ],
+  "\ud83d\udc87\u200d\u2642\ufe0f": [
+    "man_getting_haircut",
+    "haircut_man"
+  ],
+  "\ud83d\udc87\ud83c\udffb": [
+    "person_getting_haircut_light_skin_tone"
+  ],
+  "\ud83d\udc87\ud83c\udffb\u200d\u2640": [
+    "woman_getting_haircut_light_skin_tone"
+  ],
+  "\ud83d\udc87\ud83c\udffb\u200d\u2640\ufe0f": [
+    "woman_getting_haircut_light_skin_tone"
+  ],
+  "\ud83d\udc87\ud83c\udffb\u200d\u2642": [
+    "man_getting_haircut_light_skin_tone"
+  ],
+  "\ud83d\udc87\ud83c\udffb\u200d\u2642\ufe0f": [
+    "man_getting_haircut_light_skin_tone"
+  ],
+  "\ud83d\udc87\ud83c\udffc": [
+    "person_getting_haircut_medium-light_skin_tone"
+  ],
+  "\ud83d\udc87\ud83c\udffc\u200d\u2640": [
+    "woman_getting_haircut_medium-light_skin_tone"
+  ],
+  "\ud83d\udc87\ud83c\udffc\u200d\u2640\ufe0f": [
+    "woman_getting_haircut_medium-light_skin_tone"
+  ],
+  "\ud83d\udc87\ud83c\udffc\u200d\u2642": [
+    "man_getting_haircut_medium-light_skin_tone"
+  ],
+  "\ud83d\udc87\ud83c\udffc\u200d\u2642\ufe0f": [
+    "man_getting_haircut_medium-light_skin_tone"
+  ],
+  "\ud83d\udc87\ud83c\udffd": [
+    "person_getting_haircut_medium_skin_tone"
+  ],
+  "\ud83d\udc87\ud83c\udffd\u200d\u2640": [
+    "woman_getting_haircut_medium_skin_tone"
+  ],
+  "\ud83d\udc87\ud83c\udffd\u200d\u2640\ufe0f": [
+    "woman_getting_haircut_medium_skin_tone"
+  ],
+  "\ud83d\udc87\ud83c\udffd\u200d\u2642": [
+    "man_getting_haircut_medium_skin_tone"
+  ],
+  "\ud83d\udc87\ud83c\udffd\u200d\u2642\ufe0f": [
+    "man_getting_haircut_medium_skin_tone"
+  ],
+  "\ud83d\udc87\ud83c\udffe": [
+    "person_getting_haircut_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc87\ud83c\udffe\u200d\u2640": [
+    "woman_getting_haircut_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc87\ud83c\udffe\u200d\u2640\ufe0f": [
+    "woman_getting_haircut_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc87\ud83c\udffe\u200d\u2642": [
+    "man_getting_haircut_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc87\ud83c\udffe\u200d\u2642\ufe0f": [
+    "man_getting_haircut_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc87\ud83c\udfff": [
+    "person_getting_haircut_dark_skin_tone"
+  ],
+  "\ud83d\udc87\ud83c\udfff\u200d\u2640": [
+    "woman_getting_haircut_dark_skin_tone"
+  ],
+  "\ud83d\udc87\ud83c\udfff\u200d\u2640\ufe0f": [
+    "woman_getting_haircut_dark_skin_tone"
+  ],
+  "\ud83d\udc87\ud83c\udfff\u200d\u2642": [
+    "man_getting_haircut_dark_skin_tone"
+  ],
+  "\ud83d\udc87\ud83c\udfff\u200d\u2642\ufe0f": [
+    "man_getting_haircut_dark_skin_tone"
+  ],
+  "\ud83d\udc88": [
+    "barber_pole",
+    "barber"
+  ],
+  "\ud83d\udc89": [
+    "syringe"
+  ],
+  "\ud83d\udc8a": [
+    "pill"
+  ],
+  "\ud83d\udc8b": [
+    "kiss_mark",
+    "kiss"
+  ],
+  "\ud83d\udc8c": [
+    "love_letter"
+  ],
+  "\ud83d\udc8d": [
+    "ring"
+  ],
+  "\ud83d\udc8e": [
+    "gem_stone",
+    "gem"
+  ],
+  "\ud83d\udc8f": [
+    "kiss",
+    "couplekiss"
+  ],
+  "\ud83d\udc8f\ud83c\udffb": [
+    "kiss_light_skin_tone"
+  ],
+  "\ud83d\udc8f\ud83c\udffc": [
+    "kiss_medium-light_skin_tone"
+  ],
+  "\ud83d\udc8f\ud83c\udffd": [
+    "kiss_medium_skin_tone"
+  ],
+  "\ud83d\udc8f\ud83c\udffe": [
+    "kiss_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc8f\ud83c\udfff": [
+    "kiss_dark_skin_tone"
+  ],
+  "\ud83d\udc90": [
+    "bouquet"
+  ],
+  "\ud83d\udc91": [
+    "couple_with_heart"
+  ],
+  "\ud83d\udc91\ud83c\udffb": [
+    "couple_with_heart_light_skin_tone"
+  ],
+  "\ud83d\udc91\ud83c\udffc": [
+    "couple_with_heart_medium-light_skin_tone"
+  ],
+  "\ud83d\udc91\ud83c\udffd": [
+    "couple_with_heart_medium_skin_tone"
+  ],
+  "\ud83d\udc91\ud83c\udffe": [
+    "couple_with_heart_medium-dark_skin_tone"
+  ],
+  "\ud83d\udc91\ud83c\udfff": [
+    "couple_with_heart_dark_skin_tone"
+  ],
+  "\ud83d\udc92": [
+    "wedding"
+  ],
+  "\ud83d\udc93": [
+    "beating_heart",
+    "heartbeat"
+  ],
+  "\ud83d\udc94": [
+    "broken_heart"
+  ],
+  "\ud83d\udc95": [
+    "two_hearts"
+  ],
+  "\ud83d\udc96": [
+    "sparkling_heart"
+  ],
+  "\ud83d\udc97": [
+    "growing_heart",
+    "heartpulse"
+  ],
+  "\ud83d\udc98": [
+    "heart_with_arrow",
+    "cupid"
+  ],
+  "\ud83d\udc99": [
+    "blue_heart"
+  ],
+  "\ud83d\udc9a": [
+    "green_heart"
+  ],
+  "\ud83d\udc9b": [
+    "yellow_heart"
+  ],
+  "\ud83d\udc9c": [
+    "purple_heart"
+  ],
+  "\ud83d\udc9d": [
+    "heart_with_ribbon",
+    "gift_heart"
+  ],
+  "\ud83d\udc9e": [
+    "revolving_hearts"
+  ],
+  "\ud83d\udc9f": [
+    "heart_decoration"
+  ],
+  "\ud83d\udca0": [
+    "diamond_with_a_dot",
+    "diamond_shape_with_a_dot_inside"
+  ],
+  "\ud83d\udca1": [
+    "light_bulb",
+    "bulb"
+  ],
+  "\ud83d\udca2": [
+    "anger_symbol",
+    "anger"
+  ],
+  "\ud83d\udca3": [
+    "bomb"
+  ],
+  "\ud83d\udca4": [
+    "zzz",
+    "zzz"
+  ],
+  "\ud83d\udca5": [
+    "collision",
+    "boom"
+  ],
+  "\ud83d\udca6": [
+    "sweat_droplets",
+    "sweat_drops"
+  ],
+  "\ud83d\udca7": [
+    "droplet"
+  ],
+  "\ud83d\udca8": [
+    "dashing_away",
+    "dash"
+  ],
+  "\ud83d\udca9": [
+    "pile_of_poo",
+    "poop",
+    "hankey",
+    "shit"
+  ],
+  "\ud83d\udcaa": [
+    "flexed_biceps",
+    "muscle"
+  ],
+  "\ud83d\udcaa\ud83c\udffb": [
+    "flexed_biceps_light_skin_tone"
+  ],
+  "\ud83d\udcaa\ud83c\udffc": [
+    "flexed_biceps_medium-light_skin_tone"
+  ],
+  "\ud83d\udcaa\ud83c\udffd": [
+    "flexed_biceps_medium_skin_tone"
+  ],
+  "\ud83d\udcaa\ud83c\udffe": [
+    "flexed_biceps_medium-dark_skin_tone"
+  ],
+  "\ud83d\udcaa\ud83c\udfff": [
+    "flexed_biceps_dark_skin_tone"
+  ],
+  "\ud83d\udcab": [
+    "dizzy"
+  ],
+  "\ud83d\udcac": [
+    "speech_balloon"
+  ],
+  "\ud83d\udcad": [
+    "thought_balloon"
+  ],
+  "\ud83d\udcae": [
+    "white_flower"
+  ],
+  "\ud83d\udcaf": [
+    "hundred_points",
+    "100"
+  ],
+  "\ud83d\udcb0": [
+    "money_bag",
+    "moneybag"
+  ],
+  "\ud83d\udcb1": [
+    "currency_exchange"
+  ],
+  "\ud83d\udcb2": [
+    "heavy_dollar_sign"
+  ],
+  "\ud83d\udcb3": [
+    "credit_card"
+  ],
+  "\ud83d\udcb4": [
+    "yen_banknote",
+    "yen"
+  ],
+  "\ud83d\udcb5": [
+    "dollar_banknote",
+    "dollar"
+  ],
+  "\ud83d\udcb6": [
+    "euro_banknote",
+    "euro"
+  ],
+  "\ud83d\udcb7": [
+    "pound_banknote",
+    "pound"
+  ],
+  "\ud83d\udcb8": [
+    "money_with_wings"
+  ],
+  "\ud83d\udcb9": [
+    "chart_increasing_with_yen",
+    "chart"
+  ],
+  "\ud83d\udcba": [
+    "seat"
+  ],
+  "\ud83d\udcbb": [
+    "laptop",
+    "computer"
+  ],
+  "\ud83d\udcbc": [
+    "briefcase"
+  ],
+  "\ud83d\udcbd": [
+    "computer_disk",
+    "minidisc"
+  ],
+  "\ud83d\udcbe": [
+    "floppy_disk"
+  ],
+  "\ud83d\udcbf": [
+    "optical_disk",
+    "cd"
+  ],
+  "\ud83d\udcc0": [
+    "dvd"
+  ],
+  "\ud83d\udcc1": [
+    "file_folder"
+  ],
+  "\ud83d\udcc2": [
+    "open_file_folder"
+  ],
+  "\ud83d\udcc3": [
+    "page_with_curl"
+  ],
+  "\ud83d\udcc4": [
+    "page_facing_up"
+  ],
+  "\ud83d\udcc5": [
+    "calendar",
+    "date"
+  ],
+  "\ud83d\udcc6": [
+    "tear-off_calendar",
+    "calendar",
+    "tear_off_calendar"
+  ],
+  "\ud83d\udcc7": [
+    "card_index"
+  ],
+  "\ud83d\udcc8": [
+    "chart_increasing",
+    "chart_with_upwards_trend"
+  ],
+  "\ud83d\udcc9": [
+    "chart_decreasing",
+    "chart_with_downwards_trend"
+  ],
+  "\ud83d\udcca": [
+    "bar_chart"
+  ],
+  "\ud83d\udccb": [
+    "clipboard"
+  ],
+  "\ud83d\udccc": [
+    "pushpin"
+  ],
+  "\ud83d\udccd": [
+    "round_pushpin"
+  ],
+  "\ud83d\udcce": [
+    "paperclip"
+  ],
+  "\ud83d\udccf": [
+    "straight_ruler"
+  ],
+  "\ud83d\udcd0": [
+    "triangular_ruler"
+  ],
+  "\ud83d\udcd1": [
+    "bookmark_tabs"
+  ],
+  "\ud83d\udcd2": [
+    "ledger"
+  ],
+  "\ud83d\udcd3": [
+    "notebook"
+  ],
+  "\ud83d\udcd4": [
+    "notebook_with_decorative_cover"
+  ],
+  "\ud83d\udcd5": [
+    "closed_book"
+  ],
+  "\ud83d\udcd6": [
+    "open_book",
+    "book"
+  ],
+  "\ud83d\udcd7": [
+    "green_book"
+  ],
+  "\ud83d\udcd8": [
+    "blue_book"
+  ],
+  "\ud83d\udcd9": [
+    "orange_book"
+  ],
+  "\ud83d\udcda": [
+    "books"
+  ],
+  "\ud83d\udcdb": [
+    "name_badge"
+  ],
+  "\ud83d\udcdc": [
+    "scroll"
+  ],
+  "\ud83d\udcdd": [
+    "memo",
+    "pencil"
+  ],
+  "\ud83d\udcde": [
+    "telephone_receiver"
+  ],
+  "\ud83d\udcdf": [
+    "pager"
+  ],
+  "\ud83d\udce0": [
+    "fax_machine",
+    "fax"
+  ],
+  "\ud83d\udce1": [
+    "satellite_antenna",
+    "satellite"
+  ],
+  "\ud83d\udce2": [
+    "loudspeaker"
+  ],
+  "\ud83d\udce3": [
+    "megaphone",
+    "mega"
+  ],
+  "\ud83d\udce4": [
+    "outbox_tray"
+  ],
+  "\ud83d\udce5": [
+    "inbox_tray"
+  ],
+  "\ud83d\udce6": [
+    "package"
+  ],
+  "\ud83d\udce7": [
+    "e-mail",
+    "email",
+    "e_mail"
+  ],
+  "\ud83d\udce8": [
+    "incoming_envelope"
+  ],
+  "\ud83d\udce9": [
+    "envelope_with_arrow"
+  ],
+  "\ud83d\udcea": [
+    "closed_mailbox_with_lowered_flag",
+    "mailbox_closed"
+  ],
+  "\ud83d\udceb": [
+    "closed_mailbox_with_raised_flag",
+    "mailbox"
+  ],
+  "\ud83d\udcec": [
+    "open_mailbox_with_raised_flag",
+    "mailbox_with_mail"
+  ],
+  "\ud83d\udced": [
+    "open_mailbox_with_lowered_flag",
+    "mailbox_with_no_mail"
+  ],
+  "\ud83d\udcee": [
+    "postbox"
+  ],
+  "\ud83d\udcef": [
+    "postal_horn"
+  ],
+  "\ud83d\udcf0": [
+    "newspaper"
+  ],
+  "\ud83d\udcf1": [
+    "mobile_phone",
+    "iphone"
+  ],
+  "\ud83d\udcf2": [
+    "mobile_phone_with_arrow",
+    "calling"
+  ],
+  "\ud83d\udcf3": [
+    "vibration_mode"
+  ],
+  "\ud83d\udcf4": [
+    "mobile_phone_off"
+  ],
+  "\ud83d\udcf5": [
+    "no_mobile_phones"
+  ],
+  "\ud83d\udcf6": [
+    "antenna_bars",
+    "signal_strength"
+  ],
+  "\ud83d\udcf7": [
+    "camera"
+  ],
+  "\ud83d\udcf8": [
+    "camera_with_flash",
+    "camera_flash"
+  ],
+  "\ud83d\udcf9": [
+    "video_camera"
+  ],
+  "\ud83d\udcfa": [
+    "television",
+    "tv"
+  ],
+  "\ud83d\udcfb": [
+    "radio"
+  ],
+  "\ud83d\udcfc": [
+    "videocassette",
+    "vhs"
+  ],
+  "\ud83d\udcfd": [
+    "film_projector"
+  ],
+  "\ud83d\udcfd\ufe0f": [
+    "film_projector"
+  ],
+  "\ud83d\udcff": [
+    "prayer_beads"
+  ],
+  "\ud83d\udd00": [
+    "shuffle_tracks_button",
+    "twisted_rightwards_arrows"
+  ],
+  "\ud83d\udd01": [
+    "repeat_button",
+    "repeat"
+  ],
+  "\ud83d\udd02": [
+    "repeat_single_button",
+    "repeat_one"
+  ],
+  "\ud83d\udd03": [
+    "clockwise_vertical_arrows",
+    "arrows_clockwise"
+  ],
+  "\ud83d\udd04": [
+    "counterclockwise_arrows_button",
+    "arrows_counterclockwise"
+  ],
+  "\ud83d\udd05": [
+    "dim_button",
+    "low_brightness"
+  ],
+  "\ud83d\udd06": [
+    "bright_button",
+    "high_brightness"
+  ],
+  "\ud83d\udd07": [
+    "muted_speaker",
+    "mute"
+  ],
+  "\ud83d\udd08": [
+    "speaker_low_volume",
+    "speaker"
+  ],
+  "\ud83d\udd09": [
+    "speaker_medium_volume",
+    "sound"
+  ],
+  "\ud83d\udd0a": [
+    "speaker_high_volume",
+    "loud_sound"
+  ],
+  "\ud83d\udd0b": [
+    "battery"
+  ],
+  "\ud83d\udd0c": [
+    "electric_plug"
+  ],
+  "\ud83d\udd0d": [
+    "magnifying_glass_tilted_left",
+    "mag"
+  ],
+  "\ud83d\udd0e": [
+    "magnifying_glass_tilted_right",
+    "mag_right"
+  ],
+  "\ud83d\udd0f": [
+    "locked_with_pen",
+    "lock_with_ink_pen"
+  ],
+  "\ud83d\udd10": [
+    "locked_with_key",
+    "closed_lock_with_key"
+  ],
+  "\ud83d\udd11": [
+    "key"
+  ],
+  "\ud83d\udd12": [
+    "locked",
+    "lock"
+  ],
+  "\ud83d\udd13": [
+    "unlocked",
+    "unlock"
+  ],
+  "\ud83d\udd14": [
+    "bell"
+  ],
+  "\ud83d\udd15": [
+    "bell_with_slash",
+    "no_bell"
+  ],
+  "\ud83d\udd16": [
+    "bookmark"
+  ],
+  "\ud83d\udd17": [
+    "link"
+  ],
+  "\ud83d\udd18": [
+    "radio_button"
+  ],
+  "\ud83d\udd19": [
+    "back_arrow",
+    "back",
+    "back_arrow"
+  ],
+  "\ud83d\udd1a": [
+    "end_arrow",
+    "end",
+    "end_arrow"
+  ],
+  "\ud83d\udd1b": [
+    "on!_arrow",
+    "on",
+    "on_arrow",
+    "on!_arrow"
+  ],
+  "\ud83d\udd1c": [
+    "soon_arrow",
+    "soon",
+    "soon_arrow"
+  ],
+  "\ud83d\udd1d": [
+    "top_arrow",
+    "top",
+    "top_arrow"
+  ],
+  "\ud83d\udd1e": [
+    "no_one_under_eighteen",
+    "underage"
+  ],
+  "\ud83d\udd1f": [
+    "keycap_10",
+    "ten",
+    "keycap_ten"
+  ],
+  "\ud83d\udd20": [
+    "input_latin_uppercase",
+    "capital_abcd"
+  ],
+  "\ud83d\udd21": [
+    "input_latin_lowercase",
+    "abcd"
+  ],
+  "\ud83d\udd22": [
+    "input_numbers",
+    "1234"
+  ],
+  "\ud83d\udd23": [
+    "input_symbols",
+    "symbols"
+  ],
+  "\ud83d\udd24": [
+    "input_latin_letters",
+    "abc"
+  ],
+  "\ud83d\udd25": [
+    "fire"
+  ],
+  "\ud83d\udd26": [
+    "flashlight"
+  ],
+  "\ud83d\udd27": [
+    "wrench"
+  ],
+  "\ud83d\udd28": [
+    "hammer"
+  ],
+  "\ud83d\udd29": [
+    "nut_and_bolt"
+  ],
+  "\ud83d\udd2a": [
+    "kitchen_knife",
+    "hocho",
+    "knife"
+  ],
+  "\ud83d\udd2b": [
+    "water_pistol",
+    "gun"
+  ],
+  "\ud83d\udd2c": [
+    "microscope"
+  ],
+  "\ud83d\udd2d": [
+    "telescope"
+  ],
+  "\ud83d\udd2e": [
+    "crystal_ball"
+  ],
+  "\ud83d\udd2f": [
+    "dotted_six-pointed_star",
+    "six_pointed_star",
+    "dotted_six_pointed_star"
+  ],
+  "\ud83d\udd30": [
+    "japanese_symbol_for_beginner",
+    "beginner",
+    "japanese_symbol_for_beginner"
+  ],
+  "\ud83d\udd31": [
+    "trident_emblem",
+    "trident"
+  ],
+  "\ud83d\udd32": [
+    "black_square_button"
+  ],
+  "\ud83d\udd33": [
+    "white_square_button"
+  ],
+  "\ud83d\udd34": [
+    "red_circle"
+  ],
+  "\ud83d\udd35": [
+    "blue_circle",
+    "large_blue_circle"
+  ],
+  "\ud83d\udd36": [
+    "large_orange_diamond"
+  ],
+  "\ud83d\udd37": [
+    "large_blue_diamond"
+  ],
+  "\ud83d\udd38": [
+    "small_orange_diamond"
+  ],
+  "\ud83d\udd39": [
+    "small_blue_diamond"
+  ],
+  "\ud83d\udd3a": [
+    "red_triangle_pointed_up",
+    "small_red_triangle"
+  ],
+  "\ud83d\udd3b": [
+    "red_triangle_pointed_down",
+    "small_red_triangle_down"
+  ],
+  "\ud83d\udd3c": [
+    "upwards_button",
+    "arrow_up_small"
+  ],
+  "\ud83d\udd3d": [
+    "downwards_button",
+    "arrow_down_small"
+  ],
+  "\ud83d\udd49": [
+    "om",
+    "om_symbol"
+  ],
+  "\ud83d\udd49\ufe0f": [
+    "om",
+    "om_symbol"
+  ],
+  "\ud83d\udd4a": [
+    "dove",
+    "dove_of_peace"
+  ],
+  "\ud83d\udd4a\ufe0f": [
+    "dove",
+    "dove_of_peace"
+  ],
+  "\ud83d\udd4b": [
+    "kaaba"
+  ],
+  "\ud83d\udd4c": [
+    "mosque"
+  ],
+  "\ud83d\udd4d": [
+    "synagogue"
+  ],
+  "\ud83d\udd4e": [
+    "menorah",
+    "menorah_with_nine_branches"
+  ],
+  "\ud83d\udd50": [
+    "one_o\u2019clock",
+    "clock1",
+    "one_oclock"
+  ],
+  "\ud83d\udd51": [
+    "two_o\u2019clock",
+    "clock2",
+    "two_oclock"
+  ],
+  "\ud83d\udd52": [
+    "three_o\u2019clock",
+    "clock3",
+    "three_oclock"
+  ],
+  "\ud83d\udd53": [
+    "four_o\u2019clock",
+    "clock4",
+    "four_oclock"
+  ],
+  "\ud83d\udd54": [
+    "five_o\u2019clock",
+    "clock5",
+    "five_oclock"
+  ],
+  "\ud83d\udd55": [
+    "six_o\u2019clock",
+    "clock6",
+    "six_oclock"
+  ],
+  "\ud83d\udd56": [
+    "seven_o\u2019clock",
+    "clock7",
+    "seven_oclock"
+  ],
+  "\ud83d\udd57": [
+    "eight_o\u2019clock",
+    "clock8",
+    "eight_oclock"
+  ],
+  "\ud83d\udd58": [
+    "nine_o\u2019clock",
+    "clock9",
+    "nine_oclock"
+  ],
+  "\ud83d\udd59": [
+    "ten_o\u2019clock",
+    "clock10",
+    "ten_oclock"
+  ],
+  "\ud83d\udd5a": [
+    "eleven_o\u2019clock",
+    "clock11",
+    "eleven_oclock"
+  ],
+  "\ud83d\udd5b": [
+    "twelve_o\u2019clock",
+    "clock12",
+    "twelve_oclock"
+  ],
+  "\ud83d\udd5c": [
+    "one-thirty",
+    "clock130",
+    "one_thirty"
+  ],
+  "\ud83d\udd5d": [
+    "two-thirty",
+    "clock230",
+    "two_thirty"
+  ],
+  "\ud83d\udd5e": [
+    "three-thirty",
+    "clock330",
+    "three_thirty"
+  ],
+  "\ud83d\udd5f": [
+    "four-thirty",
+    "clock430",
+    "four_thirty"
+  ],
+  "\ud83d\udd60": [
+    "five-thirty",
+    "clock530",
+    "five_thirty"
+  ],
+  "\ud83d\udd61": [
+    "six-thirty",
+    "clock630",
+    "six_thirty"
+  ],
+  "\ud83d\udd62": [
+    "seven-thirty",
+    "clock730",
+    "seven_thirty"
+  ],
+  "\ud83d\udd63": [
+    "eight-thirty",
+    "clock830",
+    "eight_thirty"
+  ],
+  "\ud83d\udd64": [
+    "nine-thirty",
+    "clock930",
+    "nine_thirty"
+  ],
+  "\ud83d\udd65": [
+    "ten-thirty",
+    "clock1030",
+    "ten_thirty"
+  ],
+  "\ud83d\udd66": [
+    "eleven-thirty",
+    "clock1130",
+    "eleven_thirty"
+  ],
+  "\ud83d\udd67": [
+    "twelve-thirty",
+    "clock1230",
+    "twelve_thirty"
+  ],
+  "\ud83d\udd6f": [
+    "candle"
+  ],
+  "\ud83d\udd6f\ufe0f": [
+    "candle"
+  ],
+  "\ud83d\udd70": [
+    "mantelpiece_clock"
+  ],
+  "\ud83d\udd70\ufe0f": [
+    "mantelpiece_clock"
+  ],
+  "\ud83d\udd73": [
+    "hole"
+  ],
+  "\ud83d\udd73\ufe0f": [
+    "hole"
+  ],
+  "\ud83d\udd74": [
+    "person_in_suit_levitating",
+    "business_suit_levitating",
+    "man_in_business_suit_levitating"
+  ],
+  "\ud83d\udd74\ufe0f": [
+    "person_in_suit_levitating",
+    "business_suit_levitating",
+    "man_in_business_suit_levitating"
+  ],
+  "\ud83d\udd74\ud83c\udffb": [
+    "person_in_suit_levitating_light_skin_tone"
+  ],
+  "\ud83d\udd74\ud83c\udffc": [
+    "person_in_suit_levitating_medium-light_skin_tone"
+  ],
+  "\ud83d\udd74\ud83c\udffd": [
+    "person_in_suit_levitating_medium_skin_tone"
+  ],
+  "\ud83d\udd74\ud83c\udffe": [
+    "person_in_suit_levitating_medium-dark_skin_tone"
+  ],
+  "\ud83d\udd74\ud83c\udfff": [
+    "person_in_suit_levitating_dark_skin_tone"
+  ],
+  "\ud83d\udd75": [
+    "detective",
+    "sleuth_or_spy"
+  ],
+  "\ud83d\udd75\u200d\u2640": [
+    "woman_detective",
+    "female_detective"
+  ],
+  "\ud83d\udd75\u200d\u2640\ufe0f": [
+    "woman_detective",
+    "female_detective"
+  ],
+  "\ud83d\udd75\u200d\u2642": [
+    "man_detective",
+    "male_detective"
+  ],
+  "\ud83d\udd75\u200d\u2642\ufe0f": [
+    "man_detective",
+    "male_detective"
+  ],
+  "\ud83d\udd75\ufe0f": [
+    "detective",
+    "sleuth_or_spy"
+  ],
+  "\ud83d\udd75\ufe0f\u200d\u2640": [
+    "woman_detective",
+    "female_detective"
+  ],
+  "\ud83d\udd75\ufe0f\u200d\u2640\ufe0f": [
+    "woman_detective",
+    "female_detective"
+  ],
+  "\ud83d\udd75\ufe0f\u200d\u2642": [
+    "man_detective",
+    "male_detective"
+  ],
+  "\ud83d\udd75\ufe0f\u200d\u2642\ufe0f": [
+    "man_detective",
+    "male_detective"
+  ],
+  "\ud83d\udd75\ud83c\udffb": [
+    "detective_light_skin_tone"
+  ],
+  "\ud83d\udd75\ud83c\udffb\u200d\u2640": [
+    "woman_detective_light_skin_tone"
+  ],
+  "\ud83d\udd75\ud83c\udffb\u200d\u2640\ufe0f": [
+    "woman_detective_light_skin_tone"
+  ],
+  "\ud83d\udd75\ud83c\udffb\u200d\u2642": [
+    "man_detective_light_skin_tone"
+  ],
+  "\ud83d\udd75\ud83c\udffb\u200d\u2642\ufe0f": [
+    "man_detective_light_skin_tone"
+  ],
+  "\ud83d\udd75\ud83c\udffc": [
+    "detective_medium-light_skin_tone"
+  ],
+  "\ud83d\udd75\ud83c\udffc\u200d\u2640": [
+    "woman_detective_medium-light_skin_tone"
+  ],
+  "\ud83d\udd75\ud83c\udffc\u200d\u2640\ufe0f": [
+    "woman_detective_medium-light_skin_tone"
+  ],
+  "\ud83d\udd75\ud83c\udffc\u200d\u2642": [
+    "man_detective_medium-light_skin_tone"
+  ],
+  "\ud83d\udd75\ud83c\udffc\u200d\u2642\ufe0f": [
+    "man_detective_medium-light_skin_tone"
+  ],
+  "\ud83d\udd75\ud83c\udffd": [
+    "detective_medium_skin_tone"
+  ],
+  "\ud83d\udd75\ud83c\udffd\u200d\u2640": [
+    "woman_detective_medium_skin_tone"
+  ],
+  "\ud83d\udd75\ud83c\udffd\u200d\u2640\ufe0f": [
+    "woman_detective_medium_skin_tone"
+  ],
+  "\ud83d\udd75\ud83c\udffd\u200d\u2642": [
+    "man_detective_medium_skin_tone"
+  ],
+  "\ud83d\udd75\ud83c\udffd\u200d\u2642\ufe0f": [
+    "man_detective_medium_skin_tone"
+  ],
+  "\ud83d\udd75\ud83c\udffe": [
+    "detective_medium-dark_skin_tone"
+  ],
+  "\ud83d\udd75\ud83c\udffe\u200d\u2640": [
+    "woman_detective_medium-dark_skin_tone"
+  ],
+  "\ud83d\udd75\ud83c\udffe\u200d\u2640\ufe0f": [
+    "woman_detective_medium-dark_skin_tone"
+  ],
+  "\ud83d\udd75\ud83c\udffe\u200d\u2642": [
+    "man_detective_medium-dark_skin_tone"
+  ],
+  "\ud83d\udd75\ud83c\udffe\u200d\u2642\ufe0f": [
+    "man_detective_medium-dark_skin_tone"
+  ],
+  "\ud83d\udd75\ud83c\udfff": [
+    "detective_dark_skin_tone"
+  ],
+  "\ud83d\udd75\ud83c\udfff\u200d\u2640": [
+    "woman_detective_dark_skin_tone"
+  ],
+  "\ud83d\udd75\ud83c\udfff\u200d\u2640\ufe0f": [
+    "woman_detective_dark_skin_tone"
+  ],
+  "\ud83d\udd75\ud83c\udfff\u200d\u2642": [
+    "man_detective_dark_skin_tone"
+  ],
+  "\ud83d\udd75\ud83c\udfff\u200d\u2642\ufe0f": [
+    "man_detective_dark_skin_tone"
+  ],
+  "\ud83d\udd76": [
+    "sunglasses",
+    "dark_sunglasses"
+  ],
+  "\ud83d\udd76\ufe0f": [
+    "sunglasses",
+    "dark_sunglasses"
+  ],
+  "\ud83d\udd77": [
+    "spider"
+  ],
+  "\ud83d\udd77\ufe0f": [
+    "spider"
+  ],
+  "\ud83d\udd78": [
+    "spider_web"
+  ],
+  "\ud83d\udd78\ufe0f": [
+    "spider_web"
+  ],
+  "\ud83d\udd79": [
+    "joystick"
+  ],
+  "\ud83d\udd79\ufe0f": [
+    "joystick"
+  ],
+  "\ud83d\udd7a": [
+    "man_dancing"
+  ],
+  "\ud83d\udd7a\ud83c\udffb": [
+    "man_dancing_light_skin_tone"
+  ],
+  "\ud83d\udd7a\ud83c\udffc": [
+    "man_dancing_medium-light_skin_tone"
+  ],
+  "\ud83d\udd7a\ud83c\udffd": [
+    "man_dancing_medium_skin_tone"
+  ],
+  "\ud83d\udd7a\ud83c\udffe": [
+    "man_dancing_medium-dark_skin_tone"
+  ],
+  "\ud83d\udd7a\ud83c\udfff": [
+    "man_dancing_dark_skin_tone"
+  ],
+  "\ud83d\udd87": [
+    "linked_paperclips",
+    "paperclips"
+  ],
+  "\ud83d\udd87\ufe0f": [
+    "linked_paperclips",
+    "paperclips"
+  ],
+  "\ud83d\udd8a": [
+    "pen",
+    "lower_left_ballpoint_pen"
+  ],
+  "\ud83d\udd8a\ufe0f": [
+    "pen",
+    "lower_left_ballpoint_pen"
+  ],
+  "\ud83d\udd8b": [
+    "fountain_pen",
+    "lower_left_fountain_pen"
+  ],
+  "\ud83d\udd8b\ufe0f": [
+    "fountain_pen",
+    "lower_left_fountain_pen"
+  ],
+  "\ud83d\udd8c": [
+    "paintbrush",
+    "lower_left_paintbrush"
+  ],
+  "\ud83d\udd8c\ufe0f": [
+    "paintbrush",
+    "lower_left_paintbrush"
+  ],
+  "\ud83d\udd8d": [
+    "crayon",
+    "lower_left_crayon"
+  ],
+  "\ud83d\udd8d\ufe0f": [
+    "crayon",
+    "lower_left_crayon"
+  ],
+  "\ud83d\udd90": [
+    "hand_with_fingers_splayed",
+    "raised_hand_with_fingers_splayed"
+  ],
+  "\ud83d\udd90\ufe0f": [
+    "hand_with_fingers_splayed",
+    "raised_hand_with_fingers_splayed"
+  ],
+  "\ud83d\udd90\ud83c\udffb": [
+    "hand_with_fingers_splayed_light_skin_tone"
+  ],
+  "\ud83d\udd90\ud83c\udffc": [
+    "hand_with_fingers_splayed_medium-light_skin_tone"
+  ],
+  "\ud83d\udd90\ud83c\udffd": [
+    "hand_with_fingers_splayed_medium_skin_tone"
+  ],
+  "\ud83d\udd90\ud83c\udffe": [
+    "hand_with_fingers_splayed_medium-dark_skin_tone"
+  ],
+  "\ud83d\udd90\ud83c\udfff": [
+    "hand_with_fingers_splayed_dark_skin_tone"
+  ],
+  "\ud83d\udd95": [
+    "middle_finger",
+    "fu",
+    "reversed_hand_with_middle_finger_extended"
+  ],
+  "\ud83d\udd95\ud83c\udffb": [
+    "middle_finger_light_skin_tone"
+  ],
+  "\ud83d\udd95\ud83c\udffc": [
+    "middle_finger_medium-light_skin_tone"
+  ],
+  "\ud83d\udd95\ud83c\udffd": [
+    "middle_finger_medium_skin_tone"
+  ],
+  "\ud83d\udd95\ud83c\udffe": [
+    "middle_finger_medium-dark_skin_tone"
+  ],
+  "\ud83d\udd95\ud83c\udfff": [
+    "middle_finger_dark_skin_tone"
+  ],
+  "\ud83d\udd96": [
+    "vulcan_salute",
+    "raised_hand_with_part_between_middle_and_ring_fingers"
+  ],
+  "\ud83d\udd96\ud83c\udffb": [
+    "vulcan_salute_light_skin_tone"
+  ],
+  "\ud83d\udd96\ud83c\udffc": [
+    "vulcan_salute_medium-light_skin_tone"
+  ],
+  "\ud83d\udd96\ud83c\udffd": [
+    "vulcan_salute_medium_skin_tone"
+  ],
+  "\ud83d\udd96\ud83c\udffe": [
+    "vulcan_salute_medium-dark_skin_tone"
+  ],
+  "\ud83d\udd96\ud83c\udfff": [
+    "vulcan_salute_dark_skin_tone"
+  ],
+  "\ud83d\udda4": [
+    "black_heart"
+  ],
+  "\ud83d\udda5": [
+    "desktop_computer"
+  ],
+  "\ud83d\udda5\ufe0f": [
+    "desktop_computer"
+  ],
+  "\ud83d\udda8": [
+    "printer"
+  ],
+  "\ud83d\udda8\ufe0f": [
+    "printer"
+  ],
+  "\ud83d\uddb1": [
+    "computer_mouse",
+    "three_button_mouse"
+  ],
+  "\ud83d\uddb1\ufe0f": [
+    "computer_mouse",
+    "three_button_mouse"
+  ],
+  "\ud83d\uddb2": [
+    "trackball"
+  ],
+  "\ud83d\uddb2\ufe0f": [
+    "trackball"
+  ],
+  "\ud83d\uddbc": [
+    "framed_picture",
+    "frame_with_picture"
+  ],
+  "\ud83d\uddbc\ufe0f": [
+    "framed_picture",
+    "frame_with_picture"
+  ],
+  "\ud83d\uddc2": [
+    "card_index_dividers"
+  ],
+  "\ud83d\uddc2\ufe0f": [
+    "card_index_dividers"
+  ],
+  "\ud83d\uddc3": [
+    "card_file_box"
+  ],
+  "\ud83d\uddc3\ufe0f": [
+    "card_file_box"
+  ],
+  "\ud83d\uddc4": [
+    "file_cabinet"
+  ],
+  "\ud83d\uddc4\ufe0f": [
+    "file_cabinet"
+  ],
+  "\ud83d\uddd1": [
+    "wastebasket"
+  ],
+  "\ud83d\uddd1\ufe0f": [
+    "wastebasket"
+  ],
+  "\ud83d\uddd2": [
+    "spiral_notepad",
+    "spiral_note_pad"
+  ],
+  "\ud83d\uddd2\ufe0f": [
+    "spiral_notepad",
+    "spiral_note_pad"
+  ],
+  "\ud83d\uddd3": [
+    "spiral_calendar",
+    "spiral_calendar_pad"
+  ],
+  "\ud83d\uddd3\ufe0f": [
+    "spiral_calendar",
+    "spiral_calendar_pad"
+  ],
+  "\ud83d\udddc": [
+    "clamp",
+    "compression"
+  ],
+  "\ud83d\udddc\ufe0f": [
+    "clamp",
+    "compression"
+  ],
+  "\ud83d\udddd": [
+    "old_key"
+  ],
+  "\ud83d\udddd\ufe0f": [
+    "old_key"
+  ],
+  "\ud83d\uddde": [
+    "rolled-up_newspaper",
+    "rolled_up_newspaper",
+    "newspaper_roll"
+  ],
+  "\ud83d\uddde\ufe0f": [
+    "rolled-up_newspaper",
+    "rolled_up_newspaper",
+    "newspaper_roll"
+  ],
+  "\ud83d\udde1": [
+    "dagger",
+    "dagger_knife"
+  ],
+  "\ud83d\udde1\ufe0f": [
+    "dagger",
+    "dagger_knife"
+  ],
+  "\ud83d\udde3": [
+    "speaking_head",
+    "speaking_head_in_silhouette"
+  ],
+  "\ud83d\udde3\ufe0f": [
+    "speaking_head",
+    "speaking_head_in_silhouette"
+  ],
+  "\ud83d\udde8": [
+    "left_speech_bubble"
+  ],
+  "\ud83d\udde8\ufe0f": [
+    "left_speech_bubble"
+  ],
+  "\ud83d\uddef": [
+    "right_anger_bubble"
+  ],
+  "\ud83d\uddef\ufe0f": [
+    "right_anger_bubble"
+  ],
+  "\ud83d\uddf3": [
+    "ballot_box_with_ballot",
+    "ballot_box"
+  ],
+  "\ud83d\uddf3\ufe0f": [
+    "ballot_box_with_ballot",
+    "ballot_box"
+  ],
+  "\ud83d\uddfa": [
+    "world_map"
+  ],
+  "\ud83d\uddfa\ufe0f": [
+    "world_map"
+  ],
+  "\ud83d\uddfb": [
+    "mount_fuji"
+  ],
+  "\ud83d\uddfc": [
+    "tokyo_tower",
+    "tokyo_tower"
+  ],
+  "\ud83d\uddfd": [
+    "statue_of_liberty",
+    "statue_of_liberty"
+  ],
+  "\ud83d\uddfe": [
+    "map_of_japan",
+    "japan",
+    "map_of_japan"
+  ],
+  "\ud83d\uddff": [
+    "moai",
+    "moyai"
+  ],
+  "\ud83d\ude00": [
+    "grinning_face",
+    "grinning"
+  ],
+  "\ud83d\ude01": [
+    "beaming_face_with_smiling_eyes",
+    "grin"
+  ],
+  "\ud83d\ude02": [
+    "face_with_tears_of_joy",
+    "joy"
+  ],
+  "\ud83d\ude03": [
+    "grinning_face_with_big_eyes",
+    "smiley"
+  ],
+  "\ud83d\ude04": [
+    "grinning_face_with_smiling_eyes",
+    "smile"
+  ],
+  "\ud83d\ude05": [
+    "grinning_face_with_sweat",
+    "sweat_smile"
+  ],
+  "\ud83d\ude06": [
+    "grinning_squinting_face",
+    "satisfied",
+    "laughing"
+  ],
+  "\ud83d\ude07": [
+    "smiling_face_with_halo",
+    "innocent"
+  ],
+  "\ud83d\ude08": [
+    "smiling_face_with_horns",
+    "smiling_imp"
+  ],
+  "\ud83d\ude09": [
+    "winking_face",
+    "wink"
+  ],
+  "\ud83d\ude0a": [
+    "smiling_face_with_smiling_eyes",
+    "blush"
+  ],
+  "\ud83d\ude0b": [
+    "face_savoring_food",
+    "yum"
+  ],
+  "\ud83d\ude0c": [
+    "relieved_face",
+    "relieved"
+  ],
+  "\ud83d\ude0d": [
+    "smiling_face_with_heart-eyes",
+    "heart_eyes",
+    "smiling_face_with_heart_eyes"
+  ],
+  "\ud83d\ude0e": [
+    "smiling_face_with_sunglasses",
+    "sunglasses"
+  ],
+  "\ud83d\ude0f": [
+    "smirking_face",
+    "smirk"
+  ],
+  "\ud83d\ude10": [
+    "neutral_face"
+  ],
+  "\ud83d\ude11": [
+    "expressionless_face",
+    "expressionless"
+  ],
+  "\ud83d\ude12": [
+    "unamused_face",
+    "unamused"
+  ],
+  "\ud83d\ude13": [
+    "downcast_face_with_sweat",
+    "sweat"
+  ],
+  "\ud83d\ude14": [
+    "pensive_face",
+    "pensive"
+  ],
+  "\ud83d\ude15": [
+    "confused_face",
+    "confused"
+  ],
+  "\ud83d\ude16": [
+    "confounded_face",
+    "confounded"
+  ],
+  "\ud83d\ude17": [
+    "kissing_face",
+    "kissing"
+  ],
+  "\ud83d\ude18": [
+    "face_blowing_a_kiss",
+    "kissing_heart"
+  ],
+  "\ud83d\ude19": [
+    "kissing_face_with_smiling_eyes",
+    "kissing_smiling_eyes"
+  ],
+  "\ud83d\ude1a": [
+    "kissing_face_with_closed_eyes",
+    "kissing_closed_eyes"
+  ],
+  "\ud83d\ude1b": [
+    "face_with_tongue",
+    "stuck_out_tongue"
+  ],
+  "\ud83d\ude1c": [
+    "winking_face_with_tongue",
+    "stuck_out_tongue_winking_eye"
+  ],
+  "\ud83d\ude1d": [
+    "squinting_face_with_tongue",
+    "stuck_out_tongue_closed_eyes"
+  ],
+  "\ud83d\ude1e": [
+    "disappointed_face",
+    "disappointed"
+  ],
+  "\ud83d\ude1f": [
+    "worried_face",
+    "worried"
+  ],
+  "\ud83d\ude20": [
+    "angry_face",
+    "angry"
+  ],
+  "\ud83d\ude21": [
+    "enraged_face",
+    "rage",
+    "pout"
+  ],
+  "\ud83d\ude22": [
+    "crying_face",
+    "cry"
+  ],
+  "\ud83d\ude23": [
+    "persevering_face",
+    "persevere"
+  ],
+  "\ud83d\ude24": [
+    "face_with_steam_from_nose",
+    "triumph"
+  ],
+  "\ud83d\ude25": [
+    "sad_but_relieved_face",
+    "disappointed_relieved"
+  ],
+  "\ud83d\ude26": [
+    "frowning_face_with_open_mouth",
+    "frowning"
+  ],
+  "\ud83d\ude27": [
+    "anguished_face",
+    "anguished"
+  ],
+  "\ud83d\ude28": [
+    "fearful_face",
+    "fearful"
+  ],
+  "\ud83d\ude29": [
+    "weary_face",
+    "weary"
+  ],
+  "\ud83d\ude2a": [
+    "sleepy_face",
+    "sleepy"
+  ],
+  "\ud83d\ude2b": [
+    "tired_face"
+  ],
+  "\ud83d\ude2c": [
+    "grimacing_face",
+    "grimacing"
+  ],
+  "\ud83d\ude2d": [
+    "loudly_crying_face",
+    "sob"
+  ],
+  "\ud83d\ude2e": [
+    "face_with_open_mouth",
+    "open_mouth"
+  ],
+  "\ud83d\ude2e\u200d\ud83d\udca8": [
+    "face_exhaling"
+  ],
+  "\ud83d\ude2f": [
+    "hushed_face",
+    "hushed"
+  ],
+  "\ud83d\ude30": [
+    "anxious_face_with_sweat",
+    "cold_sweat"
+  ],
+  "\ud83d\ude31": [
+    "face_screaming_in_fear",
+    "scream"
+  ],
+  "\ud83d\ude32": [
+    "astonished_face",
+    "astonished"
+  ],
+  "\ud83d\ude33": [
+    "flushed_face",
+    "flushed"
+  ],
+  "\ud83d\ude34": [
+    "sleeping_face",
+    "sleeping"
+  ],
+  "\ud83d\ude35": [
+    "face_with_crossed-out_eyes",
+    "dizzy_face",
+    "face_with_crossed_out_eyes",
+    "knocked_out_face"
+  ],
+  "\ud83d\ude35\u200d\ud83d\udcab": [
+    "face_with_spiral_eyes"
+  ],
+  "\ud83d\ude36": [
+    "face_without_mouth",
+    "no_mouth"
+  ],
+  "\ud83d\ude36\u200d\ud83c\udf2b": [
+    "face_in_clouds"
+  ],
+  "\ud83d\ude36\u200d\ud83c\udf2b\ufe0f": [
+    "face_in_clouds"
+  ],
+  "\ud83d\ude37": [
+    "face_with_medical_mask",
+    "mask"
+  ],
+  "\ud83d\ude38": [
+    "grinning_cat_with_smiling_eyes",
+    "smile_cat"
+  ],
+  "\ud83d\ude39": [
+    "cat_with_tears_of_joy",
+    "joy_cat"
+  ],
+  "\ud83d\ude3a": [
+    "grinning_cat",
+    "smiley_cat"
+  ],
+  "\ud83d\ude3b": [
+    "smiling_cat_with_heart-eyes",
+    "heart_eyes_cat",
+    "smiling_cat_with_heart_eyes"
+  ],
+  "\ud83d\ude3c": [
+    "cat_with_wry_smile",
+    "smirk_cat"
+  ],
+  "\ud83d\ude3d": [
+    "kissing_cat"
+  ],
+  "\ud83d\ude3e": [
+    "pouting_cat"
+  ],
+  "\ud83d\ude3f": [
+    "crying_cat",
+    "crying_cat_face"
+  ],
+  "\ud83d\ude40": [
+    "weary_cat",
+    "scream_cat"
+  ],
+  "\ud83d\ude41": [
+    "slightly_frowning_face"
+  ],
+  "\ud83d\ude42": [
+    "slightly_smiling_face"
+  ],
+  "\ud83d\ude42\u200d\u2194": [
+    "head_shaking_horizontally"
+  ],
+  "\ud83d\ude42\u200d\u2194\ufe0f": [
+    "head_shaking_horizontally"
+  ],
+  "\ud83d\ude42\u200d\u2195": [
+    "head_shaking_vertically"
+  ],
+  "\ud83d\ude42\u200d\u2195\ufe0f": [
+    "head_shaking_vertically"
+  ],
+  "\ud83d\ude43": [
+    "upside-down_face",
+    "upside_down_face"
+  ],
+  "\ud83d\ude44": [
+    "face_with_rolling_eyes",
+    "roll_eyes"
+  ],
+  "\ud83d\ude45": [
+    "person_gesturing_no",
+    "no_good",
+    "person_gesturing_no"
+  ],
+  "\ud83d\ude45\u200d\u2640": [
+    "woman_gesturing_no",
+    "ng_woman",
+    "no_good_woman",
+    "woman_gesturing_no"
+  ],
+  "\ud83d\ude45\u200d\u2640\ufe0f": [
+    "woman_gesturing_no",
+    "ng_woman",
+    "no_good_woman",
+    "woman_gesturing_no"
+  ],
+  "\ud83d\ude45\u200d\u2642": [
+    "man_gesturing_no",
+    "no_good_man",
+    "ng_man",
+    "man_gesturing_no"
+  ],
+  "\ud83d\ude45\u200d\u2642\ufe0f": [
+    "man_gesturing_no",
+    "no_good_man",
+    "ng_man",
+    "man_gesturing_no"
+  ],
+  "\ud83d\ude45\ud83c\udffb": [
+    "person_gesturing_no_light_skin_tone"
+  ],
+  "\ud83d\ude45\ud83c\udffb\u200d\u2640": [
+    "woman_gesturing_no_light_skin_tone"
+  ],
+  "\ud83d\ude45\ud83c\udffb\u200d\u2640\ufe0f": [
+    "woman_gesturing_no_light_skin_tone"
+  ],
+  "\ud83d\ude45\ud83c\udffb\u200d\u2642": [
+    "man_gesturing_no_light_skin_tone"
+  ],
+  "\ud83d\ude45\ud83c\udffb\u200d\u2642\ufe0f": [
+    "man_gesturing_no_light_skin_tone"
+  ],
+  "\ud83d\ude45\ud83c\udffc": [
+    "person_gesturing_no_medium-light_skin_tone"
+  ],
+  "\ud83d\ude45\ud83c\udffc\u200d\u2640": [
+    "woman_gesturing_no_medium-light_skin_tone"
+  ],
+  "\ud83d\ude45\ud83c\udffc\u200d\u2640\ufe0f": [
+    "woman_gesturing_no_medium-light_skin_tone"
+  ],
+  "\ud83d\ude45\ud83c\udffc\u200d\u2642": [
+    "man_gesturing_no_medium-light_skin_tone"
+  ],
+  "\ud83d\ude45\ud83c\udffc\u200d\u2642\ufe0f": [
+    "man_gesturing_no_medium-light_skin_tone"
+  ],
+  "\ud83d\ude45\ud83c\udffd": [
+    "person_gesturing_no_medium_skin_tone"
+  ],
+  "\ud83d\ude45\ud83c\udffd\u200d\u2640": [
+    "woman_gesturing_no_medium_skin_tone"
+  ],
+  "\ud83d\ude45\ud83c\udffd\u200d\u2640\ufe0f": [
+    "woman_gesturing_no_medium_skin_tone"
+  ],
+  "\ud83d\ude45\ud83c\udffd\u200d\u2642": [
+    "man_gesturing_no_medium_skin_tone"
+  ],
+  "\ud83d\ude45\ud83c\udffd\u200d\u2642\ufe0f": [
+    "man_gesturing_no_medium_skin_tone"
+  ],
+  "\ud83d\ude45\ud83c\udffe": [
+    "person_gesturing_no_medium-dark_skin_tone"
+  ],
+  "\ud83d\ude45\ud83c\udffe\u200d\u2640": [
+    "woman_gesturing_no_medium-dark_skin_tone"
+  ],
+  "\ud83d\ude45\ud83c\udffe\u200d\u2640\ufe0f": [
+    "woman_gesturing_no_medium-dark_skin_tone"
+  ],
+  "\ud83d\ude45\ud83c\udffe\u200d\u2642": [
+    "man_gesturing_no_medium-dark_skin_tone"
+  ],
+  "\ud83d\ude45\ud83c\udffe\u200d\u2642\ufe0f": [
+    "man_gesturing_no_medium-dark_skin_tone"
+  ],
+  "\ud83d\ude45\ud83c\udfff": [
+    "person_gesturing_no_dark_skin_tone"
+  ],
+  "\ud83d\ude45\ud83c\udfff\u200d\u2640": [
+    "woman_gesturing_no_dark_skin_tone"
+  ],
+  "\ud83d\ude45\ud83c\udfff\u200d\u2640\ufe0f": [
+    "woman_gesturing_no_dark_skin_tone"
+  ],
+  "\ud83d\ude45\ud83c\udfff\u200d\u2642": [
+    "man_gesturing_no_dark_skin_tone"
+  ],
+  "\ud83d\ude45\ud83c\udfff\u200d\u2642\ufe0f": [
+    "man_gesturing_no_dark_skin_tone"
+  ],
+  "\ud83d\ude46": [
+    "person_gesturing_ok",
+    "ok_person",
+    "person_gesturing_ok"
+  ],
+  "\ud83d\ude46\u200d\u2640": [
+    "woman_gesturing_ok",
+    "ok_woman",
+    "woman_gesturing_ok"
+  ],
+  "\ud83d\ude46\u200d\u2640\ufe0f": [
+    "woman_gesturing_ok",
+    "ok_woman",
+    "woman_gesturing_ok"
+  ],
+  "\ud83d\ude46\u200d\u2642": [
+    "man_gesturing_ok",
+    "ok_man",
+    "man_gesturing_ok"
+  ],
+  "\ud83d\ude46\u200d\u2642\ufe0f": [
+    "man_gesturing_ok",
+    "ok_man",
+    "man_gesturing_ok"
+  ],
+  "\ud83d\ude46\ud83c\udffb": [
+    "person_gesturing_ok_light_skin_tone"
+  ],
+  "\ud83d\ude46\ud83c\udffb\u200d\u2640": [
+    "woman_gesturing_ok_light_skin_tone"
+  ],
+  "\ud83d\ude46\ud83c\udffb\u200d\u2640\ufe0f": [
+    "woman_gesturing_ok_light_skin_tone"
+  ],
+  "\ud83d\ude46\ud83c\udffb\u200d\u2642": [
+    "man_gesturing_ok_light_skin_tone"
+  ],
+  "\ud83d\ude46\ud83c\udffb\u200d\u2642\ufe0f": [
+    "man_gesturing_ok_light_skin_tone"
+  ],
+  "\ud83d\ude46\ud83c\udffc": [
+    "person_gesturing_ok_medium-light_skin_tone"
+  ],
+  "\ud83d\ude46\ud83c\udffc\u200d\u2640": [
+    "woman_gesturing_ok_medium-light_skin_tone"
+  ],
+  "\ud83d\ude46\ud83c\udffc\u200d\u2640\ufe0f": [
+    "woman_gesturing_ok_medium-light_skin_tone"
+  ],
+  "\ud83d\ude46\ud83c\udffc\u200d\u2642": [
+    "man_gesturing_ok_medium-light_skin_tone"
+  ],
+  "\ud83d\ude46\ud83c\udffc\u200d\u2642\ufe0f": [
+    "man_gesturing_ok_medium-light_skin_tone"
+  ],
+  "\ud83d\ude46\ud83c\udffd": [
+    "person_gesturing_ok_medium_skin_tone"
+  ],
+  "\ud83d\ude46\ud83c\udffd\u200d\u2640": [
+    "woman_gesturing_ok_medium_skin_tone"
+  ],
+  "\ud83d\ude46\ud83c\udffd\u200d\u2640\ufe0f": [
+    "woman_gesturing_ok_medium_skin_tone"
+  ],
+  "\ud83d\ude46\ud83c\udffd\u200d\u2642": [
+    "man_gesturing_ok_medium_skin_tone"
+  ],
+  "\ud83d\ude46\ud83c\udffd\u200d\u2642\ufe0f": [
+    "man_gesturing_ok_medium_skin_tone"
+  ],
+  "\ud83d\ude46\ud83c\udffe": [
+    "person_gesturing_ok_medium-dark_skin_tone"
+  ],
+  "\ud83d\ude46\ud83c\udffe\u200d\u2640": [
+    "woman_gesturing_ok_medium-dark_skin_tone"
+  ],
+  "\ud83d\ude46\ud83c\udffe\u200d\u2640\ufe0f": [
+    "woman_gesturing_ok_medium-dark_skin_tone"
+  ],
+  "\ud83d\ude46\ud83c\udffe\u200d\u2642": [
+    "man_gesturing_ok_medium-dark_skin_tone"
+  ],
+  "\ud83d\ude46\ud83c\udffe\u200d\u2642\ufe0f": [
+    "man_gesturing_ok_medium-dark_skin_tone"
+  ],
+  "\ud83d\ude46\ud83c\udfff": [
+    "person_gesturing_ok_dark_skin_tone"
+  ],
+  "\ud83d\ude46\ud83c\udfff\u200d\u2640": [
+    "woman_gesturing_ok_dark_skin_tone"
+  ],
+  "\ud83d\ude46\ud83c\udfff\u200d\u2640\ufe0f": [
+    "woman_gesturing_ok_dark_skin_tone"
+  ],
+  "\ud83d\ude46\ud83c\udfff\u200d\u2642": [
+    "man_gesturing_ok_dark_skin_tone"
+  ],
+  "\ud83d\ude46\ud83c\udfff\u200d\u2642\ufe0f": [
+    "man_gesturing_ok_dark_skin_tone"
+  ],
+  "\ud83d\ude47": [
+    "person_bowing",
+    "bow"
+  ],
+  "\ud83d\ude47\u200d\u2640": [
+    "woman_bowing",
+    "bowing_woman"
+  ],
+  "\ud83d\ude47\u200d\u2640\ufe0f": [
+    "woman_bowing",
+    "bowing_woman"
+  ],
+  "\ud83d\ude47\u200d\u2642": [
+    "man_bowing",
+    "bowing_man"
+  ],
+  "\ud83d\ude47\u200d\u2642\ufe0f": [
+    "man_bowing",
+    "bowing_man"
+  ],
+  "\ud83d\ude47\ud83c\udffb": [
+    "person_bowing_light_skin_tone"
+  ],
+  "\ud83d\ude47\ud83c\udffb\u200d\u2640": [
+    "woman_bowing_light_skin_tone"
+  ],
+  "\ud83d\ude47\ud83c\udffb\u200d\u2640\ufe0f": [
+    "woman_bowing_light_skin_tone"
+  ],
+  "\ud83d\ude47\ud83c\udffb\u200d\u2642": [
+    "man_bowing_light_skin_tone"
+  ],
+  "\ud83d\ude47\ud83c\udffb\u200d\u2642\ufe0f": [
+    "man_bowing_light_skin_tone"
+  ],
+  "\ud83d\ude47\ud83c\udffc": [
+    "person_bowing_medium-light_skin_tone"
+  ],
+  "\ud83d\ude47\ud83c\udffc\u200d\u2640": [
+    "woman_bowing_medium-light_skin_tone"
+  ],
+  "\ud83d\ude47\ud83c\udffc\u200d\u2640\ufe0f": [
+    "woman_bowing_medium-light_skin_tone"
+  ],
+  "\ud83d\ude47\ud83c\udffc\u200d\u2642": [
+    "man_bowing_medium-light_skin_tone"
+  ],
+  "\ud83d\ude47\ud83c\udffc\u200d\u2642\ufe0f": [
+    "man_bowing_medium-light_skin_tone"
+  ],
+  "\ud83d\ude47\ud83c\udffd": [
+    "person_bowing_medium_skin_tone"
+  ],
+  "\ud83d\ude47\ud83c\udffd\u200d\u2640": [
+    "woman_bowing_medium_skin_tone"
+  ],
+  "\ud83d\ude47\ud83c\udffd\u200d\u2640\ufe0f": [
+    "woman_bowing_medium_skin_tone"
+  ],
+  "\ud83d\ude47\ud83c\udffd\u200d\u2642": [
+    "man_bowing_medium_skin_tone"
+  ],
+  "\ud83d\ude47\ud83c\udffd\u200d\u2642\ufe0f": [
+    "man_bowing_medium_skin_tone"
+  ],
+  "\ud83d\ude47\ud83c\udffe": [
+    "person_bowing_medium-dark_skin_tone"
+  ],
+  "\ud83d\ude47\ud83c\udffe\u200d\u2640": [
+    "woman_bowing_medium-dark_skin_tone"
+  ],
+  "\ud83d\ude47\ud83c\udffe\u200d\u2640\ufe0f": [
+    "woman_bowing_medium-dark_skin_tone"
+  ],
+  "\ud83d\ude47\ud83c\udffe\u200d\u2642": [
+    "man_bowing_medium-dark_skin_tone"
+  ],
+  "\ud83d\ude47\ud83c\udffe\u200d\u2642\ufe0f": [
+    "man_bowing_medium-dark_skin_tone"
+  ],
+  "\ud83d\ude47\ud83c\udfff": [
+    "person_bowing_dark_skin_tone"
+  ],
+  "\ud83d\ude47\ud83c\udfff\u200d\u2640": [
+    "woman_bowing_dark_skin_tone"
+  ],
+  "\ud83d\ude47\ud83c\udfff\u200d\u2640\ufe0f": [
+    "woman_bowing_dark_skin_tone"
+  ],
+  "\ud83d\ude47\ud83c\udfff\u200d\u2642": [
+    "man_bowing_dark_skin_tone"
+  ],
+  "\ud83d\ude47\ud83c\udfff\u200d\u2642\ufe0f": [
+    "man_bowing_dark_skin_tone"
+  ],
+  "\ud83d\ude48": [
+    "see-no-evil_monkey",
+    "see_no_evil",
+    "see_no_evil_monkey"
+  ],
+  "\ud83d\ude49": [
+    "hear-no-evil_monkey",
+    "hear_no_evil",
+    "hear_no_evil_monkey"
+  ],
+  "\ud83d\ude4a": [
+    "speak-no-evil_monkey",
+    "speak_no_evil",
+    "speak_no_evil_monkey"
+  ],
+  "\ud83d\ude4b": [
+    "person_raising_hand",
+    "raising_hand"
+  ],
+  "\ud83d\ude4b\u200d\u2640": [
+    "woman_raising_hand",
+    "raising_hand_woman"
+  ],
+  "\ud83d\ude4b\u200d\u2640\ufe0f": [
+    "woman_raising_hand",
+    "raising_hand_woman"
+  ],
+  "\ud83d\ude4b\u200d\u2642": [
+    "man_raising_hand",
+    "raising_hand_man"
+  ],
+  "\ud83d\ude4b\u200d\u2642\ufe0f": [
+    "man_raising_hand",
+    "raising_hand_man"
+  ],
+  "\ud83d\ude4b\ud83c\udffb": [
+    "person_raising_hand_light_skin_tone"
+  ],
+  "\ud83d\ude4b\ud83c\udffb\u200d\u2640": [
+    "woman_raising_hand_light_skin_tone"
+  ],
+  "\ud83d\ude4b\ud83c\udffb\u200d\u2640\ufe0f": [
+    "woman_raising_hand_light_skin_tone"
+  ],
+  "\ud83d\ude4b\ud83c\udffb\u200d\u2642": [
+    "man_raising_hand_light_skin_tone"
+  ],
+  "\ud83d\ude4b\ud83c\udffb\u200d\u2642\ufe0f": [
+    "man_raising_hand_light_skin_tone"
+  ],
+  "\ud83d\ude4b\ud83c\udffc": [
+    "person_raising_hand_medium-light_skin_tone"
+  ],
+  "\ud83d\ude4b\ud83c\udffc\u200d\u2640": [
+    "woman_raising_hand_medium-light_skin_tone"
+  ],
+  "\ud83d\ude4b\ud83c\udffc\u200d\u2640\ufe0f": [
+    "woman_raising_hand_medium-light_skin_tone"
+  ],
+  "\ud83d\ude4b\ud83c\udffc\u200d\u2642": [
+    "man_raising_hand_medium-light_skin_tone"
+  ],
+  "\ud83d\ude4b\ud83c\udffc\u200d\u2642\ufe0f": [
+    "man_raising_hand_medium-light_skin_tone"
+  ],
+  "\ud83d\ude4b\ud83c\udffd": [
+    "person_raising_hand_medium_skin_tone"
+  ],
+  "\ud83d\ude4b\ud83c\udffd\u200d\u2640": [
+    "woman_raising_hand_medium_skin_tone"
+  ],
+  "\ud83d\ude4b\ud83c\udffd\u200d\u2640\ufe0f": [
+    "woman_raising_hand_medium_skin_tone"
+  ],
+  "\ud83d\ude4b\ud83c\udffd\u200d\u2642": [
+    "man_raising_hand_medium_skin_tone"
+  ],
+  "\ud83d\ude4b\ud83c\udffd\u200d\u2642\ufe0f": [
+    "man_raising_hand_medium_skin_tone"
+  ],
+  "\ud83d\ude4b\ud83c\udffe": [
+    "person_raising_hand_medium-dark_skin_tone"
+  ],
+  "\ud83d\ude4b\ud83c\udffe\u200d\u2640": [
+    "woman_raising_hand_medium-dark_skin_tone"
+  ],
+  "\ud83d\ude4b\ud83c\udffe\u200d\u2640\ufe0f": [
+    "woman_raising_hand_medium-dark_skin_tone"
+  ],
+  "\ud83d\ude4b\ud83c\udffe\u200d\u2642": [
+    "man_raising_hand_medium-dark_skin_tone"
+  ],
+  "\ud83d\ude4b\ud83c\udffe\u200d\u2642\ufe0f": [
+    "man_raising_hand_medium-dark_skin_tone"
+  ],
+  "\ud83d\ude4b\ud83c\udfff": [
+    "person_raising_hand_dark_skin_tone"
+  ],
+  "\ud83d\ude4b\ud83c\udfff\u200d\u2640": [
+    "woman_raising_hand_dark_skin_tone"
+  ],
+  "\ud83d\ude4b\ud83c\udfff\u200d\u2640\ufe0f": [
+    "woman_raising_hand_dark_skin_tone"
+  ],
+  "\ud83d\ude4b\ud83c\udfff\u200d\u2642": [
+    "man_raising_hand_dark_skin_tone"
+  ],
+  "\ud83d\ude4b\ud83c\udfff\u200d\u2642\ufe0f": [
+    "man_raising_hand_dark_skin_tone"
+  ],
+  "\ud83d\ude4c": [
+    "raising_hands",
+    "raised_hands"
+  ],
+  "\ud83d\ude4c\ud83c\udffb": [
+    "raising_hands_light_skin_tone"
+  ],
+  "\ud83d\ude4c\ud83c\udffc": [
+    "raising_hands_medium-light_skin_tone"
+  ],
+  "\ud83d\ude4c\ud83c\udffd": [
+    "raising_hands_medium_skin_tone"
+  ],
+  "\ud83d\ude4c\ud83c\udffe": [
+    "raising_hands_medium-dark_skin_tone"
+  ],
+  "\ud83d\ude4c\ud83c\udfff": [
+    "raising_hands_dark_skin_tone"
+  ],
+  "\ud83d\ude4d": [
+    "person_frowning",
+    "frowning_person"
+  ],
+  "\ud83d\ude4d\u200d\u2640": [
+    "woman_frowning",
+    "frowning_woman"
+  ],
+  "\ud83d\ude4d\u200d\u2640\ufe0f": [
+    "woman_frowning",
+    "frowning_woman"
+  ],
+  "\ud83d\ude4d\u200d\u2642": [
+    "man_frowning",
+    "frowning_man"
+  ],
+  "\ud83d\ude4d\u200d\u2642\ufe0f": [
+    "man_frowning",
+    "frowning_man"
+  ],
+  "\ud83d\ude4d\ud83c\udffb": [
+    "person_frowning_light_skin_tone"
+  ],
+  "\ud83d\ude4d\ud83c\udffb\u200d\u2640": [
+    "woman_frowning_light_skin_tone"
+  ],
+  "\ud83d\ude4d\ud83c\udffb\u200d\u2640\ufe0f": [
+    "woman_frowning_light_skin_tone"
+  ],
+  "\ud83d\ude4d\ud83c\udffb\u200d\u2642": [
+    "man_frowning_light_skin_tone"
+  ],
+  "\ud83d\ude4d\ud83c\udffb\u200d\u2642\ufe0f": [
+    "man_frowning_light_skin_tone"
+  ],
+  "\ud83d\ude4d\ud83c\udffc": [
+    "person_frowning_medium-light_skin_tone"
+  ],
+  "\ud83d\ude4d\ud83c\udffc\u200d\u2640": [
+    "woman_frowning_medium-light_skin_tone"
+  ],
+  "\ud83d\ude4d\ud83c\udffc\u200d\u2640\ufe0f": [
+    "woman_frowning_medium-light_skin_tone"
+  ],
+  "\ud83d\ude4d\ud83c\udffc\u200d\u2642": [
+    "man_frowning_medium-light_skin_tone"
+  ],
+  "\ud83d\ude4d\ud83c\udffc\u200d\u2642\ufe0f": [
+    "man_frowning_medium-light_skin_tone"
+  ],
+  "\ud83d\ude4d\ud83c\udffd": [
+    "person_frowning_medium_skin_tone"
+  ],
+  "\ud83d\ude4d\ud83c\udffd\u200d\u2640": [
+    "woman_frowning_medium_skin_tone"
+  ],
+  "\ud83d\ude4d\ud83c\udffd\u200d\u2640\ufe0f": [
+    "woman_frowning_medium_skin_tone"
+  ],
+  "\ud83d\ude4d\ud83c\udffd\u200d\u2642": [
+    "man_frowning_medium_skin_tone"
+  ],
+  "\ud83d\ude4d\ud83c\udffd\u200d\u2642\ufe0f": [
+    "man_frowning_medium_skin_tone"
+  ],
+  "\ud83d\ude4d\ud83c\udffe": [
+    "person_frowning_medium-dark_skin_tone"
+  ],
+  "\ud83d\ude4d\ud83c\udffe\u200d\u2640": [
+    "woman_frowning_medium-dark_skin_tone"
+  ],
+  "\ud83d\ude4d\ud83c\udffe\u200d\u2640\ufe0f": [
+    "woman_frowning_medium-dark_skin_tone"
+  ],
+  "\ud83d\ude4d\ud83c\udffe\u200d\u2642": [
+    "man_frowning_medium-dark_skin_tone"
+  ],
+  "\ud83d\ude4d\ud83c\udffe\u200d\u2642\ufe0f": [
+    "man_frowning_medium-dark_skin_tone"
+  ],
+  "\ud83d\ude4d\ud83c\udfff": [
+    "person_frowning_dark_skin_tone"
+  ],
+  "\ud83d\ude4d\ud83c\udfff\u200d\u2640": [
+    "woman_frowning_dark_skin_tone"
+  ],
+  "\ud83d\ude4d\ud83c\udfff\u200d\u2640\ufe0f": [
+    "woman_frowning_dark_skin_tone"
+  ],
+  "\ud83d\ude4d\ud83c\udfff\u200d\u2642": [
+    "man_frowning_dark_skin_tone"
+  ],
+  "\ud83d\ude4d\ud83c\udfff\u200d\u2642\ufe0f": [
+    "man_frowning_dark_skin_tone"
+  ],
+  "\ud83d\ude4e": [
+    "person_pouting",
+    "pouting_face",
+    "person_with_pouting_face"
+  ],
+  "\ud83d\ude4e\u200d\u2640": [
+    "woman_pouting",
+    "pouting_woman"
+  ],
+  "\ud83d\ude4e\u200d\u2640\ufe0f": [
+    "woman_pouting",
+    "pouting_woman"
+  ],
+  "\ud83d\ude4e\u200d\u2642": [
+    "man_pouting",
+    "pouting_man"
+  ],
+  "\ud83d\ude4e\u200d\u2642\ufe0f": [
+    "man_pouting",
+    "pouting_man"
+  ],
+  "\ud83d\ude4e\ud83c\udffb": [
+    "person_pouting_light_skin_tone"
+  ],
+  "\ud83d\ude4e\ud83c\udffb\u200d\u2640": [
+    "woman_pouting_light_skin_tone"
+  ],
+  "\ud83d\ude4e\ud83c\udffb\u200d\u2640\ufe0f": [
+    "woman_pouting_light_skin_tone"
+  ],
+  "\ud83d\ude4e\ud83c\udffb\u200d\u2642": [
+    "man_pouting_light_skin_tone"
+  ],
+  "\ud83d\ude4e\ud83c\udffb\u200d\u2642\ufe0f": [
+    "man_pouting_light_skin_tone"
+  ],
+  "\ud83d\ude4e\ud83c\udffc": [
+    "person_pouting_medium-light_skin_tone"
+  ],
+  "\ud83d\ude4e\ud83c\udffc\u200d\u2640": [
+    "woman_pouting_medium-light_skin_tone"
+  ],
+  "\ud83d\ude4e\ud83c\udffc\u200d\u2640\ufe0f": [
+    "woman_pouting_medium-light_skin_tone"
+  ],
+  "\ud83d\ude4e\ud83c\udffc\u200d\u2642": [
+    "man_pouting_medium-light_skin_tone"
+  ],
+  "\ud83d\ude4e\ud83c\udffc\u200d\u2642\ufe0f": [
+    "man_pouting_medium-light_skin_tone"
+  ],
+  "\ud83d\ude4e\ud83c\udffd": [
+    "person_pouting_medium_skin_tone"
+  ],
+  "\ud83d\ude4e\ud83c\udffd\u200d\u2640": [
+    "woman_pouting_medium_skin_tone"
+  ],
+  "\ud83d\ude4e\ud83c\udffd\u200d\u2640\ufe0f": [
+    "woman_pouting_medium_skin_tone"
+  ],
+  "\ud83d\ude4e\ud83c\udffd\u200d\u2642": [
+    "man_pouting_medium_skin_tone"
+  ],
+  "\ud83d\ude4e\ud83c\udffd\u200d\u2642\ufe0f": [
+    "man_pouting_medium_skin_tone"
+  ],
+  "\ud83d\ude4e\ud83c\udffe": [
+    "person_pouting_medium-dark_skin_tone"
+  ],
+  "\ud83d\ude4e\ud83c\udffe\u200d\u2640": [
+    "woman_pouting_medium-dark_skin_tone"
+  ],
+  "\ud83d\ude4e\ud83c\udffe\u200d\u2640\ufe0f": [
+    "woman_pouting_medium-dark_skin_tone"
+  ],
+  "\ud83d\ude4e\ud83c\udffe\u200d\u2642": [
+    "man_pouting_medium-dark_skin_tone"
+  ],
+  "\ud83d\ude4e\ud83c\udffe\u200d\u2642\ufe0f": [
+    "man_pouting_medium-dark_skin_tone"
+  ],
+  "\ud83d\ude4e\ud83c\udfff": [
+    "person_pouting_dark_skin_tone"
+  ],
+  "\ud83d\ude4e\ud83c\udfff\u200d\u2640": [
+    "woman_pouting_dark_skin_tone"
+  ],
+  "\ud83d\ude4e\ud83c\udfff\u200d\u2640\ufe0f": [
+    "woman_pouting_dark_skin_tone"
+  ],
+  "\ud83d\ude4e\ud83c\udfff\u200d\u2642": [
+    "man_pouting_dark_skin_tone"
+  ],
+  "\ud83d\ude4e\ud83c\udfff\u200d\u2642\ufe0f": [
+    "man_pouting_dark_skin_tone"
+  ],
+  "\ud83d\ude4f": [
+    "folded_hands",
+    "pray"
+  ],
+  "\ud83d\ude4f\ud83c\udffb": [
+    "folded_hands_light_skin_tone"
+  ],
+  "\ud83d\ude4f\ud83c\udffc": [
+    "folded_hands_medium-light_skin_tone"
+  ],
+  "\ud83d\ude4f\ud83c\udffd": [
+    "folded_hands_medium_skin_tone"
+  ],
+  "\ud83d\ude4f\ud83c\udffe": [
+    "folded_hands_medium-dark_skin_tone"
+  ],
+  "\ud83d\ude4f\ud83c\udfff": [
+    "folded_hands_dark_skin_tone"
+  ],
+  "\ud83d\ude80": [
+    "rocket"
+  ],
+  "\ud83d\ude81": [
+    "helicopter"
+  ],
+  "\ud83d\ude82": [
+    "locomotive",
+    "steam_locomotive"
+  ],
+  "\ud83d\ude83": [
+    "railway_car"
+  ],
+  "\ud83d\ude84": [
+    "high-speed_train",
+    "bullettrain_side",
+    "high_speed_train"
+  ],
+  "\ud83d\ude85": [
+    "bullet_train",
+    "bullettrain_front"
+  ],
+  "\ud83d\ude86": [
+    "train",
+    "train2"
+  ],
+  "\ud83d\ude87": [
+    "metro"
+  ],
+  "\ud83d\ude88": [
+    "light_rail"
+  ],
+  "\ud83d\ude89": [
+    "station"
+  ],
+  "\ud83d\ude8a": [
+    "tram"
+  ],
+  "\ud83d\ude8b": [
+    "tram_car",
+    "train"
+  ],
+  "\ud83d\ude8c": [
+    "bus"
+  ],
+  "\ud83d\ude8d": [
+    "oncoming_bus"
+  ],
+  "\ud83d\ude8e": [
+    "trolleybus"
+  ],
+  "\ud83d\ude8f": [
+    "bus_stop",
+    "busstop"
+  ],
+  "\ud83d\ude90": [
+    "minibus"
+  ],
+  "\ud83d\ude91": [
+    "ambulance"
+  ],
+  "\ud83d\ude92": [
+    "fire_engine"
+  ],
+  "\ud83d\ude93": [
+    "police_car"
+  ],
+  "\ud83d\ude94": [
+    "oncoming_police_car"
+  ],
+  "\ud83d\ude95": [
+    "taxi"
+  ],
+  "\ud83d\ude96": [
+    "oncoming_taxi"
+  ],
+  "\ud83d\ude97": [
+    "automobile",
+    "car",
+    "red_car"
+  ],
+  "\ud83d\ude98": [
+    "oncoming_automobile"
+  ],
+  "\ud83d\ude99": [
+    "sport_utility_vehicle",
+    "blue_car"
+  ],
+  "\ud83d\ude9a": [
+    "delivery_truck",
+    "truck"
+  ],
+  "\ud83d\ude9b": [
+    "articulated_lorry"
+  ],
+  "\ud83d\ude9c": [
+    "tractor"
+  ],
+  "\ud83d\ude9d": [
+    "monorail"
+  ],
+  "\ud83d\ude9e": [
+    "mountain_railway"
+  ],
+  "\ud83d\ude9f": [
+    "suspension_railway"
+  ],
+  "\ud83d\udea0": [
+    "mountain_cableway"
+  ],
+  "\ud83d\udea1": [
+    "aerial_tramway"
+  ],
+  "\ud83d\udea2": [
+    "ship"
+  ],
+  "\ud83d\udea3": [
+    "person_rowing_boat",
+    "rowboat"
+  ],
+  "\ud83d\udea3\u200d\u2640": [
+    "woman_rowing_boat",
+    "rowing_woman"
+  ],
+  "\ud83d\udea3\u200d\u2640\ufe0f": [
+    "woman_rowing_boat",
+    "rowing_woman"
+  ],
+  "\ud83d\udea3\u200d\u2642": [
+    "man_rowing_boat",
+    "rowing_man"
+  ],
+  "\ud83d\udea3\u200d\u2642\ufe0f": [
+    "man_rowing_boat",
+    "rowing_man"
+  ],
+  "\ud83d\udea3\ud83c\udffb": [
+    "person_rowing_boat_light_skin_tone"
+  ],
+  "\ud83d\udea3\ud83c\udffb\u200d\u2640": [
+    "woman_rowing_boat_light_skin_tone"
+  ],
+  "\ud83d\udea3\ud83c\udffb\u200d\u2640\ufe0f": [
+    "woman_rowing_boat_light_skin_tone"
+  ],
+  "\ud83d\udea3\ud83c\udffb\u200d\u2642": [
+    "man_rowing_boat_light_skin_tone"
+  ],
+  "\ud83d\udea3\ud83c\udffb\u200d\u2642\ufe0f": [
+    "man_rowing_boat_light_skin_tone"
+  ],
+  "\ud83d\udea3\ud83c\udffc": [
+    "person_rowing_boat_medium-light_skin_tone"
+  ],
+  "\ud83d\udea3\ud83c\udffc\u200d\u2640": [
+    "woman_rowing_boat_medium-light_skin_tone"
+  ],
+  "\ud83d\udea3\ud83c\udffc\u200d\u2640\ufe0f": [
+    "woman_rowing_boat_medium-light_skin_tone"
+  ],
+  "\ud83d\udea3\ud83c\udffc\u200d\u2642": [
+    "man_rowing_boat_medium-light_skin_tone"
+  ],
+  "\ud83d\udea3\ud83c\udffc\u200d\u2642\ufe0f": [
+    "man_rowing_boat_medium-light_skin_tone"
+  ],
+  "\ud83d\udea3\ud83c\udffd": [
+    "person_rowing_boat_medium_skin_tone"
+  ],
+  "\ud83d\udea3\ud83c\udffd\u200d\u2640": [
+    "woman_rowing_boat_medium_skin_tone"
+  ],
+  "\ud83d\udea3\ud83c\udffd\u200d\u2640\ufe0f": [
+    "woman_rowing_boat_medium_skin_tone"
+  ],
+  "\ud83d\udea3\ud83c\udffd\u200d\u2642": [
+    "man_rowing_boat_medium_skin_tone"
+  ],
+  "\ud83d\udea3\ud83c\udffd\u200d\u2642\ufe0f": [
+    "man_rowing_boat_medium_skin_tone"
+  ],
+  "\ud83d\udea3\ud83c\udffe": [
+    "person_rowing_boat_medium-dark_skin_tone"
+  ],
+  "\ud83d\udea3\ud83c\udffe\u200d\u2640": [
+    "woman_rowing_boat_medium-dark_skin_tone"
+  ],
+  "\ud83d\udea3\ud83c\udffe\u200d\u2640\ufe0f": [
+    "woman_rowing_boat_medium-dark_skin_tone"
+  ],
+  "\ud83d\udea3\ud83c\udffe\u200d\u2642": [
+    "man_rowing_boat_medium-dark_skin_tone"
+  ],
+  "\ud83d\udea3\ud83c\udffe\u200d\u2642\ufe0f": [
+    "man_rowing_boat_medium-dark_skin_tone"
+  ],
+  "\ud83d\udea3\ud83c\udfff": [
+    "person_rowing_boat_dark_skin_tone"
+  ],
+  "\ud83d\udea3\ud83c\udfff\u200d\u2640": [
+    "woman_rowing_boat_dark_skin_tone"
+  ],
+  "\ud83d\udea3\ud83c\udfff\u200d\u2640\ufe0f": [
+    "woman_rowing_boat_dark_skin_tone"
+  ],
+  "\ud83d\udea3\ud83c\udfff\u200d\u2642": [
+    "man_rowing_boat_dark_skin_tone"
+  ],
+  "\ud83d\udea3\ud83c\udfff\u200d\u2642\ufe0f": [
+    "man_rowing_boat_dark_skin_tone"
+  ],
+  "\ud83d\udea4": [
+    "speedboat"
+  ],
+  "\ud83d\udea5": [
+    "horizontal_traffic_light",
+    "traffic_light"
+  ],
+  "\ud83d\udea6": [
+    "vertical_traffic_light"
+  ],
+  "\ud83d\udea7": [
+    "construction"
+  ],
+  "\ud83d\udea8": [
+    "police_car_light",
+    "rotating_light"
+  ],
+  "\ud83d\udea9": [
+    "triangular_flag",
+    "triangular_flag_on_post"
+  ],
+  "\ud83d\udeaa": [
+    "door"
+  ],
+  "\ud83d\udeab": [
+    "prohibited",
+    "no_entry_sign"
+  ],
+  "\ud83d\udeac": [
+    "cigarette",
+    "smoking"
+  ],
+  "\ud83d\udead": [
+    "no_smoking"
+  ],
+  "\ud83d\udeae": [
+    "litter_in_bin_sign",
+    "put_litter_in_its_place"
+  ],
+  "\ud83d\udeaf": [
+    "no_littering",
+    "do_not_litter"
+  ],
+  "\ud83d\udeb0": [
+    "potable_water"
+  ],
+  "\ud83d\udeb1": [
+    "non-potable_water",
+    "non_potable_water"
+  ],
+  "\ud83d\udeb2": [
+    "bicycle",
+    "bike"
+  ],
+  "\ud83d\udeb3": [
+    "no_bicycles"
+  ],
+  "\ud83d\udeb4": [
+    "person_biking",
+    "bicyclist"
+  ],
+  "\ud83d\udeb4\u200d\u2640": [
+    "woman_biking",
+    "biking_woman"
+  ],
+  "\ud83d\udeb4\u200d\u2640\ufe0f": [
+    "woman_biking",
+    "biking_woman"
+  ],
+  "\ud83d\udeb4\u200d\u2642": [
+    "man_biking",
+    "biking_man"
+  ],
+  "\ud83d\udeb4\u200d\u2642\ufe0f": [
+    "man_biking",
+    "biking_man"
+  ],
+  "\ud83d\udeb4\ud83c\udffb": [
+    "person_biking_light_skin_tone"
+  ],
+  "\ud83d\udeb4\ud83c\udffb\u200d\u2640": [
+    "woman_biking_light_skin_tone"
+  ],
+  "\ud83d\udeb4\ud83c\udffb\u200d\u2640\ufe0f": [
+    "woman_biking_light_skin_tone"
+  ],
+  "\ud83d\udeb4\ud83c\udffb\u200d\u2642": [
+    "man_biking_light_skin_tone"
+  ],
+  "\ud83d\udeb4\ud83c\udffb\u200d\u2642\ufe0f": [
+    "man_biking_light_skin_tone"
+  ],
+  "\ud83d\udeb4\ud83c\udffc": [
+    "person_biking_medium-light_skin_tone"
+  ],
+  "\ud83d\udeb4\ud83c\udffc\u200d\u2640": [
+    "woman_biking_medium-light_skin_tone"
+  ],
+  "\ud83d\udeb4\ud83c\udffc\u200d\u2640\ufe0f": [
+    "woman_biking_medium-light_skin_tone"
+  ],
+  "\ud83d\udeb4\ud83c\udffc\u200d\u2642": [
+    "man_biking_medium-light_skin_tone"
+  ],
+  "\ud83d\udeb4\ud83c\udffc\u200d\u2642\ufe0f": [
+    "man_biking_medium-light_skin_tone"
+  ],
+  "\ud83d\udeb4\ud83c\udffd": [
+    "person_biking_medium_skin_tone"
+  ],
+  "\ud83d\udeb4\ud83c\udffd\u200d\u2640": [
+    "woman_biking_medium_skin_tone"
+  ],
+  "\ud83d\udeb4\ud83c\udffd\u200d\u2640\ufe0f": [
+    "woman_biking_medium_skin_tone"
+  ],
+  "\ud83d\udeb4\ud83c\udffd\u200d\u2642": [
+    "man_biking_medium_skin_tone"
+  ],
+  "\ud83d\udeb4\ud83c\udffd\u200d\u2642\ufe0f": [
+    "man_biking_medium_skin_tone"
+  ],
+  "\ud83d\udeb4\ud83c\udffe": [
+    "person_biking_medium-dark_skin_tone"
+  ],
+  "\ud83d\udeb4\ud83c\udffe\u200d\u2640": [
+    "woman_biking_medium-dark_skin_tone"
+  ],
+  "\ud83d\udeb4\ud83c\udffe\u200d\u2640\ufe0f": [
+    "woman_biking_medium-dark_skin_tone"
+  ],
+  "\ud83d\udeb4\ud83c\udffe\u200d\u2642": [
+    "man_biking_medium-dark_skin_tone"
+  ],
+  "\ud83d\udeb4\ud83c\udffe\u200d\u2642\ufe0f": [
+    "man_biking_medium-dark_skin_tone"
+  ],
+  "\ud83d\udeb4\ud83c\udfff": [
+    "person_biking_dark_skin_tone"
+  ],
+  "\ud83d\udeb4\ud83c\udfff\u200d\u2640": [
+    "woman_biking_dark_skin_tone"
+  ],
+  "\ud83d\udeb4\ud83c\udfff\u200d\u2640\ufe0f": [
+    "woman_biking_dark_skin_tone"
+  ],
+  "\ud83d\udeb4\ud83c\udfff\u200d\u2642": [
+    "man_biking_dark_skin_tone"
+  ],
+  "\ud83d\udeb4\ud83c\udfff\u200d\u2642\ufe0f": [
+    "man_biking_dark_skin_tone"
+  ],
+  "\ud83d\udeb5": [
+    "person_mountain_biking",
+    "mountain_bicyclist"
+  ],
+  "\ud83d\udeb5\u200d\u2640": [
+    "woman_mountain_biking",
+    "mountain_biking_woman"
+  ],
+  "\ud83d\udeb5\u200d\u2640\ufe0f": [
+    "woman_mountain_biking",
+    "mountain_biking_woman"
+  ],
+  "\ud83d\udeb5\u200d\u2642": [
+    "man_mountain_biking",
+    "mountain_biking_man"
+  ],
+  "\ud83d\udeb5\u200d\u2642\ufe0f": [
+    "man_mountain_biking",
+    "mountain_biking_man"
+  ],
+  "\ud83d\udeb5\ud83c\udffb": [
+    "person_mountain_biking_light_skin_tone"
+  ],
+  "\ud83d\udeb5\ud83c\udffb\u200d\u2640": [
+    "woman_mountain_biking_light_skin_tone"
+  ],
+  "\ud83d\udeb5\ud83c\udffb\u200d\u2640\ufe0f": [
+    "woman_mountain_biking_light_skin_tone"
+  ],
+  "\ud83d\udeb5\ud83c\udffb\u200d\u2642": [
+    "man_mountain_biking_light_skin_tone"
+  ],
+  "\ud83d\udeb5\ud83c\udffb\u200d\u2642\ufe0f": [
+    "man_mountain_biking_light_skin_tone"
+  ],
+  "\ud83d\udeb5\ud83c\udffc": [
+    "person_mountain_biking_medium-light_skin_tone"
+  ],
+  "\ud83d\udeb5\ud83c\udffc\u200d\u2640": [
+    "woman_mountain_biking_medium-light_skin_tone"
+  ],
+  "\ud83d\udeb5\ud83c\udffc\u200d\u2640\ufe0f": [
+    "woman_mountain_biking_medium-light_skin_tone"
+  ],
+  "\ud83d\udeb5\ud83c\udffc\u200d\u2642": [
+    "man_mountain_biking_medium-light_skin_tone"
+  ],
+  "\ud83d\udeb5\ud83c\udffc\u200d\u2642\ufe0f": [
+    "man_mountain_biking_medium-light_skin_tone"
+  ],
+  "\ud83d\udeb5\ud83c\udffd": [
+    "person_mountain_biking_medium_skin_tone"
+  ],
+  "\ud83d\udeb5\ud83c\udffd\u200d\u2640": [
+    "woman_mountain_biking_medium_skin_tone"
+  ],
+  "\ud83d\udeb5\ud83c\udffd\u200d\u2640\ufe0f": [
+    "woman_mountain_biking_medium_skin_tone"
+  ],
+  "\ud83d\udeb5\ud83c\udffd\u200d\u2642": [
+    "man_mountain_biking_medium_skin_tone"
+  ],
+  "\ud83d\udeb5\ud83c\udffd\u200d\u2642\ufe0f": [
+    "man_mountain_biking_medium_skin_tone"
+  ],
+  "\ud83d\udeb5\ud83c\udffe": [
+    "person_mountain_biking_medium-dark_skin_tone"
+  ],
+  "\ud83d\udeb5\ud83c\udffe\u200d\u2640": [
+    "woman_mountain_biking_medium-dark_skin_tone"
+  ],
+  "\ud83d\udeb5\ud83c\udffe\u200d\u2640\ufe0f": [
+    "woman_mountain_biking_medium-dark_skin_tone"
+  ],
+  "\ud83d\udeb5\ud83c\udffe\u200d\u2642": [
+    "man_mountain_biking_medium-dark_skin_tone"
+  ],
+  "\ud83d\udeb5\ud83c\udffe\u200d\u2642\ufe0f": [
+    "man_mountain_biking_medium-dark_skin_tone"
+  ],
+  "\ud83d\udeb5\ud83c\udfff": [
+    "person_mountain_biking_dark_skin_tone"
+  ],
+  "\ud83d\udeb5\ud83c\udfff\u200d\u2640": [
+    "woman_mountain_biking_dark_skin_tone"
+  ],
+  "\ud83d\udeb5\ud83c\udfff\u200d\u2640\ufe0f": [
+    "woman_mountain_biking_dark_skin_tone"
+  ],
+  "\ud83d\udeb5\ud83c\udfff\u200d\u2642": [
+    "man_mountain_biking_dark_skin_tone"
+  ],
+  "\ud83d\udeb5\ud83c\udfff\u200d\u2642\ufe0f": [
+    "man_mountain_biking_dark_skin_tone"
+  ],
+  "\ud83d\udeb6": [
+    "person_walking",
+    "walking"
+  ],
+  "\ud83d\udeb6\u200d\u2640": [
+    "woman_walking",
+    "walking_woman"
+  ],
+  "\ud83d\udeb6\u200d\u2640\u200d\u27a1": [
+    "woman_walking_facing_right"
+  ],
+  "\ud83d\udeb6\u200d\u2640\u200d\u27a1\ufe0f": [
+    "woman_walking_facing_right"
+  ],
+  "\ud83d\udeb6\u200d\u2640\ufe0f": [
+    "woman_walking",
+    "walking_woman"
+  ],
+  "\ud83d\udeb6\u200d\u2640\ufe0f\u200d\u27a1": [
+    "woman_walking_facing_right"
+  ],
+  "\ud83d\udeb6\u200d\u2640\ufe0f\u200d\u27a1\ufe0f": [
+    "woman_walking_facing_right"
+  ],
+  "\ud83d\udeb6\u200d\u2642": [
+    "man_walking",
+    "walking_man"
+  ],
+  "\ud83d\udeb6\u200d\u2642\u200d\u27a1": [
+    "man_walking_facing_right"
+  ],
+  "\ud83d\udeb6\u200d\u2642\u200d\u27a1\ufe0f": [
+    "man_walking_facing_right"
+  ],
+  "\ud83d\udeb6\u200d\u2642\ufe0f": [
+    "man_walking",
+    "walking_man"
+  ],
+  "\ud83d\udeb6\u200d\u2642\ufe0f\u200d\u27a1": [
+    "man_walking_facing_right"
+  ],
+  "\ud83d\udeb6\u200d\u2642\ufe0f\u200d\u27a1\ufe0f": [
+    "man_walking_facing_right"
+  ],
+  "\ud83d\udeb6\u200d\u27a1": [
+    "person_walking_facing_right"
+  ],
+  "\ud83d\udeb6\u200d\u27a1\ufe0f": [
+    "person_walking_facing_right"
+  ],
+  "\ud83d\udeb6\ud83c\udffb": [
+    "person_walking_light_skin_tone"
+  ],
+  "\ud83d\udeb6\ud83c\udffb\u200d\u2640": [
+    "woman_walking_light_skin_tone"
+  ],
+  "\ud83d\udeb6\ud83c\udffb\u200d\u2640\u200d\u27a1": [
+    "woman_walking_facing_right_light_skin_tone"
+  ],
+  "\ud83d\udeb6\ud83c\udffb\u200d\u2640\u200d\u27a1\ufe0f": [
+    "woman_walking_facing_right_light_skin_tone"
+  ],
+  "\ud83d\udeb6\ud83c\udffb\u200d\u2640\ufe0f": [
+    "woman_walking_light_skin_tone"
+  ],
+  "\ud83d\udeb6\ud83c\udffb\u200d\u2640\ufe0f\u200d\u27a1": [
+    "woman_walking_facing_right_light_skin_tone"
+  ],
+  "\ud83d\udeb6\ud83c\udffb\u200d\u2640\ufe0f\u200d\u27a1\ufe0f": [
+    "woman_walking_facing_right_light_skin_tone"
+  ],
+  "\ud83d\udeb6\ud83c\udffb\u200d\u2642": [
+    "man_walking_light_skin_tone"
+  ],
+  "\ud83d\udeb6\ud83c\udffb\u200d\u2642\u200d\u27a1": [
+    "man_walking_facing_right_light_skin_tone"
+  ],
+  "\ud83d\udeb6\ud83c\udffb\u200d\u2642\u200d\u27a1\ufe0f": [
+    "man_walking_facing_right_light_skin_tone"
+  ],
+  "\ud83d\udeb6\ud83c\udffb\u200d\u2642\ufe0f": [
+    "man_walking_light_skin_tone"
+  ],
+  "\ud83d\udeb6\ud83c\udffb\u200d\u2642\ufe0f\u200d\u27a1": [
+    "man_walking_facing_right_light_skin_tone"
+  ],
+  "\ud83d\udeb6\ud83c\udffb\u200d\u2642\ufe0f\u200d\u27a1\ufe0f": [
+    "man_walking_facing_right_light_skin_tone"
+  ],
+  "\ud83d\udeb6\ud83c\udffb\u200d\u27a1": [
+    "person_walking_facing_right_light_skin_tone"
+  ],
+  "\ud83d\udeb6\ud83c\udffb\u200d\u27a1\ufe0f": [
+    "person_walking_facing_right_light_skin_tone"
+  ],
+  "\ud83d\udeb6\ud83c\udffc": [
+    "person_walking_medium-light_skin_tone"
+  ],
+  "\ud83d\udeb6\ud83c\udffc\u200d\u2640": [
+    "woman_walking_medium-light_skin_tone"
+  ],
+  "\ud83d\udeb6\ud83c\udffc\u200d\u2640\u200d\u27a1": [
+    "woman_walking_facing_right_medium-light_skin_tone"
+  ],
+  "\ud83d\udeb6\ud83c\udffc\u200d\u2640\u200d\u27a1\ufe0f": [
+    "woman_walking_facing_right_medium-light_skin_tone"
+  ],
+  "\ud83d\udeb6\ud83c\udffc\u200d\u2640\ufe0f": [
+    "woman_walking_medium-light_skin_tone"
+  ],
+  "\ud83d\udeb6\ud83c\udffc\u200d\u2640\ufe0f\u200d\u27a1": [
+    "woman_walking_facing_right_medium-light_skin_tone"
+  ],
+  "\ud83d\udeb6\ud83c\udffc\u200d\u2640\ufe0f\u200d\u27a1\ufe0f": [
+    "woman_walking_facing_right_medium-light_skin_tone"
+  ],
+  "\ud83d\udeb6\ud83c\udffc\u200d\u2642": [
+    "man_walking_medium-light_skin_tone"
+  ],
+  "\ud83d\udeb6\ud83c\udffc\u200d\u2642\u200d\u27a1": [
+    "man_walking_facing_right_medium-light_skin_tone"
+  ],
+  "\ud83d\udeb6\ud83c\udffc\u200d\u2642\u200d\u27a1\ufe0f": [
+    "man_walking_facing_right_medium-light_skin_tone"
+  ],
+  "\ud83d\udeb6\ud83c\udffc\u200d\u2642\ufe0f": [
+    "man_walking_medium-light_skin_tone"
+  ],
+  "\ud83d\udeb6\ud83c\udffc\u200d\u2642\ufe0f\u200d\u27a1": [
+    "man_walking_facing_right_medium-light_skin_tone"
+  ],
+  "\ud83d\udeb6\ud83c\udffc\u200d\u2642\ufe0f\u200d\u27a1\ufe0f": [
+    "man_walking_facing_right_medium-light_skin_tone"
+  ],
+  "\ud83d\udeb6\ud83c\udffc\u200d\u27a1": [
+    "person_walking_facing_right_medium-light_skin_tone"
+  ],
+  "\ud83d\udeb6\ud83c\udffc\u200d\u27a1\ufe0f": [
+    "person_walking_facing_right_medium-light_skin_tone"
+  ],
+  "\ud83d\udeb6\ud83c\udffd": [
+    "person_walking_medium_skin_tone"
+  ],
+  "\ud83d\udeb6\ud83c\udffd\u200d\u2640": [
+    "woman_walking_medium_skin_tone"
+  ],
+  "\ud83d\udeb6\ud83c\udffd\u200d\u2640\u200d\u27a1": [
+    "woman_walking_facing_right_medium_skin_tone"
+  ],
+  "\ud83d\udeb6\ud83c\udffd\u200d\u2640\u200d\u27a1\ufe0f": [
+    "woman_walking_facing_right_medium_skin_tone"
+  ],
+  "\ud83d\udeb6\ud83c\udffd\u200d\u2640\ufe0f": [
+    "woman_walking_medium_skin_tone"
+  ],
+  "\ud83d\udeb6\ud83c\udffd\u200d\u2640\ufe0f\u200d\u27a1": [
+    "woman_walking_facing_right_medium_skin_tone"
+  ],
+  "\ud83d\udeb6\ud83c\udffd\u200d\u2640\ufe0f\u200d\u27a1\ufe0f": [
+    "woman_walking_facing_right_medium_skin_tone"
+  ],
+  "\ud83d\udeb6\ud83c\udffd\u200d\u2642": [
+    "man_walking_medium_skin_tone"
+  ],
+  "\ud83d\udeb6\ud83c\udffd\u200d\u2642\u200d\u27a1": [
+    "man_walking_facing_right_medium_skin_tone"
+  ],
+  "\ud83d\udeb6\ud83c\udffd\u200d\u2642\u200d\u27a1\ufe0f": [
+    "man_walking_facing_right_medium_skin_tone"
+  ],
+  "\ud83d\udeb6\ud83c\udffd\u200d\u2642\ufe0f": [
+    "man_walking_medium_skin_tone"
+  ],
+  "\ud83d\udeb6\ud83c\udffd\u200d\u2642\ufe0f\u200d\u27a1": [
+    "man_walking_facing_right_medium_skin_tone"
+  ],
+  "\ud83d\udeb6\ud83c\udffd\u200d\u2642\ufe0f\u200d\u27a1\ufe0f": [
+    "man_walking_facing_right_medium_skin_tone"
+  ],
+  "\ud83d\udeb6\ud83c\udffd\u200d\u27a1": [
+    "person_walking_facing_right_medium_skin_tone"
+  ],
+  "\ud83d\udeb6\ud83c\udffd\u200d\u27a1\ufe0f": [
+    "person_walking_facing_right_medium_skin_tone"
+  ],
+  "\ud83d\udeb6\ud83c\udffe": [
+    "person_walking_medium-dark_skin_tone"
+  ],
+  "\ud83d\udeb6\ud83c\udffe\u200d\u2640": [
+    "woman_walking_medium-dark_skin_tone"
+  ],
+  "\ud83d\udeb6\ud83c\udffe\u200d\u2640\u200d\u27a1": [
+    "woman_walking_facing_right_medium-dark_skin_tone"
+  ],
+  "\ud83d\udeb6\ud83c\udffe\u200d\u2640\u200d\u27a1\ufe0f": [
+    "woman_walking_facing_right_medium-dark_skin_tone"
+  ],
+  "\ud83d\udeb6\ud83c\udffe\u200d\u2640\ufe0f": [
+    "woman_walking_medium-dark_skin_tone"
+  ],
+  "\ud83d\udeb6\ud83c\udffe\u200d\u2640\ufe0f\u200d\u27a1": [
+    "woman_walking_facing_right_medium-dark_skin_tone"
+  ],
+  "\ud83d\udeb6\ud83c\udffe\u200d\u2640\ufe0f\u200d\u27a1\ufe0f": [
+    "woman_walking_facing_right_medium-dark_skin_tone"
+  ],
+  "\ud83d\udeb6\ud83c\udffe\u200d\u2642": [
+    "man_walking_medium-dark_skin_tone"
+  ],
+  "\ud83d\udeb6\ud83c\udffe\u200d\u2642\u200d\u27a1": [
+    "man_walking_facing_right_medium-dark_skin_tone"
+  ],
+  "\ud83d\udeb6\ud83c\udffe\u200d\u2642\u200d\u27a1\ufe0f": [
+    "man_walking_facing_right_medium-dark_skin_tone"
+  ],
+  "\ud83d\udeb6\ud83c\udffe\u200d\u2642\ufe0f": [
+    "man_walking_medium-dark_skin_tone"
+  ],
+  "\ud83d\udeb6\ud83c\udffe\u200d\u2642\ufe0f\u200d\u27a1": [
+    "man_walking_facing_right_medium-dark_skin_tone"
+  ],
+  "\ud83d\udeb6\ud83c\udffe\u200d\u2642\ufe0f\u200d\u27a1\ufe0f": [
+    "man_walking_facing_right_medium-dark_skin_tone"
+  ],
+  "\ud83d\udeb6\ud83c\udffe\u200d\u27a1": [
+    "person_walking_facing_right_medium-dark_skin_tone"
+  ],
+  "\ud83d\udeb6\ud83c\udffe\u200d\u27a1\ufe0f": [
+    "person_walking_facing_right_medium-dark_skin_tone"
+  ],
+  "\ud83d\udeb6\ud83c\udfff": [
+    "person_walking_dark_skin_tone"
+  ],
+  "\ud83d\udeb6\ud83c\udfff\u200d\u2640": [
+    "woman_walking_dark_skin_tone"
+  ],
+  "\ud83d\udeb6\ud83c\udfff\u200d\u2640\u200d\u27a1": [
+    "woman_walking_facing_right_dark_skin_tone"
+  ],
+  "\ud83d\udeb6\ud83c\udfff\u200d\u2640\u200d\u27a1\ufe0f": [
+    "woman_walking_facing_right_dark_skin_tone"
+  ],
+  "\ud83d\udeb6\ud83c\udfff\u200d\u2640\ufe0f": [
+    "woman_walking_dark_skin_tone"
+  ],
+  "\ud83d\udeb6\ud83c\udfff\u200d\u2640\ufe0f\u200d\u27a1": [
+    "woman_walking_facing_right_dark_skin_tone"
+  ],
+  "\ud83d\udeb6\ud83c\udfff\u200d\u2640\ufe0f\u200d\u27a1\ufe0f": [
+    "woman_walking_facing_right_dark_skin_tone"
+  ],
+  "\ud83d\udeb6\ud83c\udfff\u200d\u2642": [
+    "man_walking_dark_skin_tone"
+  ],
+  "\ud83d\udeb6\ud83c\udfff\u200d\u2642\u200d\u27a1": [
+    "man_walking_facing_right_dark_skin_tone"
+  ],
+  "\ud83d\udeb6\ud83c\udfff\u200d\u2642\u200d\u27a1\ufe0f": [
+    "man_walking_facing_right_dark_skin_tone"
+  ],
+  "\ud83d\udeb6\ud83c\udfff\u200d\u2642\ufe0f": [
+    "man_walking_dark_skin_tone"
+  ],
+  "\ud83d\udeb6\ud83c\udfff\u200d\u2642\ufe0f\u200d\u27a1": [
+    "man_walking_facing_right_dark_skin_tone"
+  ],
+  "\ud83d\udeb6\ud83c\udfff\u200d\u2642\ufe0f\u200d\u27a1\ufe0f": [
+    "man_walking_facing_right_dark_skin_tone"
+  ],
+  "\ud83d\udeb6\ud83c\udfff\u200d\u27a1": [
+    "person_walking_facing_right_dark_skin_tone"
+  ],
+  "\ud83d\udeb6\ud83c\udfff\u200d\u27a1\ufe0f": [
+    "person_walking_facing_right_dark_skin_tone"
+  ],
+  "\ud83d\udeb7": [
+    "no_pedestrians"
+  ],
+  "\ud83d\udeb8": [
+    "children_crossing"
+  ],
+  "\ud83d\udeb9": [
+    "men\u2019s_room",
+    "mens",
+    "mens_room"
+  ],
+  "\ud83d\udeba": [
+    "women\u2019s_room",
+    "womens",
+    "womens_room"
+  ],
+  "\ud83d\udebb": [
+    "restroom"
+  ],
+  "\ud83d\udebc": [
+    "baby_symbol"
+  ],
+  "\ud83d\udebd": [
+    "toilet"
+  ],
+  "\ud83d\udebe": [
+    "water_closet",
+    "wc"
+  ],
+  "\ud83d\udebf": [
+    "shower"
+  ],
+  "\ud83d\udec0": [
+    "person_taking_bath",
+    "bath"
+  ],
+  "\ud83d\udec0\ud83c\udffb": [
+    "person_taking_bath_light_skin_tone"
+  ],
+  "\ud83d\udec0\ud83c\udffc": [
+    "person_taking_bath_medium-light_skin_tone"
+  ],
+  "\ud83d\udec0\ud83c\udffd": [
+    "person_taking_bath_medium_skin_tone"
+  ],
+  "\ud83d\udec0\ud83c\udffe": [
+    "person_taking_bath_medium-dark_skin_tone"
+  ],
+  "\ud83d\udec0\ud83c\udfff": [
+    "person_taking_bath_dark_skin_tone"
+  ],
+  "\ud83d\udec1": [
+    "bathtub"
+  ],
+  "\ud83d\udec2": [
+    "passport_control"
+  ],
+  "\ud83d\udec3": [
+    "customs"
+  ],
+  "\ud83d\udec4": [
+    "baggage_claim"
+  ],
+  "\ud83d\udec5": [
+    "left_luggage"
+  ],
+  "\ud83d\udecb": [
+    "couch_and_lamp"
+  ],
+  "\ud83d\udecb\ufe0f": [
+    "couch_and_lamp"
+  ],
+  "\ud83d\udecc": [
+    "person_in_bed",
+    "sleeping_bed",
+    "sleeping_accommodation"
+  ],
+  "\ud83d\udecc\ud83c\udffb": [
+    "person_in_bed_light_skin_tone"
+  ],
+  "\ud83d\udecc\ud83c\udffc": [
+    "person_in_bed_medium-light_skin_tone"
+  ],
+  "\ud83d\udecc\ud83c\udffd": [
+    "person_in_bed_medium_skin_tone"
+  ],
+  "\ud83d\udecc\ud83c\udffe": [
+    "person_in_bed_medium-dark_skin_tone"
+  ],
+  "\ud83d\udecc\ud83c\udfff": [
+    "person_in_bed_dark_skin_tone"
+  ],
+  "\ud83d\udecd": [
+    "shopping_bags",
+    "shopping"
+  ],
+  "\ud83d\udecd\ufe0f": [
+    "shopping_bags",
+    "shopping"
+  ],
+  "\ud83d\udece": [
+    "bellhop_bell"
+  ],
+  "\ud83d\udece\ufe0f": [
+    "bellhop_bell"
+  ],
+  "\ud83d\udecf": [
+    "bed"
+  ],
+  "\ud83d\udecf\ufe0f": [
+    "bed"
+  ],
+  "\ud83d\uded0": [
+    "place_of_worship"
+  ],
+  "\ud83d\uded1": [
+    "stop_sign"
+  ],
+  "\ud83d\uded2": [
+    "shopping_cart"
+  ],
+  "\ud83d\uded5": [
+    "hindu_temple"
+  ],
+  "\ud83d\uded6": [
+    "hut"
+  ],
+  "\ud83d\uded7": [
+    "elevator"
+  ],
+  "\ud83d\udedc": [
+    "wireless"
+  ],
+  "\ud83d\udedd": [
+    "playground_slide"
+  ],
+  "\ud83d\udede": [
+    "wheel"
+  ],
+  "\ud83d\udedf": [
+    "ring_buoy"
+  ],
+  "\ud83d\udee0": [
+    "hammer_and_wrench"
+  ],
+  "\ud83d\udee0\ufe0f": [
+    "hammer_and_wrench"
+  ],
+  "\ud83d\udee1": [
+    "shield"
+  ],
+  "\ud83d\udee1\ufe0f": [
+    "shield"
+  ],
+  "\ud83d\udee2": [
+    "oil_drum"
+  ],
+  "\ud83d\udee2\ufe0f": [
+    "oil_drum"
+  ],
+  "\ud83d\udee3": [
+    "motorway"
+  ],
+  "\ud83d\udee3\ufe0f": [
+    "motorway"
+  ],
+  "\ud83d\udee4": [
+    "railway_track"
+  ],
+  "\ud83d\udee4\ufe0f": [
+    "railway_track"
+  ],
+  "\ud83d\udee5": [
+    "motor_boat"
+  ],
+  "\ud83d\udee5\ufe0f": [
+    "motor_boat"
+  ],
+  "\ud83d\udee9": [
+    "small_airplane"
+  ],
+  "\ud83d\udee9\ufe0f": [
+    "small_airplane"
+  ],
+  "\ud83d\udeeb": [
+    "airplane_departure",
+    "flight_departure"
+  ],
+  "\ud83d\udeec": [
+    "airplane_arrival",
+    "airplane_arriving",
+    "flight_arrival"
+  ],
+  "\ud83d\udef0": [
+    "satellite",
+    "artificial_satellite"
+  ],
+  "\ud83d\udef0\ufe0f": [
+    "satellite",
+    "artificial_satellite"
+  ],
+  "\ud83d\udef3": [
+    "passenger_ship"
+  ],
+  "\ud83d\udef3\ufe0f": [
+    "passenger_ship"
+  ],
+  "\ud83d\udef4": [
+    "kick_scooter"
+  ],
+  "\ud83d\udef5": [
+    "motor_scooter"
+  ],
+  "\ud83d\udef6": [
+    "canoe"
+  ],
+  "\ud83d\udef7": [
+    "sled"
+  ],
+  "\ud83d\udef8": [
+    "flying_saucer"
+  ],
+  "\ud83d\udef9": [
+    "skateboard"
+  ],
+  "\ud83d\udefa": [
+    "auto_rickshaw"
+  ],
+  "\ud83d\udefb": [
+    "pickup_truck"
+  ],
+  "\ud83d\udefc": [
+    "roller_skate"
+  ],
+  "\ud83d\udfe0": [
+    "orange_circle"
+  ],
+  "\ud83d\udfe1": [
+    "yellow_circle"
+  ],
+  "\ud83d\udfe2": [
+    "green_circle"
+  ],
+  "\ud83d\udfe3": [
+    "purple_circle"
+  ],
+  "\ud83d\udfe4": [
+    "brown_circle"
+  ],
+  "\ud83d\udfe5": [
+    "red_square"
+  ],
+  "\ud83d\udfe6": [
+    "blue_square"
+  ],
+  "\ud83d\udfe7": [
+    "orange_square"
+  ],
+  "\ud83d\udfe8": [
+    "yellow_square"
+  ],
+  "\ud83d\udfe9": [
+    "green_square"
+  ],
+  "\ud83d\udfea": [
+    "purple_square"
+  ],
+  "\ud83d\udfeb": [
+    "brown_square"
+  ],
+  "\ud83d\udff0": [
+    "heavy_equals_sign"
+  ],
+  "\ud83e\udd0c": [
+    "pinched_fingers"
+  ],
+  "\ud83e\udd0c\ud83c\udffb": [
+    "pinched_fingers_light_skin_tone"
+  ],
+  "\ud83e\udd0c\ud83c\udffc": [
+    "pinched_fingers_medium-light_skin_tone"
+  ],
+  "\ud83e\udd0c\ud83c\udffd": [
+    "pinched_fingers_medium_skin_tone"
+  ],
+  "\ud83e\udd0c\ud83c\udffe": [
+    "pinched_fingers_medium-dark_skin_tone"
+  ],
+  "\ud83e\udd0c\ud83c\udfff": [
+    "pinched_fingers_dark_skin_tone"
+  ],
+  "\ud83e\udd0d": [
+    "white_heart"
+  ],
+  "\ud83e\udd0e": [
+    "brown_heart"
+  ],
+  "\ud83e\udd0f": [
+    "pinching_hand"
+  ],
+  "\ud83e\udd0f\ud83c\udffb": [
+    "pinching_hand_light_skin_tone"
+  ],
+  "\ud83e\udd0f\ud83c\udffc": [
+    "pinching_hand_medium-light_skin_tone"
+  ],
+  "\ud83e\udd0f\ud83c\udffd": [
+    "pinching_hand_medium_skin_tone"
+  ],
+  "\ud83e\udd0f\ud83c\udffe": [
+    "pinching_hand_medium-dark_skin_tone"
+  ],
+  "\ud83e\udd0f\ud83c\udfff": [
+    "pinching_hand_dark_skin_tone"
+  ],
+  "\ud83e\udd10": [
+    "zipper-mouth_face",
+    "zipper_mouth_face"
+  ],
+  "\ud83e\udd11": [
+    "money-mouth_face",
+    "money_mouth_face"
+  ],
+  "\ud83e\udd12": [
+    "face_with_thermometer"
+  ],
+  "\ud83e\udd13": [
+    "nerd_face"
+  ],
+  "\ud83e\udd14": [
+    "thinking_face",
+    "thinking"
+  ],
+  "\ud83e\udd15": [
+    "face_with_head-bandage",
+    "face_with_head_bandage"
+  ],
+  "\ud83e\udd16": [
+    "robot",
+    "robot_face"
+  ],
+  "\ud83e\udd17": [
+    "smiling_face_with_open_hands",
+    "hugging_face",
+    "hugs"
+  ],
+  "\ud83e\udd18": [
+    "sign_of_the_horns",
+    "metal"
+  ],
+  "\ud83e\udd18\ud83c\udffb": [
+    "sign_of_the_horns_light_skin_tone"
+  ],
+  "\ud83e\udd18\ud83c\udffc": [
+    "sign_of_the_horns_medium-light_skin_tone"
+  ],
+  "\ud83e\udd18\ud83c\udffd": [
+    "sign_of_the_horns_medium_skin_tone"
+  ],
+  "\ud83e\udd18\ud83c\udffe": [
+    "sign_of_the_horns_medium-dark_skin_tone"
+  ],
+  "\ud83e\udd18\ud83c\udfff": [
+    "sign_of_the_horns_dark_skin_tone"
+  ],
+  "\ud83e\udd19": [
+    "call_me_hand"
+  ],
+  "\ud83e\udd19\ud83c\udffb": [
+    "call_me_hand_light_skin_tone"
+  ],
+  "\ud83e\udd19\ud83c\udffc": [
+    "call_me_hand_medium-light_skin_tone"
+  ],
+  "\ud83e\udd19\ud83c\udffd": [
+    "call_me_hand_medium_skin_tone"
+  ],
+  "\ud83e\udd19\ud83c\udffe": [
+    "call_me_hand_medium-dark_skin_tone"
+  ],
+  "\ud83e\udd19\ud83c\udfff": [
+    "call_me_hand_dark_skin_tone"
+  ],
+  "\ud83e\udd1a": [
+    "raised_back_of_hand"
+  ],
+  "\ud83e\udd1a\ud83c\udffb": [
+    "raised_back_of_hand_light_skin_tone"
+  ],
+  "\ud83e\udd1a\ud83c\udffc": [
+    "raised_back_of_hand_medium-light_skin_tone"
+  ],
+  "\ud83e\udd1a\ud83c\udffd": [
+    "raised_back_of_hand_medium_skin_tone"
+  ],
+  "\ud83e\udd1a\ud83c\udffe": [
+    "raised_back_of_hand_medium-dark_skin_tone"
+  ],
+  "\ud83e\udd1a\ud83c\udfff": [
+    "raised_back_of_hand_dark_skin_tone"
+  ],
+  "\ud83e\udd1b": [
+    "left-facing_fist",
+    "fist_left",
+    "left_facing_fist"
+  ],
+  "\ud83e\udd1b\ud83c\udffb": [
+    "left-facing_fist_light_skin_tone"
+  ],
+  "\ud83e\udd1b\ud83c\udffc": [
+    "left-facing_fist_medium-light_skin_tone"
+  ],
+  "\ud83e\udd1b\ud83c\udffd": [
+    "left-facing_fist_medium_skin_tone"
+  ],
+  "\ud83e\udd1b\ud83c\udffe": [
+    "left-facing_fist_medium-dark_skin_tone"
+  ],
+  "\ud83e\udd1b\ud83c\udfff": [
+    "left-facing_fist_dark_skin_tone"
+  ],
+  "\ud83e\udd1c": [
+    "right-facing_fist",
+    "fist_right",
+    "right_facing_fist"
+  ],
+  "\ud83e\udd1c\ud83c\udffb": [
+    "right-facing_fist_light_skin_tone"
+  ],
+  "\ud83e\udd1c\ud83c\udffc": [
+    "right-facing_fist_medium-light_skin_tone"
+  ],
+  "\ud83e\udd1c\ud83c\udffd": [
+    "right-facing_fist_medium_skin_tone"
+  ],
+  "\ud83e\udd1c\ud83c\udffe": [
+    "right-facing_fist_medium-dark_skin_tone"
+  ],
+  "\ud83e\udd1c\ud83c\udfff": [
+    "right-facing_fist_dark_skin_tone"
+  ],
+  "\ud83e\udd1d": [
+    "handshake"
+  ],
+  "\ud83e\udd1d\ud83c\udffb": [
+    "handshake_light_skin_tone"
+  ],
+  "\ud83e\udd1d\ud83c\udffc": [
+    "handshake_medium-light_skin_tone"
+  ],
+  "\ud83e\udd1d\ud83c\udffd": [
+    "handshake_medium_skin_tone"
+  ],
+  "\ud83e\udd1d\ud83c\udffe": [
+    "handshake_medium-dark_skin_tone"
+  ],
+  "\ud83e\udd1d\ud83c\udfff": [
+    "handshake_dark_skin_tone"
+  ],
+  "\ud83e\udd1e": [
+    "crossed_fingers"
+  ],
+  "\ud83e\udd1e\ud83c\udffb": [
+    "crossed_fingers_light_skin_tone"
+  ],
+  "\ud83e\udd1e\ud83c\udffc": [
+    "crossed_fingers_medium-light_skin_tone"
+  ],
+  "\ud83e\udd1e\ud83c\udffd": [
+    "crossed_fingers_medium_skin_tone"
+  ],
+  "\ud83e\udd1e\ud83c\udffe": [
+    "crossed_fingers_medium-dark_skin_tone"
+  ],
+  "\ud83e\udd1e\ud83c\udfff": [
+    "crossed_fingers_dark_skin_tone"
+  ],
+  "\ud83e\udd1f": [
+    "love-you_gesture",
+    "love_you_gesture"
+  ],
+  "\ud83e\udd1f\ud83c\udffb": [
+    "love-you_gesture_light_skin_tone"
+  ],
+  "\ud83e\udd1f\ud83c\udffc": [
+    "love-you_gesture_medium-light_skin_tone"
+  ],
+  "\ud83e\udd1f\ud83c\udffd": [
+    "love-you_gesture_medium_skin_tone"
+  ],
+  "\ud83e\udd1f\ud83c\udffe": [
+    "love-you_gesture_medium-dark_skin_tone"
+  ],
+  "\ud83e\udd1f\ud83c\udfff": [
+    "love-you_gesture_dark_skin_tone"
+  ],
+  "\ud83e\udd20": [
+    "cowboy_hat_face"
+  ],
+  "\ud83e\udd21": [
+    "clown_face"
+  ],
+  "\ud83e\udd22": [
+    "nauseated_face"
+  ],
+  "\ud83e\udd23": [
+    "rolling_on_the_floor_laughing",
+    "rofl"
+  ],
+  "\ud83e\udd24": [
+    "drooling_face"
+  ],
+  "\ud83e\udd25": [
+    "lying_face"
+  ],
+  "\ud83e\udd26": [
+    "person_facepalming",
+    "facepalm"
+  ],
+  "\ud83e\udd26\u200d\u2640": [
+    "woman_facepalming"
+  ],
+  "\ud83e\udd26\u200d\u2640\ufe0f": [
+    "woman_facepalming"
+  ],
+  "\ud83e\udd26\u200d\u2642": [
+    "man_facepalming"
+  ],
+  "\ud83e\udd26\u200d\u2642\ufe0f": [
+    "man_facepalming"
+  ],
+  "\ud83e\udd26\ud83c\udffb": [
+    "person_facepalming_light_skin_tone"
+  ],
+  "\ud83e\udd26\ud83c\udffb\u200d\u2640": [
+    "woman_facepalming_light_skin_tone"
+  ],
+  "\ud83e\udd26\ud83c\udffb\u200d\u2640\ufe0f": [
+    "woman_facepalming_light_skin_tone"
+  ],
+  "\ud83e\udd26\ud83c\udffb\u200d\u2642": [
+    "man_facepalming_light_skin_tone"
+  ],
+  "\ud83e\udd26\ud83c\udffb\u200d\u2642\ufe0f": [
+    "man_facepalming_light_skin_tone"
+  ],
+  "\ud83e\udd26\ud83c\udffc": [
+    "person_facepalming_medium-light_skin_tone"
+  ],
+  "\ud83e\udd26\ud83c\udffc\u200d\u2640": [
+    "woman_facepalming_medium-light_skin_tone"
+  ],
+  "\ud83e\udd26\ud83c\udffc\u200d\u2640\ufe0f": [
+    "woman_facepalming_medium-light_skin_tone"
+  ],
+  "\ud83e\udd26\ud83c\udffc\u200d\u2642": [
+    "man_facepalming_medium-light_skin_tone"
+  ],
+  "\ud83e\udd26\ud83c\udffc\u200d\u2642\ufe0f": [
+    "man_facepalming_medium-light_skin_tone"
+  ],
+  "\ud83e\udd26\ud83c\udffd": [
+    "person_facepalming_medium_skin_tone"
+  ],
+  "\ud83e\udd26\ud83c\udffd\u200d\u2640": [
+    "woman_facepalming_medium_skin_tone"
+  ],
+  "\ud83e\udd26\ud83c\udffd\u200d\u2640\ufe0f": [
+    "woman_facepalming_medium_skin_tone"
+  ],
+  "\ud83e\udd26\ud83c\udffd\u200d\u2642": [
+    "man_facepalming_medium_skin_tone"
+  ],
+  "\ud83e\udd26\ud83c\udffd\u200d\u2642\ufe0f": [
+    "man_facepalming_medium_skin_tone"
+  ],
+  "\ud83e\udd26\ud83c\udffe": [
+    "person_facepalming_medium-dark_skin_tone"
+  ],
+  "\ud83e\udd26\ud83c\udffe\u200d\u2640": [
+    "woman_facepalming_medium-dark_skin_tone"
+  ],
+  "\ud83e\udd26\ud83c\udffe\u200d\u2640\ufe0f": [
+    "woman_facepalming_medium-dark_skin_tone"
+  ],
+  "\ud83e\udd26\ud83c\udffe\u200d\u2642": [
+    "man_facepalming_medium-dark_skin_tone"
+  ],
+  "\ud83e\udd26\ud83c\udffe\u200d\u2642\ufe0f": [
+    "man_facepalming_medium-dark_skin_tone"
+  ],
+  "\ud83e\udd26\ud83c\udfff": [
+    "person_facepalming_dark_skin_tone"
+  ],
+  "\ud83e\udd26\ud83c\udfff\u200d\u2640": [
+    "woman_facepalming_dark_skin_tone"
+  ],
+  "\ud83e\udd26\ud83c\udfff\u200d\u2640\ufe0f": [
+    "woman_facepalming_dark_skin_tone"
+  ],
+  "\ud83e\udd26\ud83c\udfff\u200d\u2642": [
+    "man_facepalming_dark_skin_tone"
+  ],
+  "\ud83e\udd26\ud83c\udfff\u200d\u2642\ufe0f": [
+    "man_facepalming_dark_skin_tone"
+  ],
+  "\ud83e\udd27": [
+    "sneezing_face"
+  ],
+  "\ud83e\udd28": [
+    "face_with_raised_eyebrow",
+    "raised_eyebrow"
+  ],
+  "\ud83e\udd29": [
+    "star-struck",
+    "star_struck"
+  ],
+  "\ud83e\udd2a": [
+    "zany_face"
+  ],
+  "\ud83e\udd2b": [
+    "shushing_face"
+  ],
+  "\ud83e\udd2c": [
+    "face_with_symbols_on_mouth",
+    "cursing_face"
+  ],
+  "\ud83e\udd2d": [
+    "face_with_hand_over_mouth",
+    "hand_over_mouth"
+  ],
+  "\ud83e\udd2e": [
+    "face_vomiting",
+    "vomiting_face"
+  ],
+  "\ud83e\udd2f": [
+    "exploding_head"
+  ],
+  "\ud83e\udd30": [
+    "pregnant_woman"
+  ],
+  "\ud83e\udd30\ud83c\udffb": [
+    "pregnant_woman_light_skin_tone"
+  ],
+  "\ud83e\udd30\ud83c\udffc": [
+    "pregnant_woman_medium-light_skin_tone"
+  ],
+  "\ud83e\udd30\ud83c\udffd": [
+    "pregnant_woman_medium_skin_tone"
+  ],
+  "\ud83e\udd30\ud83c\udffe": [
+    "pregnant_woman_medium-dark_skin_tone"
+  ],
+  "\ud83e\udd30\ud83c\udfff": [
+    "pregnant_woman_dark_skin_tone"
+  ],
+  "\ud83e\udd31": [
+    "breast-feeding",
+    "breast_feeding"
+  ],
+  "\ud83e\udd31\ud83c\udffb": [
+    "breast-feeding_light_skin_tone"
+  ],
+  "\ud83e\udd31\ud83c\udffc": [
+    "breast-feeding_medium-light_skin_tone"
+  ],
+  "\ud83e\udd31\ud83c\udffd": [
+    "breast-feeding_medium_skin_tone"
+  ],
+  "\ud83e\udd31\ud83c\udffe": [
+    "breast-feeding_medium-dark_skin_tone"
+  ],
+  "\ud83e\udd31\ud83c\udfff": [
+    "breast-feeding_dark_skin_tone"
+  ],
+  "\ud83e\udd32": [
+    "palms_up_together"
+  ],
+  "\ud83e\udd32\ud83c\udffb": [
+    "palms_up_together_light_skin_tone"
+  ],
+  "\ud83e\udd32\ud83c\udffc": [
+    "palms_up_together_medium-light_skin_tone"
+  ],
+  "\ud83e\udd32\ud83c\udffd": [
+    "palms_up_together_medium_skin_tone"
+  ],
+  "\ud83e\udd32\ud83c\udffe": [
+    "palms_up_together_medium-dark_skin_tone"
+  ],
+  "\ud83e\udd32\ud83c\udfff": [
+    "palms_up_together_dark_skin_tone"
+  ],
+  "\ud83e\udd33": [
+    "selfie"
+  ],
+  "\ud83e\udd33\ud83c\udffb": [
+    "selfie_light_skin_tone"
+  ],
+  "\ud83e\udd33\ud83c\udffc": [
+    "selfie_medium-light_skin_tone"
+  ],
+  "\ud83e\udd33\ud83c\udffd": [
+    "selfie_medium_skin_tone"
+  ],
+  "\ud83e\udd33\ud83c\udffe": [
+    "selfie_medium-dark_skin_tone"
+  ],
+  "\ud83e\udd33\ud83c\udfff": [
+    "selfie_dark_skin_tone"
+  ],
+  "\ud83e\udd34": [
+    "prince"
+  ],
+  "\ud83e\udd34\ud83c\udffb": [
+    "prince_light_skin_tone"
+  ],
+  "\ud83e\udd34\ud83c\udffc": [
+    "prince_medium-light_skin_tone"
+  ],
+  "\ud83e\udd34\ud83c\udffd": [
+    "prince_medium_skin_tone"
+  ],
+  "\ud83e\udd34\ud83c\udffe": [
+    "prince_medium-dark_skin_tone"
+  ],
+  "\ud83e\udd34\ud83c\udfff": [
+    "prince_dark_skin_tone"
+  ],
+  "\ud83e\udd35": [
+    "person_in_tuxedo"
+  ],
+  "\ud83e\udd35\u200d\u2640": [
+    "woman_in_tuxedo"
+  ],
+  "\ud83e\udd35\u200d\u2640\ufe0f": [
+    "woman_in_tuxedo"
+  ],
+  "\ud83e\udd35\u200d\u2642": [
+    "man_in_tuxedo"
+  ],
+  "\ud83e\udd35\u200d\u2642\ufe0f": [
+    "man_in_tuxedo"
+  ],
+  "\ud83e\udd35\ud83c\udffb": [
+    "person_in_tuxedo_light_skin_tone"
+  ],
+  "\ud83e\udd35\ud83c\udffb\u200d\u2640": [
+    "woman_in_tuxedo_light_skin_tone"
+  ],
+  "\ud83e\udd35\ud83c\udffb\u200d\u2640\ufe0f": [
+    "woman_in_tuxedo_light_skin_tone"
+  ],
+  "\ud83e\udd35\ud83c\udffb\u200d\u2642": [
+    "man_in_tuxedo_light_skin_tone"
+  ],
+  "\ud83e\udd35\ud83c\udffb\u200d\u2642\ufe0f": [
+    "man_in_tuxedo_light_skin_tone"
+  ],
+  "\ud83e\udd35\ud83c\udffc": [
+    "person_in_tuxedo_medium-light_skin_tone"
+  ],
+  "\ud83e\udd35\ud83c\udffc\u200d\u2640": [
+    "woman_in_tuxedo_medium-light_skin_tone"
+  ],
+  "\ud83e\udd35\ud83c\udffc\u200d\u2640\ufe0f": [
+    "woman_in_tuxedo_medium-light_skin_tone"
+  ],
+  "\ud83e\udd35\ud83c\udffc\u200d\u2642": [
+    "man_in_tuxedo_medium-light_skin_tone"
+  ],
+  "\ud83e\udd35\ud83c\udffc\u200d\u2642\ufe0f": [
+    "man_in_tuxedo_medium-light_skin_tone"
+  ],
+  "\ud83e\udd35\ud83c\udffd": [
+    "person_in_tuxedo_medium_skin_tone"
+  ],
+  "\ud83e\udd35\ud83c\udffd\u200d\u2640": [
+    "woman_in_tuxedo_medium_skin_tone"
+  ],
+  "\ud83e\udd35\ud83c\udffd\u200d\u2640\ufe0f": [
+    "woman_in_tuxedo_medium_skin_tone"
+  ],
+  "\ud83e\udd35\ud83c\udffd\u200d\u2642": [
+    "man_in_tuxedo_medium_skin_tone"
+  ],
+  "\ud83e\udd35\ud83c\udffd\u200d\u2642\ufe0f": [
+    "man_in_tuxedo_medium_skin_tone"
+  ],
+  "\ud83e\udd35\ud83c\udffe": [
+    "person_in_tuxedo_medium-dark_skin_tone"
+  ],
+  "\ud83e\udd35\ud83c\udffe\u200d\u2640": [
+    "woman_in_tuxedo_medium-dark_skin_tone"
+  ],
+  "\ud83e\udd35\ud83c\udffe\u200d\u2640\ufe0f": [
+    "woman_in_tuxedo_medium-dark_skin_tone"
+  ],
+  "\ud83e\udd35\ud83c\udffe\u200d\u2642": [
+    "man_in_tuxedo_medium-dark_skin_tone"
+  ],
+  "\ud83e\udd35\ud83c\udffe\u200d\u2642\ufe0f": [
+    "man_in_tuxedo_medium-dark_skin_tone"
+  ],
+  "\ud83e\udd35\ud83c\udfff": [
+    "person_in_tuxedo_dark_skin_tone"
+  ],
+  "\ud83e\udd35\ud83c\udfff\u200d\u2640": [
+    "woman_in_tuxedo_dark_skin_tone"
+  ],
+  "\ud83e\udd35\ud83c\udfff\u200d\u2640\ufe0f": [
+    "woman_in_tuxedo_dark_skin_tone"
+  ],
+  "\ud83e\udd35\ud83c\udfff\u200d\u2642": [
+    "man_in_tuxedo_dark_skin_tone"
+  ],
+  "\ud83e\udd35\ud83c\udfff\u200d\u2642\ufe0f": [
+    "man_in_tuxedo_dark_skin_tone"
+  ],
+  "\ud83e\udd36": [
+    "mrs._claus",
+    "mrs_claus"
+  ],
+  "\ud83e\udd36\ud83c\udffb": [
+    "mrs._claus_light_skin_tone"
+  ],
+  "\ud83e\udd36\ud83c\udffc": [
+    "mrs._claus_medium-light_skin_tone"
+  ],
+  "\ud83e\udd36\ud83c\udffd": [
+    "mrs._claus_medium_skin_tone"
+  ],
+  "\ud83e\udd36\ud83c\udffe": [
+    "mrs._claus_medium-dark_skin_tone"
+  ],
+  "\ud83e\udd36\ud83c\udfff": [
+    "mrs._claus_dark_skin_tone"
+  ],
+  "\ud83e\udd37": [
+    "person_shrugging",
+    "shrug"
+  ],
+  "\ud83e\udd37\u200d\u2640": [
+    "woman_shrugging"
+  ],
+  "\ud83e\udd37\u200d\u2640\ufe0f": [
+    "woman_shrugging"
+  ],
+  "\ud83e\udd37\u200d\u2642": [
+    "man_shrugging"
+  ],
+  "\ud83e\udd37\u200d\u2642\ufe0f": [
+    "man_shrugging"
+  ],
+  "\ud83e\udd37\ud83c\udffb": [
+    "person_shrugging_light_skin_tone"
+  ],
+  "\ud83e\udd37\ud83c\udffb\u200d\u2640": [
+    "woman_shrugging_light_skin_tone"
+  ],
+  "\ud83e\udd37\ud83c\udffb\u200d\u2640\ufe0f": [
+    "woman_shrugging_light_skin_tone"
+  ],
+  "\ud83e\udd37\ud83c\udffb\u200d\u2642": [
+    "man_shrugging_light_skin_tone"
+  ],
+  "\ud83e\udd37\ud83c\udffb\u200d\u2642\ufe0f": [
+    "man_shrugging_light_skin_tone"
+  ],
+  "\ud83e\udd37\ud83c\udffc": [
+    "person_shrugging_medium-light_skin_tone"
+  ],
+  "\ud83e\udd37\ud83c\udffc\u200d\u2640": [
+    "woman_shrugging_medium-light_skin_tone"
+  ],
+  "\ud83e\udd37\ud83c\udffc\u200d\u2640\ufe0f": [
+    "woman_shrugging_medium-light_skin_tone"
+  ],
+  "\ud83e\udd37\ud83c\udffc\u200d\u2642": [
+    "man_shrugging_medium-light_skin_tone"
+  ],
+  "\ud83e\udd37\ud83c\udffc\u200d\u2642\ufe0f": [
+    "man_shrugging_medium-light_skin_tone"
+  ],
+  "\ud83e\udd37\ud83c\udffd": [
+    "person_shrugging_medium_skin_tone"
+  ],
+  "\ud83e\udd37\ud83c\udffd\u200d\u2640": [
+    "woman_shrugging_medium_skin_tone"
+  ],
+  "\ud83e\udd37\ud83c\udffd\u200d\u2640\ufe0f": [
+    "woman_shrugging_medium_skin_tone"
+  ],
+  "\ud83e\udd37\ud83c\udffd\u200d\u2642": [
+    "man_shrugging_medium_skin_tone"
+  ],
+  "\ud83e\udd37\ud83c\udffd\u200d\u2642\ufe0f": [
+    "man_shrugging_medium_skin_tone"
+  ],
+  "\ud83e\udd37\ud83c\udffe": [
+    "person_shrugging_medium-dark_skin_tone"
+  ],
+  "\ud83e\udd37\ud83c\udffe\u200d\u2640": [
+    "woman_shrugging_medium-dark_skin_tone"
+  ],
+  "\ud83e\udd37\ud83c\udffe\u200d\u2640\ufe0f": [
+    "woman_shrugging_medium-dark_skin_tone"
+  ],
+  "\ud83e\udd37\ud83c\udffe\u200d\u2642": [
+    "man_shrugging_medium-dark_skin_tone"
+  ],
+  "\ud83e\udd37\ud83c\udffe\u200d\u2642\ufe0f": [
+    "man_shrugging_medium-dark_skin_tone"
+  ],
+  "\ud83e\udd37\ud83c\udfff": [
+    "person_shrugging_dark_skin_tone"
+  ],
+  "\ud83e\udd37\ud83c\udfff\u200d\u2640": [
+    "woman_shrugging_dark_skin_tone"
+  ],
+  "\ud83e\udd37\ud83c\udfff\u200d\u2640\ufe0f": [
+    "woman_shrugging_dark_skin_tone"
+  ],
+  "\ud83e\udd37\ud83c\udfff\u200d\u2642": [
+    "man_shrugging_dark_skin_tone"
+  ],
+  "\ud83e\udd37\ud83c\udfff\u200d\u2642\ufe0f": [
+    "man_shrugging_dark_skin_tone"
+  ],
+  "\ud83e\udd38": [
+    "person_cartwheeling",
+    "cartwheeling"
+  ],
+  "\ud83e\udd38\u200d\u2640": [
+    "woman_cartwheeling"
+  ],
+  "\ud83e\udd38\u200d\u2640\ufe0f": [
+    "woman_cartwheeling"
+  ],
+  "\ud83e\udd38\u200d\u2642": [
+    "man_cartwheeling"
+  ],
+  "\ud83e\udd38\u200d\u2642\ufe0f": [
+    "man_cartwheeling"
+  ],
+  "\ud83e\udd38\ud83c\udffb": [
+    "person_cartwheeling_light_skin_tone"
+  ],
+  "\ud83e\udd38\ud83c\udffb\u200d\u2640": [
+    "woman_cartwheeling_light_skin_tone"
+  ],
+  "\ud83e\udd38\ud83c\udffb\u200d\u2640\ufe0f": [
+    "woman_cartwheeling_light_skin_tone"
+  ],
+  "\ud83e\udd38\ud83c\udffb\u200d\u2642": [
+    "man_cartwheeling_light_skin_tone"
+  ],
+  "\ud83e\udd38\ud83c\udffb\u200d\u2642\ufe0f": [
+    "man_cartwheeling_light_skin_tone"
+  ],
+  "\ud83e\udd38\ud83c\udffc": [
+    "person_cartwheeling_medium-light_skin_tone"
+  ],
+  "\ud83e\udd38\ud83c\udffc\u200d\u2640": [
+    "woman_cartwheeling_medium-light_skin_tone"
+  ],
+  "\ud83e\udd38\ud83c\udffc\u200d\u2640\ufe0f": [
+    "woman_cartwheeling_medium-light_skin_tone"
+  ],
+  "\ud83e\udd38\ud83c\udffc\u200d\u2642": [
+    "man_cartwheeling_medium-light_skin_tone"
+  ],
+  "\ud83e\udd38\ud83c\udffc\u200d\u2642\ufe0f": [
+    "man_cartwheeling_medium-light_skin_tone"
+  ],
+  "\ud83e\udd38\ud83c\udffd": [
+    "person_cartwheeling_medium_skin_tone"
+  ],
+  "\ud83e\udd38\ud83c\udffd\u200d\u2640": [
+    "woman_cartwheeling_medium_skin_tone"
+  ],
+  "\ud83e\udd38\ud83c\udffd\u200d\u2640\ufe0f": [
+    "woman_cartwheeling_medium_skin_tone"
+  ],
+  "\ud83e\udd38\ud83c\udffd\u200d\u2642": [
+    "man_cartwheeling_medium_skin_tone"
+  ],
+  "\ud83e\udd38\ud83c\udffd\u200d\u2642\ufe0f": [
+    "man_cartwheeling_medium_skin_tone"
+  ],
+  "\ud83e\udd38\ud83c\udffe": [
+    "person_cartwheeling_medium-dark_skin_tone"
+  ],
+  "\ud83e\udd38\ud83c\udffe\u200d\u2640": [
+    "woman_cartwheeling_medium-dark_skin_tone"
+  ],
+  "\ud83e\udd38\ud83c\udffe\u200d\u2640\ufe0f": [
+    "woman_cartwheeling_medium-dark_skin_tone"
+  ],
+  "\ud83e\udd38\ud83c\udffe\u200d\u2642": [
+    "man_cartwheeling_medium-dark_skin_tone"
+  ],
+  "\ud83e\udd38\ud83c\udffe\u200d\u2642\ufe0f": [
+    "man_cartwheeling_medium-dark_skin_tone"
+  ],
+  "\ud83e\udd38\ud83c\udfff": [
+    "person_cartwheeling_dark_skin_tone"
+  ],
+  "\ud83e\udd38\ud83c\udfff\u200d\u2640": [
+    "woman_cartwheeling_dark_skin_tone"
+  ],
+  "\ud83e\udd38\ud83c\udfff\u200d\u2640\ufe0f": [
+    "woman_cartwheeling_dark_skin_tone"
+  ],
+  "\ud83e\udd38\ud83c\udfff\u200d\u2642": [
+    "man_cartwheeling_dark_skin_tone"
+  ],
+  "\ud83e\udd38\ud83c\udfff\u200d\u2642\ufe0f": [
+    "man_cartwheeling_dark_skin_tone"
+  ],
+  "\ud83e\udd39": [
+    "person_juggling",
+    "juggling_person"
+  ],
+  "\ud83e\udd39\u200d\u2640": [
+    "woman_juggling"
+  ],
+  "\ud83e\udd39\u200d\u2640\ufe0f": [
+    "woman_juggling"
+  ],
+  "\ud83e\udd39\u200d\u2642": [
+    "man_juggling"
+  ],
+  "\ud83e\udd39\u200d\u2642\ufe0f": [
+    "man_juggling"
+  ],
+  "\ud83e\udd39\ud83c\udffb": [
+    "person_juggling_light_skin_tone"
+  ],
+  "\ud83e\udd39\ud83c\udffb\u200d\u2640": [
+    "woman_juggling_light_skin_tone"
+  ],
+  "\ud83e\udd39\ud83c\udffb\u200d\u2640\ufe0f": [
+    "woman_juggling_light_skin_tone"
+  ],
+  "\ud83e\udd39\ud83c\udffb\u200d\u2642": [
+    "man_juggling_light_skin_tone"
+  ],
+  "\ud83e\udd39\ud83c\udffb\u200d\u2642\ufe0f": [
+    "man_juggling_light_skin_tone"
+  ],
+  "\ud83e\udd39\ud83c\udffc": [
+    "person_juggling_medium-light_skin_tone"
+  ],
+  "\ud83e\udd39\ud83c\udffc\u200d\u2640": [
+    "woman_juggling_medium-light_skin_tone"
+  ],
+  "\ud83e\udd39\ud83c\udffc\u200d\u2640\ufe0f": [
+    "woman_juggling_medium-light_skin_tone"
+  ],
+  "\ud83e\udd39\ud83c\udffc\u200d\u2642": [
+    "man_juggling_medium-light_skin_tone"
+  ],
+  "\ud83e\udd39\ud83c\udffc\u200d\u2642\ufe0f": [
+    "man_juggling_medium-light_skin_tone"
+  ],
+  "\ud83e\udd39\ud83c\udffd": [
+    "person_juggling_medium_skin_tone"
+  ],
+  "\ud83e\udd39\ud83c\udffd\u200d\u2640": [
+    "woman_juggling_medium_skin_tone"
+  ],
+  "\ud83e\udd39\ud83c\udffd\u200d\u2640\ufe0f": [
+    "woman_juggling_medium_skin_tone"
+  ],
+  "\ud83e\udd39\ud83c\udffd\u200d\u2642": [
+    "man_juggling_medium_skin_tone"
+  ],
+  "\ud83e\udd39\ud83c\udffd\u200d\u2642\ufe0f": [
+    "man_juggling_medium_skin_tone"
+  ],
+  "\ud83e\udd39\ud83c\udffe": [
+    "person_juggling_medium-dark_skin_tone"
+  ],
+  "\ud83e\udd39\ud83c\udffe\u200d\u2640": [
+    "woman_juggling_medium-dark_skin_tone"
+  ],
+  "\ud83e\udd39\ud83c\udffe\u200d\u2640\ufe0f": [
+    "woman_juggling_medium-dark_skin_tone"
+  ],
+  "\ud83e\udd39\ud83c\udffe\u200d\u2642": [
+    "man_juggling_medium-dark_skin_tone"
+  ],
+  "\ud83e\udd39\ud83c\udffe\u200d\u2642\ufe0f": [
+    "man_juggling_medium-dark_skin_tone"
+  ],
+  "\ud83e\udd39\ud83c\udfff": [
+    "person_juggling_dark_skin_tone"
+  ],
+  "\ud83e\udd39\ud83c\udfff\u200d\u2640": [
+    "woman_juggling_dark_skin_tone"
+  ],
+  "\ud83e\udd39\ud83c\udfff\u200d\u2640\ufe0f": [
+    "woman_juggling_dark_skin_tone"
+  ],
+  "\ud83e\udd39\ud83c\udfff\u200d\u2642": [
+    "man_juggling_dark_skin_tone"
+  ],
+  "\ud83e\udd39\ud83c\udfff\u200d\u2642\ufe0f": [
+    "man_juggling_dark_skin_tone"
+  ],
+  "\ud83e\udd3a": [
+    "person_fencing"
+  ],
+  "\ud83e\udd3c": [
+    "people_wrestling",
+    "wrestling"
+  ],
+  "\ud83e\udd3c\u200d\u2640": [
+    "women_wrestling"
+  ],
+  "\ud83e\udd3c\u200d\u2640\ufe0f": [
+    "women_wrestling"
+  ],
+  "\ud83e\udd3c\u200d\u2642": [
+    "men_wrestling"
+  ],
+  "\ud83e\udd3c\u200d\u2642\ufe0f": [
+    "men_wrestling"
+  ],
+  "\ud83e\udd3d": [
+    "person_playing_water_polo",
+    "water_polo"
+  ],
+  "\ud83e\udd3d\u200d\u2640": [
+    "woman_playing_water_polo"
+  ],
+  "\ud83e\udd3d\u200d\u2640\ufe0f": [
+    "woman_playing_water_polo"
+  ],
+  "\ud83e\udd3d\u200d\u2642": [
+    "man_playing_water_polo"
+  ],
+  "\ud83e\udd3d\u200d\u2642\ufe0f": [
+    "man_playing_water_polo"
+  ],
+  "\ud83e\udd3d\ud83c\udffb": [
+    "person_playing_water_polo_light_skin_tone"
+  ],
+  "\ud83e\udd3d\ud83c\udffb\u200d\u2640": [
+    "woman_playing_water_polo_light_skin_tone"
+  ],
+  "\ud83e\udd3d\ud83c\udffb\u200d\u2640\ufe0f": [
+    "woman_playing_water_polo_light_skin_tone"
+  ],
+  "\ud83e\udd3d\ud83c\udffb\u200d\u2642": [
+    "man_playing_water_polo_light_skin_tone"
+  ],
+  "\ud83e\udd3d\ud83c\udffb\u200d\u2642\ufe0f": [
+    "man_playing_water_polo_light_skin_tone"
+  ],
+  "\ud83e\udd3d\ud83c\udffc": [
+    "person_playing_water_polo_medium-light_skin_tone"
+  ],
+  "\ud83e\udd3d\ud83c\udffc\u200d\u2640": [
+    "woman_playing_water_polo_medium-light_skin_tone"
+  ],
+  "\ud83e\udd3d\ud83c\udffc\u200d\u2640\ufe0f": [
+    "woman_playing_water_polo_medium-light_skin_tone"
+  ],
+  "\ud83e\udd3d\ud83c\udffc\u200d\u2642": [
+    "man_playing_water_polo_medium-light_skin_tone"
+  ],
+  "\ud83e\udd3d\ud83c\udffc\u200d\u2642\ufe0f": [
+    "man_playing_water_polo_medium-light_skin_tone"
+  ],
+  "\ud83e\udd3d\ud83c\udffd": [
+    "person_playing_water_polo_medium_skin_tone"
+  ],
+  "\ud83e\udd3d\ud83c\udffd\u200d\u2640": [
+    "woman_playing_water_polo_medium_skin_tone"
+  ],
+  "\ud83e\udd3d\ud83c\udffd\u200d\u2640\ufe0f": [
+    "woman_playing_water_polo_medium_skin_tone"
+  ],
+  "\ud83e\udd3d\ud83c\udffd\u200d\u2642": [
+    "man_playing_water_polo_medium_skin_tone"
+  ],
+  "\ud83e\udd3d\ud83c\udffd\u200d\u2642\ufe0f": [
+    "man_playing_water_polo_medium_skin_tone"
+  ],
+  "\ud83e\udd3d\ud83c\udffe": [
+    "person_playing_water_polo_medium-dark_skin_tone"
+  ],
+  "\ud83e\udd3d\ud83c\udffe\u200d\u2640": [
+    "woman_playing_water_polo_medium-dark_skin_tone"
+  ],
+  "\ud83e\udd3d\ud83c\udffe\u200d\u2640\ufe0f": [
+    "woman_playing_water_polo_medium-dark_skin_tone"
+  ],
+  "\ud83e\udd3d\ud83c\udffe\u200d\u2642": [
+    "man_playing_water_polo_medium-dark_skin_tone"
+  ],
+  "\ud83e\udd3d\ud83c\udffe\u200d\u2642\ufe0f": [
+    "man_playing_water_polo_medium-dark_skin_tone"
+  ],
+  "\ud83e\udd3d\ud83c\udfff": [
+    "person_playing_water_polo_dark_skin_tone"
+  ],
+  "\ud83e\udd3d\ud83c\udfff\u200d\u2640": [
+    "woman_playing_water_polo_dark_skin_tone"
+  ],
+  "\ud83e\udd3d\ud83c\udfff\u200d\u2640\ufe0f": [
+    "woman_playing_water_polo_dark_skin_tone"
+  ],
+  "\ud83e\udd3d\ud83c\udfff\u200d\u2642": [
+    "man_playing_water_polo_dark_skin_tone"
+  ],
+  "\ud83e\udd3d\ud83c\udfff\u200d\u2642\ufe0f": [
+    "man_playing_water_polo_dark_skin_tone"
+  ],
+  "\ud83e\udd3e": [
+    "person_playing_handball",
+    "handball_person"
+  ],
+  "\ud83e\udd3e\u200d\u2640": [
+    "woman_playing_handball"
+  ],
+  "\ud83e\udd3e\u200d\u2640\ufe0f": [
+    "woman_playing_handball"
+  ],
+  "\ud83e\udd3e\u200d\u2642": [
+    "man_playing_handball"
+  ],
+  "\ud83e\udd3e\u200d\u2642\ufe0f": [
+    "man_playing_handball"
+  ],
+  "\ud83e\udd3e\ud83c\udffb": [
+    "person_playing_handball_light_skin_tone"
+  ],
+  "\ud83e\udd3e\ud83c\udffb\u200d\u2640": [
+    "woman_playing_handball_light_skin_tone"
+  ],
+  "\ud83e\udd3e\ud83c\udffb\u200d\u2640\ufe0f": [
+    "woman_playing_handball_light_skin_tone"
+  ],
+  "\ud83e\udd3e\ud83c\udffb\u200d\u2642": [
+    "man_playing_handball_light_skin_tone"
+  ],
+  "\ud83e\udd3e\ud83c\udffb\u200d\u2642\ufe0f": [
+    "man_playing_handball_light_skin_tone"
+  ],
+  "\ud83e\udd3e\ud83c\udffc": [
+    "person_playing_handball_medium-light_skin_tone"
+  ],
+  "\ud83e\udd3e\ud83c\udffc\u200d\u2640": [
+    "woman_playing_handball_medium-light_skin_tone"
+  ],
+  "\ud83e\udd3e\ud83c\udffc\u200d\u2640\ufe0f": [
+    "woman_playing_handball_medium-light_skin_tone"
+  ],
+  "\ud83e\udd3e\ud83c\udffc\u200d\u2642": [
+    "man_playing_handball_medium-light_skin_tone"
+  ],
+  "\ud83e\udd3e\ud83c\udffc\u200d\u2642\ufe0f": [
+    "man_playing_handball_medium-light_skin_tone"
+  ],
+  "\ud83e\udd3e\ud83c\udffd": [
+    "person_playing_handball_medium_skin_tone"
+  ],
+  "\ud83e\udd3e\ud83c\udffd\u200d\u2640": [
+    "woman_playing_handball_medium_skin_tone"
+  ],
+  "\ud83e\udd3e\ud83c\udffd\u200d\u2640\ufe0f": [
+    "woman_playing_handball_medium_skin_tone"
+  ],
+  "\ud83e\udd3e\ud83c\udffd\u200d\u2642": [
+    "man_playing_handball_medium_skin_tone"
+  ],
+  "\ud83e\udd3e\ud83c\udffd\u200d\u2642\ufe0f": [
+    "man_playing_handball_medium_skin_tone"
+  ],
+  "\ud83e\udd3e\ud83c\udffe": [
+    "person_playing_handball_medium-dark_skin_tone"
+  ],
+  "\ud83e\udd3e\ud83c\udffe\u200d\u2640": [
+    "woman_playing_handball_medium-dark_skin_tone"
+  ],
+  "\ud83e\udd3e\ud83c\udffe\u200d\u2640\ufe0f": [
+    "woman_playing_handball_medium-dark_skin_tone"
+  ],
+  "\ud83e\udd3e\ud83c\udffe\u200d\u2642": [
+    "man_playing_handball_medium-dark_skin_tone"
+  ],
+  "\ud83e\udd3e\ud83c\udffe\u200d\u2642\ufe0f": [
+    "man_playing_handball_medium-dark_skin_tone"
+  ],
+  "\ud83e\udd3e\ud83c\udfff": [
+    "person_playing_handball_dark_skin_tone"
+  ],
+  "\ud83e\udd3e\ud83c\udfff\u200d\u2640": [
+    "woman_playing_handball_dark_skin_tone"
+  ],
+  "\ud83e\udd3e\ud83c\udfff\u200d\u2640\ufe0f": [
+    "woman_playing_handball_dark_skin_tone"
+  ],
+  "\ud83e\udd3e\ud83c\udfff\u200d\u2642": [
+    "man_playing_handball_dark_skin_tone"
+  ],
+  "\ud83e\udd3e\ud83c\udfff\u200d\u2642\ufe0f": [
+    "man_playing_handball_dark_skin_tone"
+  ],
+  "\ud83e\udd3f": [
+    "diving_mask"
+  ],
+  "\ud83e\udd40": [
+    "wilted_flower"
+  ],
+  "\ud83e\udd41": [
+    "drum"
+  ],
+  "\ud83e\udd42": [
+    "clinking_glasses"
+  ],
+  "\ud83e\udd43": [
+    "tumbler_glass"
+  ],
+  "\ud83e\udd44": [
+    "spoon"
+  ],
+  "\ud83e\udd45": [
+    "goal_net"
+  ],
+  "\ud83e\udd47": [
+    "1st_place_medal"
+  ],
+  "\ud83e\udd48": [
+    "2nd_place_medal"
+  ],
+  "\ud83e\udd49": [
+    "3rd_place_medal"
+  ],
+  "\ud83e\udd4a": [
+    "boxing_glove"
+  ],
+  "\ud83e\udd4b": [
+    "martial_arts_uniform"
+  ],
+  "\ud83e\udd4c": [
+    "curling_stone"
+  ],
+  "\ud83e\udd4d": [
+    "lacrosse"
+  ],
+  "\ud83e\udd4e": [
+    "softball"
+  ],
+  "\ud83e\udd4f": [
+    "flying_disc"
+  ],
+  "\ud83e\udd50": [
+    "croissant"
+  ],
+  "\ud83e\udd51": [
+    "avocado"
+  ],
+  "\ud83e\udd52": [
+    "cucumber"
+  ],
+  "\ud83e\udd53": [
+    "bacon"
+  ],
+  "\ud83e\udd54": [
+    "potato"
+  ],
+  "\ud83e\udd55": [
+    "carrot"
+  ],
+  "\ud83e\udd56": [
+    "baguette_bread"
+  ],
+  "\ud83e\udd57": [
+    "green_salad"
+  ],
+  "\ud83e\udd58": [
+    "shallow_pan_of_food"
+  ],
+  "\ud83e\udd59": [
+    "stuffed_flatbread"
+  ],
+  "\ud83e\udd5a": [
+    "egg",
+    "egg2"
+  ],
+  "\ud83e\udd5b": [
+    "glass_of_milk",
+    "milk_glass"
+  ],
+  "\ud83e\udd5c": [
+    "peanuts"
+  ],
+  "\ud83e\udd5d": [
+    "kiwi_fruit"
+  ],
+  "\ud83e\udd5e": [
+    "pancakes"
+  ],
+  "\ud83e\udd5f": [
+    "dumpling"
+  ],
+  "\ud83e\udd60": [
+    "fortune_cookie"
+  ],
+  "\ud83e\udd61": [
+    "takeout_box"
+  ],
+  "\ud83e\udd62": [
+    "chopsticks"
+  ],
+  "\ud83e\udd63": [
+    "bowl_with_spoon"
+  ],
+  "\ud83e\udd64": [
+    "cup_with_straw"
+  ],
+  "\ud83e\udd65": [
+    "coconut"
+  ],
+  "\ud83e\udd66": [
+    "broccoli"
+  ],
+  "\ud83e\udd67": [
+    "pie"
+  ],
+  "\ud83e\udd68": [
+    "pretzel"
+  ],
+  "\ud83e\udd69": [
+    "cut_of_meat"
+  ],
+  "\ud83e\udd6a": [
+    "sandwich"
+  ],
+  "\ud83e\udd6b": [
+    "canned_food"
+  ],
+  "\ud83e\udd6c": [
+    "leafy_green"
+  ],
+  "\ud83e\udd6d": [
+    "mango"
+  ],
+  "\ud83e\udd6e": [
+    "moon_cake"
+  ],
+  "\ud83e\udd6f": [
+    "bagel"
+  ],
+  "\ud83e\udd70": [
+    "smiling_face_with_hearts",
+    "smiling_face_with_three_hearts"
+  ],
+  "\ud83e\udd71": [
+    "yawning_face"
+  ],
+  "\ud83e\udd72": [
+    "smiling_face_with_tear"
+  ],
+  "\ud83e\udd73": [
+    "partying_face"
+  ],
+  "\ud83e\udd74": [
+    "woozy_face"
+  ],
+  "\ud83e\udd75": [
+    "hot_face"
+  ],
+  "\ud83e\udd76": [
+    "cold_face"
+  ],
+  "\ud83e\udd77": [
+    "ninja"
+  ],
+  "\ud83e\udd77\ud83c\udffb": [
+    "ninja_light_skin_tone"
+  ],
+  "\ud83e\udd77\ud83c\udffc": [
+    "ninja_medium-light_skin_tone"
+  ],
+  "\ud83e\udd77\ud83c\udffd": [
+    "ninja_medium_skin_tone"
+  ],
+  "\ud83e\udd77\ud83c\udffe": [
+    "ninja_medium-dark_skin_tone"
+  ],
+  "\ud83e\udd77\ud83c\udfff": [
+    "ninja_dark_skin_tone"
+  ],
+  "\ud83e\udd78": [
+    "disguised_face"
+  ],
+  "\ud83e\udd79": [
+    "face_holding_back_tears"
+  ],
+  "\ud83e\udd7a": [
+    "pleading_face"
+  ],
+  "\ud83e\udd7b": [
+    "sari"
+  ],
+  "\ud83e\udd7c": [
+    "lab_coat"
+  ],
+  "\ud83e\udd7d": [
+    "goggles"
+  ],
+  "\ud83e\udd7e": [
+    "hiking_boot"
+  ],
+  "\ud83e\udd7f": [
+    "flat_shoe"
+  ],
+  "\ud83e\udd80": [
+    "crab"
+  ],
+  "\ud83e\udd81": [
+    "lion",
+    "lion_face"
+  ],
+  "\ud83e\udd82": [
+    "scorpion"
+  ],
+  "\ud83e\udd83": [
+    "turkey"
+  ],
+  "\ud83e\udd84": [
+    "unicorn",
+    "unicorn_face"
+  ],
+  "\ud83e\udd85": [
+    "eagle"
+  ],
+  "\ud83e\udd86": [
+    "duck"
+  ],
+  "\ud83e\udd87": [
+    "bat"
+  ],
+  "\ud83e\udd88": [
+    "shark"
+  ],
+  "\ud83e\udd89": [
+    "owl"
+  ],
+  "\ud83e\udd8a": [
+    "fox",
+    "fox_face"
+  ],
+  "\ud83e\udd8b": [
+    "butterfly"
+  ],
+  "\ud83e\udd8c": [
+    "deer"
+  ],
+  "\ud83e\udd8d": [
+    "gorilla",
+    "harambe"
+  ],
+  "\ud83e\udd8e": [
+    "lizard"
+  ],
+  "\ud83e\udd8f": [
+    "rhinoceros"
+  ],
+  "\ud83e\udd90": [
+    "shrimp"
+  ],
+  "\ud83e\udd91": [
+    "squid"
+  ],
+  "\ud83e\udd92": [
+    "giraffe"
+  ],
+  "\ud83e\udd93": [
+    "zebra"
+  ],
+  "\ud83e\udd94": [
+    "hedgehog"
+  ],
+  "\ud83e\udd95": [
+    "sauropod"
+  ],
+  "\ud83e\udd96": [
+    "t-rex",
+    "t-rex",
+    "t_rex"
+  ],
+  "\ud83e\udd97": [
+    "cricket"
+  ],
+  "\ud83e\udd98": [
+    "kangaroo"
+  ],
+  "\ud83e\udd99": [
+    "llama"
+  ],
+  "\ud83e\udd9a": [
+    "peacock"
+  ],
+  "\ud83e\udd9b": [
+    "hippopotamus"
+  ],
+  "\ud83e\udd9c": [
+    "parrot"
+  ],
+  "\ud83e\udd9d": [
+    "raccoon"
+  ],
+  "\ud83e\udd9e": [
+    "lobster"
+  ],
+  "\ud83e\udd9f": [
+    "mosquito"
+  ],
+  "\ud83e\udda0": [
+    "microbe"
+  ],
+  "\ud83e\udda1": [
+    "badger"
+  ],
+  "\ud83e\udda2": [
+    "swan"
+  ],
+  "\ud83e\udda3": [
+    "mammoth"
+  ],
+  "\ud83e\udda4": [
+    "dodo"
+  ],
+  "\ud83e\udda5": [
+    "sloth"
+  ],
+  "\ud83e\udda6": [
+    "otter"
+  ],
+  "\ud83e\udda7": [
+    "orangutan"
+  ],
+  "\ud83e\udda8": [
+    "skunk"
+  ],
+  "\ud83e\udda9": [
+    "flamingo"
+  ],
+  "\ud83e\uddaa": [
+    "oyster"
+  ],
+  "\ud83e\uddab": [
+    "beaver"
+  ],
+  "\ud83e\uddac": [
+    "bison"
+  ],
+  "\ud83e\uddad": [
+    "seal"
+  ],
+  "\ud83e\uddae": [
+    "guide_dog"
+  ],
+  "\ud83e\uddaf": [
+    "white_cane",
+    "probing_cane"
+  ],
+  "\ud83e\uddb0": [
+    "red_hair"
+  ],
+  "\ud83e\uddb1": [
+    "curly_hair"
+  ],
+  "\ud83e\uddb2": [
+    "bald"
+  ],
+  "\ud83e\uddb3": [
+    "white_hair"
+  ],
+  "\ud83e\uddb4": [
+    "bone"
+  ],
+  "\ud83e\uddb5": [
+    "leg"
+  ],
+  "\ud83e\uddb5\ud83c\udffb": [
+    "leg_light_skin_tone"
+  ],
+  "\ud83e\uddb5\ud83c\udffc": [
+    "leg_medium-light_skin_tone"
+  ],
+  "\ud83e\uddb5\ud83c\udffd": [
+    "leg_medium_skin_tone"
+  ],
+  "\ud83e\uddb5\ud83c\udffe": [
+    "leg_medium-dark_skin_tone"
+  ],
+  "\ud83e\uddb5\ud83c\udfff": [
+    "leg_dark_skin_tone"
+  ],
+  "\ud83e\uddb6": [
+    "foot"
+  ],
+  "\ud83e\uddb6\ud83c\udffb": [
+    "foot_light_skin_tone"
+  ],
+  "\ud83e\uddb6\ud83c\udffc": [
+    "foot_medium-light_skin_tone"
+  ],
+  "\ud83e\uddb6\ud83c\udffd": [
+    "foot_medium_skin_tone"
+  ],
+  "\ud83e\uddb6\ud83c\udffe": [
+    "foot_medium-dark_skin_tone"
+  ],
+  "\ud83e\uddb6\ud83c\udfff": [
+    "foot_dark_skin_tone"
+  ],
+  "\ud83e\uddb7": [
+    "tooth"
+  ],
+  "\ud83e\uddb8": [
+    "superhero"
+  ],
+  "\ud83e\uddb8\u200d\u2640": [
+    "woman_superhero",
+    "superhero_woman"
+  ],
+  "\ud83e\uddb8\u200d\u2640\ufe0f": [
+    "woman_superhero",
+    "superhero_woman"
+  ],
+  "\ud83e\uddb8\u200d\u2642": [
+    "man_superhero",
+    "superhero_man"
+  ],
+  "\ud83e\uddb8\u200d\u2642\ufe0f": [
+    "man_superhero",
+    "superhero_man"
+  ],
+  "\ud83e\uddb8\ud83c\udffb": [
+    "superhero_light_skin_tone"
+  ],
+  "\ud83e\uddb8\ud83c\udffb\u200d\u2640": [
+    "woman_superhero_light_skin_tone"
+  ],
+  "\ud83e\uddb8\ud83c\udffb\u200d\u2640\ufe0f": [
+    "woman_superhero_light_skin_tone"
+  ],
+  "\ud83e\uddb8\ud83c\udffb\u200d\u2642": [
+    "man_superhero_light_skin_tone"
+  ],
+  "\ud83e\uddb8\ud83c\udffb\u200d\u2642\ufe0f": [
+    "man_superhero_light_skin_tone"
+  ],
+  "\ud83e\uddb8\ud83c\udffc": [
+    "superhero_medium-light_skin_tone"
+  ],
+  "\ud83e\uddb8\ud83c\udffc\u200d\u2640": [
+    "woman_superhero_medium-light_skin_tone"
+  ],
+  "\ud83e\uddb8\ud83c\udffc\u200d\u2640\ufe0f": [
+    "woman_superhero_medium-light_skin_tone"
+  ],
+  "\ud83e\uddb8\ud83c\udffc\u200d\u2642": [
+    "man_superhero_medium-light_skin_tone"
+  ],
+  "\ud83e\uddb8\ud83c\udffc\u200d\u2642\ufe0f": [
+    "man_superhero_medium-light_skin_tone"
+  ],
+  "\ud83e\uddb8\ud83c\udffd": [
+    "superhero_medium_skin_tone"
+  ],
+  "\ud83e\uddb8\ud83c\udffd\u200d\u2640": [
+    "woman_superhero_medium_skin_tone"
+  ],
+  "\ud83e\uddb8\ud83c\udffd\u200d\u2640\ufe0f": [
+    "woman_superhero_medium_skin_tone"
+  ],
+  "\ud83e\uddb8\ud83c\udffd\u200d\u2642": [
+    "man_superhero_medium_skin_tone"
+  ],
+  "\ud83e\uddb8\ud83c\udffd\u200d\u2642\ufe0f": [
+    "man_superhero_medium_skin_tone"
+  ],
+  "\ud83e\uddb8\ud83c\udffe": [
+    "superhero_medium-dark_skin_tone"
+  ],
+  "\ud83e\uddb8\ud83c\udffe\u200d\u2640": [
+    "woman_superhero_medium-dark_skin_tone"
+  ],
+  "\ud83e\uddb8\ud83c\udffe\u200d\u2640\ufe0f": [
+    "woman_superhero_medium-dark_skin_tone"
+  ],
+  "\ud83e\uddb8\ud83c\udffe\u200d\u2642": [
+    "man_superhero_medium-dark_skin_tone"
+  ],
+  "\ud83e\uddb8\ud83c\udffe\u200d\u2642\ufe0f": [
+    "man_superhero_medium-dark_skin_tone"
+  ],
+  "\ud83e\uddb8\ud83c\udfff": [
+    "superhero_dark_skin_tone"
+  ],
+  "\ud83e\uddb8\ud83c\udfff\u200d\u2640": [
+    "woman_superhero_dark_skin_tone"
+  ],
+  "\ud83e\uddb8\ud83c\udfff\u200d\u2640\ufe0f": [
+    "woman_superhero_dark_skin_tone"
+  ],
+  "\ud83e\uddb8\ud83c\udfff\u200d\u2642": [
+    "man_superhero_dark_skin_tone"
+  ],
+  "\ud83e\uddb8\ud83c\udfff\u200d\u2642\ufe0f": [
+    "man_superhero_dark_skin_tone"
+  ],
+  "\ud83e\uddb9": [
+    "supervillain"
+  ],
+  "\ud83e\uddb9\u200d\u2640": [
+    "woman_supervillain",
+    "supervillain_woman"
+  ],
+  "\ud83e\uddb9\u200d\u2640\ufe0f": [
+    "woman_supervillain",
+    "supervillain_woman"
+  ],
+  "\ud83e\uddb9\u200d\u2642": [
+    "man_supervillain",
+    "supervillain_man"
+  ],
+  "\ud83e\uddb9\u200d\u2642\ufe0f": [
+    "man_supervillain",
+    "supervillain_man"
+  ],
+  "\ud83e\uddb9\ud83c\udffb": [
+    "supervillain_light_skin_tone"
+  ],
+  "\ud83e\uddb9\ud83c\udffb\u200d\u2640": [
+    "woman_supervillain_light_skin_tone"
+  ],
+  "\ud83e\uddb9\ud83c\udffb\u200d\u2640\ufe0f": [
+    "woman_supervillain_light_skin_tone"
+  ],
+  "\ud83e\uddb9\ud83c\udffb\u200d\u2642": [
+    "man_supervillain_light_skin_tone"
+  ],
+  "\ud83e\uddb9\ud83c\udffb\u200d\u2642\ufe0f": [
+    "man_supervillain_light_skin_tone"
+  ],
+  "\ud83e\uddb9\ud83c\udffc": [
+    "supervillain_medium-light_skin_tone"
+  ],
+  "\ud83e\uddb9\ud83c\udffc\u200d\u2640": [
+    "woman_supervillain_medium-light_skin_tone"
+  ],
+  "\ud83e\uddb9\ud83c\udffc\u200d\u2640\ufe0f": [
+    "woman_supervillain_medium-light_skin_tone"
+  ],
+  "\ud83e\uddb9\ud83c\udffc\u200d\u2642": [
+    "man_supervillain_medium-light_skin_tone"
+  ],
+  "\ud83e\uddb9\ud83c\udffc\u200d\u2642\ufe0f": [
+    "man_supervillain_medium-light_skin_tone"
+  ],
+  "\ud83e\uddb9\ud83c\udffd": [
+    "supervillain_medium_skin_tone"
+  ],
+  "\ud83e\uddb9\ud83c\udffd\u200d\u2640": [
+    "woman_supervillain_medium_skin_tone"
+  ],
+  "\ud83e\uddb9\ud83c\udffd\u200d\u2640\ufe0f": [
+    "woman_supervillain_medium_skin_tone"
+  ],
+  "\ud83e\uddb9\ud83c\udffd\u200d\u2642": [
+    "man_supervillain_medium_skin_tone"
+  ],
+  "\ud83e\uddb9\ud83c\udffd\u200d\u2642\ufe0f": [
+    "man_supervillain_medium_skin_tone"
+  ],
+  "\ud83e\uddb9\ud83c\udffe": [
+    "supervillain_medium-dark_skin_tone"
+  ],
+  "\ud83e\uddb9\ud83c\udffe\u200d\u2640": [
+    "woman_supervillain_medium-dark_skin_tone"
+  ],
+  "\ud83e\uddb9\ud83c\udffe\u200d\u2640\ufe0f": [
+    "woman_supervillain_medium-dark_skin_tone"
+  ],
+  "\ud83e\uddb9\ud83c\udffe\u200d\u2642": [
+    "man_supervillain_medium-dark_skin_tone"
+  ],
+  "\ud83e\uddb9\ud83c\udffe\u200d\u2642\ufe0f": [
+    "man_supervillain_medium-dark_skin_tone"
+  ],
+  "\ud83e\uddb9\ud83c\udfff": [
+    "supervillain_dark_skin_tone"
+  ],
+  "\ud83e\uddb9\ud83c\udfff\u200d\u2640": [
+    "woman_supervillain_dark_skin_tone"
+  ],
+  "\ud83e\uddb9\ud83c\udfff\u200d\u2640\ufe0f": [
+    "woman_supervillain_dark_skin_tone"
+  ],
+  "\ud83e\uddb9\ud83c\udfff\u200d\u2642": [
+    "man_supervillain_dark_skin_tone"
+  ],
+  "\ud83e\uddb9\ud83c\udfff\u200d\u2642\ufe0f": [
+    "man_supervillain_dark_skin_tone"
+  ],
+  "\ud83e\uddba": [
+    "safety_vest"
+  ],
+  "\ud83e\uddbb": [
+    "ear_with_hearing_aid"
+  ],
+  "\ud83e\uddbb\ud83c\udffb": [
+    "ear_with_hearing_aid_light_skin_tone"
+  ],
+  "\ud83e\uddbb\ud83c\udffc": [
+    "ear_with_hearing_aid_medium-light_skin_tone"
+  ],
+  "\ud83e\uddbb\ud83c\udffd": [
+    "ear_with_hearing_aid_medium_skin_tone"
+  ],
+  "\ud83e\uddbb\ud83c\udffe": [
+    "ear_with_hearing_aid_medium-dark_skin_tone"
+  ],
+  "\ud83e\uddbb\ud83c\udfff": [
+    "ear_with_hearing_aid_dark_skin_tone"
+  ],
+  "\ud83e\uddbc": [
+    "motorized_wheelchair"
+  ],
+  "\ud83e\uddbd": [
+    "manual_wheelchair"
+  ],
+  "\ud83e\uddbe": [
+    "mechanical_arm"
+  ],
+  "\ud83e\uddbf": [
+    "mechanical_leg"
+  ],
+  "\ud83e\uddc0": [
+    "cheese_wedge",
+    "cheese"
+  ],
+  "\ud83e\uddc1": [
+    "cupcake"
+  ],
+  "\ud83e\uddc2": [
+    "salt"
+  ],
+  "\ud83e\uddc3": [
+    "beverage_box"
+  ],
+  "\ud83e\uddc4": [
+    "garlic"
+  ],
+  "\ud83e\uddc5": [
+    "onion"
+  ],
+  "\ud83e\uddc6": [
+    "falafel"
+  ],
+  "\ud83e\uddc7": [
+    "waffle"
+  ],
+  "\ud83e\uddc8": [
+    "butter"
+  ],
+  "\ud83e\uddc9": [
+    "mate"
+  ],
+  "\ud83e\uddca": [
+    "ice",
+    "ice_cube"
+  ],
+  "\ud83e\uddcb": [
+    "bubble_tea"
+  ],
+  "\ud83e\uddcc": [
+    "troll"
+  ],
+  "\ud83e\uddcd": [
+    "person_standing",
+    "standing_person"
+  ],
+  "\ud83e\uddcd\u200d\u2640": [
+    "woman_standing",
+    "standing_woman"
+  ],
+  "\ud83e\uddcd\u200d\u2640\ufe0f": [
+    "woman_standing",
+    "standing_woman"
+  ],
+  "\ud83e\uddcd\u200d\u2642": [
+    "man_standing",
+    "standing_man"
+  ],
+  "\ud83e\uddcd\u200d\u2642\ufe0f": [
+    "man_standing",
+    "standing_man"
+  ],
+  "\ud83e\uddcd\ud83c\udffb": [
+    "person_standing_light_skin_tone"
+  ],
+  "\ud83e\uddcd\ud83c\udffb\u200d\u2640": [
+    "woman_standing_light_skin_tone"
+  ],
+  "\ud83e\uddcd\ud83c\udffb\u200d\u2640\ufe0f": [
+    "woman_standing_light_skin_tone"
+  ],
+  "\ud83e\uddcd\ud83c\udffb\u200d\u2642": [
+    "man_standing_light_skin_tone"
+  ],
+  "\ud83e\uddcd\ud83c\udffb\u200d\u2642\ufe0f": [
+    "man_standing_light_skin_tone"
+  ],
+  "\ud83e\uddcd\ud83c\udffc": [
+    "person_standing_medium-light_skin_tone"
+  ],
+  "\ud83e\uddcd\ud83c\udffc\u200d\u2640": [
+    "woman_standing_medium-light_skin_tone"
+  ],
+  "\ud83e\uddcd\ud83c\udffc\u200d\u2640\ufe0f": [
+    "woman_standing_medium-light_skin_tone"
+  ],
+  "\ud83e\uddcd\ud83c\udffc\u200d\u2642": [
+    "man_standing_medium-light_skin_tone"
+  ],
+  "\ud83e\uddcd\ud83c\udffc\u200d\u2642\ufe0f": [
+    "man_standing_medium-light_skin_tone"
+  ],
+  "\ud83e\uddcd\ud83c\udffd": [
+    "person_standing_medium_skin_tone"
+  ],
+  "\ud83e\uddcd\ud83c\udffd\u200d\u2640": [
+    "woman_standing_medium_skin_tone"
+  ],
+  "\ud83e\uddcd\ud83c\udffd\u200d\u2640\ufe0f": [
+    "woman_standing_medium_skin_tone"
+  ],
+  "\ud83e\uddcd\ud83c\udffd\u200d\u2642": [
+    "man_standing_medium_skin_tone"
+  ],
+  "\ud83e\uddcd\ud83c\udffd\u200d\u2642\ufe0f": [
+    "man_standing_medium_skin_tone"
+  ],
+  "\ud83e\uddcd\ud83c\udffe": [
+    "person_standing_medium-dark_skin_tone"
+  ],
+  "\ud83e\uddcd\ud83c\udffe\u200d\u2640": [
+    "woman_standing_medium-dark_skin_tone"
+  ],
+  "\ud83e\uddcd\ud83c\udffe\u200d\u2640\ufe0f": [
+    "woman_standing_medium-dark_skin_tone"
+  ],
+  "\ud83e\uddcd\ud83c\udffe\u200d\u2642": [
+    "man_standing_medium-dark_skin_tone"
+  ],
+  "\ud83e\uddcd\ud83c\udffe\u200d\u2642\ufe0f": [
+    "man_standing_medium-dark_skin_tone"
+  ],
+  "\ud83e\uddcd\ud83c\udfff": [
+    "person_standing_dark_skin_tone"
+  ],
+  "\ud83e\uddcd\ud83c\udfff\u200d\u2640": [
+    "woman_standing_dark_skin_tone"
+  ],
+  "\ud83e\uddcd\ud83c\udfff\u200d\u2640\ufe0f": [
+    "woman_standing_dark_skin_tone"
+  ],
+  "\ud83e\uddcd\ud83c\udfff\u200d\u2642": [
+    "man_standing_dark_skin_tone"
+  ],
+  "\ud83e\uddcd\ud83c\udfff\u200d\u2642\ufe0f": [
+    "man_standing_dark_skin_tone"
+  ],
+  "\ud83e\uddce": [
+    "person_kneeling",
+    "kneeling_person"
+  ],
+  "\ud83e\uddce\u200d\u2640": [
+    "woman_kneeling",
+    "kneeling_woman"
+  ],
+  "\ud83e\uddce\u200d\u2640\u200d\u27a1": [
+    "woman_kneeling_facing_right"
+  ],
+  "\ud83e\uddce\u200d\u2640\u200d\u27a1\ufe0f": [
+    "woman_kneeling_facing_right"
+  ],
+  "\ud83e\uddce\u200d\u2640\ufe0f": [
+    "woman_kneeling",
+    "kneeling_woman"
+  ],
+  "\ud83e\uddce\u200d\u2640\ufe0f\u200d\u27a1": [
+    "woman_kneeling_facing_right"
+  ],
+  "\ud83e\uddce\u200d\u2640\ufe0f\u200d\u27a1\ufe0f": [
+    "woman_kneeling_facing_right"
+  ],
+  "\ud83e\uddce\u200d\u2642": [
+    "man_kneeling",
+    "kneeling_man"
+  ],
+  "\ud83e\uddce\u200d\u2642\u200d\u27a1": [
+    "man_kneeling_facing_right"
+  ],
+  "\ud83e\uddce\u200d\u2642\u200d\u27a1\ufe0f": [
+    "man_kneeling_facing_right"
+  ],
+  "\ud83e\uddce\u200d\u2642\ufe0f": [
+    "man_kneeling",
+    "kneeling_man"
+  ],
+  "\ud83e\uddce\u200d\u2642\ufe0f\u200d\u27a1": [
+    "man_kneeling_facing_right"
+  ],
+  "\ud83e\uddce\u200d\u2642\ufe0f\u200d\u27a1\ufe0f": [
+    "man_kneeling_facing_right"
+  ],
+  "\ud83e\uddce\u200d\u27a1": [
+    "person_kneeling_facing_right"
+  ],
+  "\ud83e\uddce\u200d\u27a1\ufe0f": [
+    "person_kneeling_facing_right"
+  ],
+  "\ud83e\uddce\ud83c\udffb": [
+    "person_kneeling_light_skin_tone"
+  ],
+  "\ud83e\uddce\ud83c\udffb\u200d\u2640": [
+    "woman_kneeling_light_skin_tone"
+  ],
+  "\ud83e\uddce\ud83c\udffb\u200d\u2640\u200d\u27a1": [
+    "woman_kneeling_facing_right_light_skin_tone"
+  ],
+  "\ud83e\uddce\ud83c\udffb\u200d\u2640\u200d\u27a1\ufe0f": [
+    "woman_kneeling_facing_right_light_skin_tone"
+  ],
+  "\ud83e\uddce\ud83c\udffb\u200d\u2640\ufe0f": [
+    "woman_kneeling_light_skin_tone"
+  ],
+  "\ud83e\uddce\ud83c\udffb\u200d\u2640\ufe0f\u200d\u27a1": [
+    "woman_kneeling_facing_right_light_skin_tone"
+  ],
+  "\ud83e\uddce\ud83c\udffb\u200d\u2640\ufe0f\u200d\u27a1\ufe0f": [
+    "woman_kneeling_facing_right_light_skin_tone"
+  ],
+  "\ud83e\uddce\ud83c\udffb\u200d\u2642": [
+    "man_kneeling_light_skin_tone"
+  ],
+  "\ud83e\uddce\ud83c\udffb\u200d\u2642\u200d\u27a1": [
+    "man_kneeling_facing_right_light_skin_tone"
+  ],
+  "\ud83e\uddce\ud83c\udffb\u200d\u2642\u200d\u27a1\ufe0f": [
+    "man_kneeling_facing_right_light_skin_tone"
+  ],
+  "\ud83e\uddce\ud83c\udffb\u200d\u2642\ufe0f": [
+    "man_kneeling_light_skin_tone"
+  ],
+  "\ud83e\uddce\ud83c\udffb\u200d\u2642\ufe0f\u200d\u27a1": [
+    "man_kneeling_facing_right_light_skin_tone"
+  ],
+  "\ud83e\uddce\ud83c\udffb\u200d\u2642\ufe0f\u200d\u27a1\ufe0f": [
+    "man_kneeling_facing_right_light_skin_tone"
+  ],
+  "\ud83e\uddce\ud83c\udffb\u200d\u27a1": [
+    "person_kneeling_facing_right_light_skin_tone"
+  ],
+  "\ud83e\uddce\ud83c\udffb\u200d\u27a1\ufe0f": [
+    "person_kneeling_facing_right_light_skin_tone"
+  ],
+  "\ud83e\uddce\ud83c\udffc": [
+    "person_kneeling_medium-light_skin_tone"
+  ],
+  "\ud83e\uddce\ud83c\udffc\u200d\u2640": [
+    "woman_kneeling_medium-light_skin_tone"
+  ],
+  "\ud83e\uddce\ud83c\udffc\u200d\u2640\u200d\u27a1": [
+    "woman_kneeling_facing_right_medium-light_skin_tone"
+  ],
+  "\ud83e\uddce\ud83c\udffc\u200d\u2640\u200d\u27a1\ufe0f": [
+    "woman_kneeling_facing_right_medium-light_skin_tone"
+  ],
+  "\ud83e\uddce\ud83c\udffc\u200d\u2640\ufe0f": [
+    "woman_kneeling_medium-light_skin_tone"
+  ],
+  "\ud83e\uddce\ud83c\udffc\u200d\u2640\ufe0f\u200d\u27a1": [
+    "woman_kneeling_facing_right_medium-light_skin_tone"
+  ],
+  "\ud83e\uddce\ud83c\udffc\u200d\u2640\ufe0f\u200d\u27a1\ufe0f": [
+    "woman_kneeling_facing_right_medium-light_skin_tone"
+  ],
+  "\ud83e\uddce\ud83c\udffc\u200d\u2642": [
+    "man_kneeling_medium-light_skin_tone"
+  ],
+  "\ud83e\uddce\ud83c\udffc\u200d\u2642\u200d\u27a1": [
+    "man_kneeling_facing_right_medium-light_skin_tone"
+  ],
+  "\ud83e\uddce\ud83c\udffc\u200d\u2642\u200d\u27a1\ufe0f": [
+    "man_kneeling_facing_right_medium-light_skin_tone"
+  ],
+  "\ud83e\uddce\ud83c\udffc\u200d\u2642\ufe0f": [
+    "man_kneeling_medium-light_skin_tone"
+  ],
+  "\ud83e\uddce\ud83c\udffc\u200d\u2642\ufe0f\u200d\u27a1": [
+    "man_kneeling_facing_right_medium-light_skin_tone"
+  ],
+  "\ud83e\uddce\ud83c\udffc\u200d\u2642\ufe0f\u200d\u27a1\ufe0f": [
+    "man_kneeling_facing_right_medium-light_skin_tone"
+  ],
+  "\ud83e\uddce\ud83c\udffc\u200d\u27a1": [
+    "person_kneeling_facing_right_medium-light_skin_tone"
+  ],
+  "\ud83e\uddce\ud83c\udffc\u200d\u27a1\ufe0f": [
+    "person_kneeling_facing_right_medium-light_skin_tone"
+  ],
+  "\ud83e\uddce\ud83c\udffd": [
+    "person_kneeling_medium_skin_tone"
+  ],
+  "\ud83e\uddce\ud83c\udffd\u200d\u2640": [
+    "woman_kneeling_medium_skin_tone"
+  ],
+  "\ud83e\uddce\ud83c\udffd\u200d\u2640\u200d\u27a1": [
+    "woman_kneeling_facing_right_medium_skin_tone"
+  ],
+  "\ud83e\uddce\ud83c\udffd\u200d\u2640\u200d\u27a1\ufe0f": [
+    "woman_kneeling_facing_right_medium_skin_tone"
+  ],
+  "\ud83e\uddce\ud83c\udffd\u200d\u2640\ufe0f": [
+    "woman_kneeling_medium_skin_tone"
+  ],
+  "\ud83e\uddce\ud83c\udffd\u200d\u2640\ufe0f\u200d\u27a1": [
+    "woman_kneeling_facing_right_medium_skin_tone"
+  ],
+  "\ud83e\uddce\ud83c\udffd\u200d\u2640\ufe0f\u200d\u27a1\ufe0f": [
+    "woman_kneeling_facing_right_medium_skin_tone"
+  ],
+  "\ud83e\uddce\ud83c\udffd\u200d\u2642": [
+    "man_kneeling_medium_skin_tone"
+  ],
+  "\ud83e\uddce\ud83c\udffd\u200d\u2642\u200d\u27a1": [
+    "man_kneeling_facing_right_medium_skin_tone"
+  ],
+  "\ud83e\uddce\ud83c\udffd\u200d\u2642\u200d\u27a1\ufe0f": [
+    "man_kneeling_facing_right_medium_skin_tone"
+  ],
+  "\ud83e\uddce\ud83c\udffd\u200d\u2642\ufe0f": [
+    "man_kneeling_medium_skin_tone"
+  ],
+  "\ud83e\uddce\ud83c\udffd\u200d\u2642\ufe0f\u200d\u27a1": [
+    "man_kneeling_facing_right_medium_skin_tone"
+  ],
+  "\ud83e\uddce\ud83c\udffd\u200d\u2642\ufe0f\u200d\u27a1\ufe0f": [
+    "man_kneeling_facing_right_medium_skin_tone"
+  ],
+  "\ud83e\uddce\ud83c\udffd\u200d\u27a1": [
+    "person_kneeling_facing_right_medium_skin_tone"
+  ],
+  "\ud83e\uddce\ud83c\udffd\u200d\u27a1\ufe0f": [
+    "person_kneeling_facing_right_medium_skin_tone"
+  ],
+  "\ud83e\uddce\ud83c\udffe": [
+    "person_kneeling_medium-dark_skin_tone"
+  ],
+  "\ud83e\uddce\ud83c\udffe\u200d\u2640": [
+    "woman_kneeling_medium-dark_skin_tone"
+  ],
+  "\ud83e\uddce\ud83c\udffe\u200d\u2640\u200d\u27a1": [
+    "woman_kneeling_facing_right_medium-dark_skin_tone"
+  ],
+  "\ud83e\uddce\ud83c\udffe\u200d\u2640\u200d\u27a1\ufe0f": [
+    "woman_kneeling_facing_right_medium-dark_skin_tone"
+  ],
+  "\ud83e\uddce\ud83c\udffe\u200d\u2640\ufe0f": [
+    "woman_kneeling_medium-dark_skin_tone"
+  ],
+  "\ud83e\uddce\ud83c\udffe\u200d\u2640\ufe0f\u200d\u27a1": [
+    "woman_kneeling_facing_right_medium-dark_skin_tone"
+  ],
+  "\ud83e\uddce\ud83c\udffe\u200d\u2640\ufe0f\u200d\u27a1\ufe0f": [
+    "woman_kneeling_facing_right_medium-dark_skin_tone"
+  ],
+  "\ud83e\uddce\ud83c\udffe\u200d\u2642": [
+    "man_kneeling_medium-dark_skin_tone"
+  ],
+  "\ud83e\uddce\ud83c\udffe\u200d\u2642\u200d\u27a1": [
+    "man_kneeling_facing_right_medium-dark_skin_tone"
+  ],
+  "\ud83e\uddce\ud83c\udffe\u200d\u2642\u200d\u27a1\ufe0f": [
+    "man_kneeling_facing_right_medium-dark_skin_tone"
+  ],
+  "\ud83e\uddce\ud83c\udffe\u200d\u2642\ufe0f": [
+    "man_kneeling_medium-dark_skin_tone"
+  ],
+  "\ud83e\uddce\ud83c\udffe\u200d\u2642\ufe0f\u200d\u27a1": [
+    "man_kneeling_facing_right_medium-dark_skin_tone"
+  ],
+  "\ud83e\uddce\ud83c\udffe\u200d\u2642\ufe0f\u200d\u27a1\ufe0f": [
+    "man_kneeling_facing_right_medium-dark_skin_tone"
+  ],
+  "\ud83e\uddce\ud83c\udffe\u200d\u27a1": [
+    "person_kneeling_facing_right_medium-dark_skin_tone"
+  ],
+  "\ud83e\uddce\ud83c\udffe\u200d\u27a1\ufe0f": [
+    "person_kneeling_facing_right_medium-dark_skin_tone"
+  ],
+  "\ud83e\uddce\ud83c\udfff": [
+    "person_kneeling_dark_skin_tone"
+  ],
+  "\ud83e\uddce\ud83c\udfff\u200d\u2640": [
+    "woman_kneeling_dark_skin_tone"
+  ],
+  "\ud83e\uddce\ud83c\udfff\u200d\u2640\u200d\u27a1": [
+    "woman_kneeling_facing_right_dark_skin_tone"
+  ],
+  "\ud83e\uddce\ud83c\udfff\u200d\u2640\u200d\u27a1\ufe0f": [
+    "woman_kneeling_facing_right_dark_skin_tone"
+  ],
+  "\ud83e\uddce\ud83c\udfff\u200d\u2640\ufe0f": [
+    "woman_kneeling_dark_skin_tone"
+  ],
+  "\ud83e\uddce\ud83c\udfff\u200d\u2640\ufe0f\u200d\u27a1": [
+    "woman_kneeling_facing_right_dark_skin_tone"
+  ],
+  "\ud83e\uddce\ud83c\udfff\u200d\u2640\ufe0f\u200d\u27a1\ufe0f": [
+    "woman_kneeling_facing_right_dark_skin_tone"
+  ],
+  "\ud83e\uddce\ud83c\udfff\u200d\u2642": [
+    "man_kneeling_dark_skin_tone"
+  ],
+  "\ud83e\uddce\ud83c\udfff\u200d\u2642\u200d\u27a1": [
+    "man_kneeling_facing_right_dark_skin_tone"
+  ],
+  "\ud83e\uddce\ud83c\udfff\u200d\u2642\u200d\u27a1\ufe0f": [
+    "man_kneeling_facing_right_dark_skin_tone"
+  ],
+  "\ud83e\uddce\ud83c\udfff\u200d\u2642\ufe0f": [
+    "man_kneeling_dark_skin_tone"
+  ],
+  "\ud83e\uddce\ud83c\udfff\u200d\u2642\ufe0f\u200d\u27a1": [
+    "man_kneeling_facing_right_dark_skin_tone"
+  ],
+  "\ud83e\uddce\ud83c\udfff\u200d\u2642\ufe0f\u200d\u27a1\ufe0f": [
+    "man_kneeling_facing_right_dark_skin_tone"
+  ],
+  "\ud83e\uddce\ud83c\udfff\u200d\u27a1": [
+    "person_kneeling_facing_right_dark_skin_tone"
+  ],
+  "\ud83e\uddce\ud83c\udfff\u200d\u27a1\ufe0f": [
+    "person_kneeling_facing_right_dark_skin_tone"
+  ],
+  "\ud83e\uddcf": [
+    "deaf_person"
+  ],
+  "\ud83e\uddcf\u200d\u2640": [
+    "deaf_woman"
+  ],
+  "\ud83e\uddcf\u200d\u2640\ufe0f": [
+    "deaf_woman"
+  ],
+  "\ud83e\uddcf\u200d\u2642": [
+    "deaf_man"
+  ],
+  "\ud83e\uddcf\u200d\u2642\ufe0f": [
+    "deaf_man"
+  ],
+  "\ud83e\uddcf\ud83c\udffb": [
+    "deaf_person_light_skin_tone"
+  ],
+  "\ud83e\uddcf\ud83c\udffb\u200d\u2640": [
+    "deaf_woman_light_skin_tone"
+  ],
+  "\ud83e\uddcf\ud83c\udffb\u200d\u2640\ufe0f": [
+    "deaf_woman_light_skin_tone"
+  ],
+  "\ud83e\uddcf\ud83c\udffb\u200d\u2642": [
+    "deaf_man_light_skin_tone"
+  ],
+  "\ud83e\uddcf\ud83c\udffb\u200d\u2642\ufe0f": [
+    "deaf_man_light_skin_tone"
+  ],
+  "\ud83e\uddcf\ud83c\udffc": [
+    "deaf_person_medium-light_skin_tone"
+  ],
+  "\ud83e\uddcf\ud83c\udffc\u200d\u2640": [
+    "deaf_woman_medium-light_skin_tone"
+  ],
+  "\ud83e\uddcf\ud83c\udffc\u200d\u2640\ufe0f": [
+    "deaf_woman_medium-light_skin_tone"
+  ],
+  "\ud83e\uddcf\ud83c\udffc\u200d\u2642": [
+    "deaf_man_medium-light_skin_tone"
+  ],
+  "\ud83e\uddcf\ud83c\udffc\u200d\u2642\ufe0f": [
+    "deaf_man_medium-light_skin_tone"
+  ],
+  "\ud83e\uddcf\ud83c\udffd": [
+    "deaf_person_medium_skin_tone"
+  ],
+  "\ud83e\uddcf\ud83c\udffd\u200d\u2640": [
+    "deaf_woman_medium_skin_tone"
+  ],
+  "\ud83e\uddcf\ud83c\udffd\u200d\u2640\ufe0f": [
+    "deaf_woman_medium_skin_tone"
+  ],
+  "\ud83e\uddcf\ud83c\udffd\u200d\u2642": [
+    "deaf_man_medium_skin_tone"
+  ],
+  "\ud83e\uddcf\ud83c\udffd\u200d\u2642\ufe0f": [
+    "deaf_man_medium_skin_tone"
+  ],
+  "\ud83e\uddcf\ud83c\udffe": [
+    "deaf_person_medium-dark_skin_tone"
+  ],
+  "\ud83e\uddcf\ud83c\udffe\u200d\u2640": [
+    "deaf_woman_medium-dark_skin_tone"
+  ],
+  "\ud83e\uddcf\ud83c\udffe\u200d\u2640\ufe0f": [
+    "deaf_woman_medium-dark_skin_tone"
+  ],
+  "\ud83e\uddcf\ud83c\udffe\u200d\u2642": [
+    "deaf_man_medium-dark_skin_tone"
+  ],
+  "\ud83e\uddcf\ud83c\udffe\u200d\u2642\ufe0f": [
+    "deaf_man_medium-dark_skin_tone"
+  ],
+  "\ud83e\uddcf\ud83c\udfff": [
+    "deaf_person_dark_skin_tone"
+  ],
+  "\ud83e\uddcf\ud83c\udfff\u200d\u2640": [
+    "deaf_woman_dark_skin_tone"
+  ],
+  "\ud83e\uddcf\ud83c\udfff\u200d\u2640\ufe0f": [
+    "deaf_woman_dark_skin_tone"
+  ],
+  "\ud83e\uddcf\ud83c\udfff\u200d\u2642": [
+    "deaf_man_dark_skin_tone"
+  ],
+  "\ud83e\uddcf\ud83c\udfff\u200d\u2642\ufe0f": [
+    "deaf_man_dark_skin_tone"
+  ],
+  "\ud83e\uddd0": [
+    "face_with_monocle",
+    "monocle_face"
+  ],
+  "\ud83e\uddd1": [
+    "person",
+    "adult"
+  ],
+  "\ud83e\uddd1\u200d\u2695": [
+    "health_worker"
+  ],
+  "\ud83e\uddd1\u200d\u2695\ufe0f": [
+    "health_worker"
+  ],
+  "\ud83e\uddd1\u200d\u2696": [
+    "judge"
+  ],
+  "\ud83e\uddd1\u200d\u2696\ufe0f": [
+    "judge"
+  ],
+  "\ud83e\uddd1\u200d\u2708": [
+    "pilot"
+  ],
+  "\ud83e\uddd1\u200d\u2708\ufe0f": [
+    "pilot"
+  ],
+  "\ud83e\uddd1\u200d\ud83c\udf3e": [
+    "farmer"
+  ],
+  "\ud83e\uddd1\u200d\ud83c\udf73": [
+    "cook"
+  ],
+  "\ud83e\uddd1\u200d\ud83c\udf7c": [
+    "person_feeding_baby"
+  ],
+  "\ud83e\uddd1\u200d\ud83c\udf84": [
+    "mx_claus"
+  ],
+  "\ud83e\uddd1\u200d\ud83c\udf93": [
+    "student"
+  ],
+  "\ud83e\uddd1\u200d\ud83c\udfa4": [
+    "singer"
+  ],
+  "\ud83e\uddd1\u200d\ud83c\udfa8": [
+    "artist"
+  ],
+  "\ud83e\uddd1\u200d\ud83c\udfeb": [
+    "teacher"
+  ],
+  "\ud83e\uddd1\u200d\ud83c\udfed": [
+    "factory_worker"
+  ],
+  "\ud83e\uddd1\u200d\ud83d\udcbb": [
+    "technologist"
+  ],
+  "\ud83e\uddd1\u200d\ud83d\udcbc": [
+    "office_worker"
+  ],
+  "\ud83e\uddd1\u200d\ud83d\udd27": [
+    "mechanic"
+  ],
+  "\ud83e\uddd1\u200d\ud83d\udd2c": [
+    "scientist"
+  ],
+  "\ud83e\uddd1\u200d\ud83d\ude80": [
+    "astronaut"
+  ],
+  "\ud83e\uddd1\u200d\ud83d\ude92": [
+    "firefighter"
+  ],
+  "\ud83e\uddd1\u200d\ud83e\udd1d\u200d\ud83e\uddd1": [
+    "people_holding_hands"
+  ],
+  "\ud83e\uddd1\u200d\ud83e\uddaf": [
+    "person_with_white_cane",
+    "person_with_probing_cane"
+  ],
+  "\ud83e\uddd1\u200d\ud83e\uddaf\u200d\u27a1": [
+    "person_with_white_cane_facing_right"
+  ],
+  "\ud83e\uddd1\u200d\ud83e\uddaf\u200d\u27a1\ufe0f": [
+    "person_with_white_cane_facing_right"
+  ],
+  "\ud83e\uddd1\u200d\ud83e\uddb0": [
+    "person_red_hair"
+  ],
+  "\ud83e\uddd1\u200d\ud83e\uddb1": [
+    "person_curly_hair"
+  ],
+  "\ud83e\uddd1\u200d\ud83e\uddb2": [
+    "person_bald"
+  ],
+  "\ud83e\uddd1\u200d\ud83e\uddb3": [
+    "person_white_hair"
+  ],
+  "\ud83e\uddd1\u200d\ud83e\uddbc": [
+    "person_in_motorized_wheelchair"
+  ],
+  "\ud83e\uddd1\u200d\ud83e\uddbc\u200d\u27a1": [
+    "person_in_motorized_wheelchair_facing_right"
+  ],
+  "\ud83e\uddd1\u200d\ud83e\uddbc\u200d\u27a1\ufe0f": [
+    "person_in_motorized_wheelchair_facing_right"
+  ],
+  "\ud83e\uddd1\u200d\ud83e\uddbd": [
+    "person_in_manual_wheelchair"
+  ],
+  "\ud83e\uddd1\u200d\ud83e\uddbd\u200d\u27a1": [
+    "person_in_manual_wheelchair_facing_right"
+  ],
+  "\ud83e\uddd1\u200d\ud83e\uddbd\u200d\u27a1\ufe0f": [
+    "person_in_manual_wheelchair_facing_right"
+  ],
+  "\ud83e\uddd1\u200d\ud83e\uddd1\u200d\ud83e\uddd2": [
+    "family_adult_adult_child"
+  ],
+  "\ud83e\uddd1\u200d\ud83e\uddd1\u200d\ud83e\uddd2\u200d\ud83e\uddd2": [
+    "family_adult_adult_child_child"
+  ],
+  "\ud83e\uddd1\u200d\ud83e\uddd2": [
+    "family_adult_child"
+  ],
+  "\ud83e\uddd1\u200d\ud83e\uddd2\u200d\ud83e\uddd2": [
+    "family_adult_child_child"
+  ],
+  "\ud83e\uddd1\ud83c\udffb": [
+    "person_light_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffb\u200d\u2695": [
+    "health_worker_light_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffb\u200d\u2695\ufe0f": [
+    "health_worker_light_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffb\u200d\u2696": [
+    "judge_light_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffb\u200d\u2696\ufe0f": [
+    "judge_light_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffb\u200d\u2708": [
+    "pilot_light_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffb\u200d\u2708\ufe0f": [
+    "pilot_light_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffb\u200d\u2764\u200d\ud83d\udc8b\u200d\ud83e\uddd1\ud83c\udffc": [
+    "kiss_person_person_light_skin_tone_medium-light_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffb\u200d\u2764\u200d\ud83d\udc8b\u200d\ud83e\uddd1\ud83c\udffd": [
+    "kiss_person_person_light_skin_tone_medium_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffb\u200d\u2764\u200d\ud83d\udc8b\u200d\ud83e\uddd1\ud83c\udffe": [
+    "kiss_person_person_light_skin_tone_medium-dark_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffb\u200d\u2764\u200d\ud83d\udc8b\u200d\ud83e\uddd1\ud83c\udfff": [
+    "kiss_person_person_light_skin_tone_dark_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffb\u200d\u2764\u200d\ud83e\uddd1\ud83c\udffc": [
+    "couple_with_heart_person_person_light_skin_tone_medium-light_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffb\u200d\u2764\u200d\ud83e\uddd1\ud83c\udffd": [
+    "couple_with_heart_person_person_light_skin_tone_medium_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffb\u200d\u2764\u200d\ud83e\uddd1\ud83c\udffe": [
+    "couple_with_heart_person_person_light_skin_tone_medium-dark_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffb\u200d\u2764\u200d\ud83e\uddd1\ud83c\udfff": [
+    "couple_with_heart_person_person_light_skin_tone_dark_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffb\u200d\u2764\ufe0f\u200d\ud83d\udc8b\u200d\ud83e\uddd1\ud83c\udffc": [
+    "kiss_person_person_light_skin_tone_medium-light_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffb\u200d\u2764\ufe0f\u200d\ud83d\udc8b\u200d\ud83e\uddd1\ud83c\udffd": [
+    "kiss_person_person_light_skin_tone_medium_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffb\u200d\u2764\ufe0f\u200d\ud83d\udc8b\u200d\ud83e\uddd1\ud83c\udffe": [
+    "kiss_person_person_light_skin_tone_medium-dark_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffb\u200d\u2764\ufe0f\u200d\ud83d\udc8b\u200d\ud83e\uddd1\ud83c\udfff": [
+    "kiss_person_person_light_skin_tone_dark_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffb\u200d\u2764\ufe0f\u200d\ud83e\uddd1\ud83c\udffc": [
+    "couple_with_heart_person_person_light_skin_tone_medium-light_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffb\u200d\u2764\ufe0f\u200d\ud83e\uddd1\ud83c\udffd": [
+    "couple_with_heart_person_person_light_skin_tone_medium_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffb\u200d\u2764\ufe0f\u200d\ud83e\uddd1\ud83c\udffe": [
+    "couple_with_heart_person_person_light_skin_tone_medium-dark_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffb\u200d\u2764\ufe0f\u200d\ud83e\uddd1\ud83c\udfff": [
+    "couple_with_heart_person_person_light_skin_tone_dark_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffb\u200d\ud83c\udf3e": [
+    "farmer_light_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffb\u200d\ud83c\udf73": [
+    "cook_light_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffb\u200d\ud83c\udf7c": [
+    "person_feeding_baby_light_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffb\u200d\ud83c\udf84": [
+    "mx_claus_light_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffb\u200d\ud83c\udf93": [
+    "student_light_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffb\u200d\ud83c\udfa4": [
+    "singer_light_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffb\u200d\ud83c\udfa8": [
+    "artist_light_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffb\u200d\ud83c\udfeb": [
+    "teacher_light_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffb\u200d\ud83c\udfed": [
+    "factory_worker_light_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffb\u200d\ud83d\udcbb": [
+    "technologist_light_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffb\u200d\ud83d\udcbc": [
+    "office_worker_light_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffb\u200d\ud83d\udd27": [
+    "mechanic_light_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffb\u200d\ud83d\udd2c": [
+    "scientist_light_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffb\u200d\ud83d\ude80": [
+    "astronaut_light_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffb\u200d\ud83d\ude92": [
+    "firefighter_light_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffb\u200d\ud83e\udd1d\u200d\ud83e\uddd1\ud83c\udffb": [
+    "people_holding_hands_light_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffb\u200d\ud83e\udd1d\u200d\ud83e\uddd1\ud83c\udffc": [
+    "people_holding_hands_light_skin_tone_medium-light_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffb\u200d\ud83e\udd1d\u200d\ud83e\uddd1\ud83c\udffd": [
+    "people_holding_hands_light_skin_tone_medium_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffb\u200d\ud83e\udd1d\u200d\ud83e\uddd1\ud83c\udffe": [
+    "people_holding_hands_light_skin_tone_medium-dark_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffb\u200d\ud83e\udd1d\u200d\ud83e\uddd1\ud83c\udfff": [
+    "people_holding_hands_light_skin_tone_dark_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffb\u200d\ud83e\uddaf": [
+    "person_with_white_cane_light_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffb\u200d\ud83e\uddaf\u200d\u27a1": [
+    "person_with_white_cane_facing_right_light_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffb\u200d\ud83e\uddaf\u200d\u27a1\ufe0f": [
+    "person_with_white_cane_facing_right_light_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffb\u200d\ud83e\uddb0": [
+    "person_light_skin_tone_red_hair"
+  ],
+  "\ud83e\uddd1\ud83c\udffb\u200d\ud83e\uddb1": [
+    "person_light_skin_tone_curly_hair"
+  ],
+  "\ud83e\uddd1\ud83c\udffb\u200d\ud83e\uddb2": [
+    "person_light_skin_tone_bald"
+  ],
+  "\ud83e\uddd1\ud83c\udffb\u200d\ud83e\uddb3": [
+    "person_light_skin_tone_white_hair"
+  ],
+  "\ud83e\uddd1\ud83c\udffb\u200d\ud83e\uddbc": [
+    "person_in_motorized_wheelchair_light_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffb\u200d\ud83e\uddbc\u200d\u27a1": [
+    "person_in_motorized_wheelchair_facing_right_light_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffb\u200d\ud83e\uddbc\u200d\u27a1\ufe0f": [
+    "person_in_motorized_wheelchair_facing_right_light_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffb\u200d\ud83e\uddbd": [
+    "person_in_manual_wheelchair_light_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffb\u200d\ud83e\uddbd\u200d\u27a1": [
+    "person_in_manual_wheelchair_facing_right_light_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffb\u200d\ud83e\uddbd\u200d\u27a1\ufe0f": [
+    "person_in_manual_wheelchair_facing_right_light_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffc": [
+    "person_medium-light_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffc\u200d\u2695": [
+    "health_worker_medium-light_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffc\u200d\u2695\ufe0f": [
+    "health_worker_medium-light_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffc\u200d\u2696": [
+    "judge_medium-light_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffc\u200d\u2696\ufe0f": [
+    "judge_medium-light_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffc\u200d\u2708": [
+    "pilot_medium-light_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffc\u200d\u2708\ufe0f": [
+    "pilot_medium-light_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffc\u200d\u2764\u200d\ud83d\udc8b\u200d\ud83e\uddd1\ud83c\udffb": [
+    "kiss_person_person_medium-light_skin_tone_light_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffc\u200d\u2764\u200d\ud83d\udc8b\u200d\ud83e\uddd1\ud83c\udffd": [
+    "kiss_person_person_medium-light_skin_tone_medium_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffc\u200d\u2764\u200d\ud83d\udc8b\u200d\ud83e\uddd1\ud83c\udffe": [
+    "kiss_person_person_medium-light_skin_tone_medium-dark_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffc\u200d\u2764\u200d\ud83d\udc8b\u200d\ud83e\uddd1\ud83c\udfff": [
+    "kiss_person_person_medium-light_skin_tone_dark_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffc\u200d\u2764\u200d\ud83e\uddd1\ud83c\udffb": [
+    "couple_with_heart_person_person_medium-light_skin_tone_light_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffc\u200d\u2764\u200d\ud83e\uddd1\ud83c\udffd": [
+    "couple_with_heart_person_person_medium-light_skin_tone_medium_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffc\u200d\u2764\u200d\ud83e\uddd1\ud83c\udffe": [
+    "couple_with_heart_person_person_medium-light_skin_tone_medium-dark_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffc\u200d\u2764\u200d\ud83e\uddd1\ud83c\udfff": [
+    "couple_with_heart_person_person_medium-light_skin_tone_dark_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffc\u200d\u2764\ufe0f\u200d\ud83d\udc8b\u200d\ud83e\uddd1\ud83c\udffb": [
+    "kiss_person_person_medium-light_skin_tone_light_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffc\u200d\u2764\ufe0f\u200d\ud83d\udc8b\u200d\ud83e\uddd1\ud83c\udffd": [
+    "kiss_person_person_medium-light_skin_tone_medium_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffc\u200d\u2764\ufe0f\u200d\ud83d\udc8b\u200d\ud83e\uddd1\ud83c\udffe": [
+    "kiss_person_person_medium-light_skin_tone_medium-dark_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffc\u200d\u2764\ufe0f\u200d\ud83d\udc8b\u200d\ud83e\uddd1\ud83c\udfff": [
+    "kiss_person_person_medium-light_skin_tone_dark_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffc\u200d\u2764\ufe0f\u200d\ud83e\uddd1\ud83c\udffb": [
+    "couple_with_heart_person_person_medium-light_skin_tone_light_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffc\u200d\u2764\ufe0f\u200d\ud83e\uddd1\ud83c\udffd": [
+    "couple_with_heart_person_person_medium-light_skin_tone_medium_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffc\u200d\u2764\ufe0f\u200d\ud83e\uddd1\ud83c\udffe": [
+    "couple_with_heart_person_person_medium-light_skin_tone_medium-dark_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffc\u200d\u2764\ufe0f\u200d\ud83e\uddd1\ud83c\udfff": [
+    "couple_with_heart_person_person_medium-light_skin_tone_dark_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffc\u200d\ud83c\udf3e": [
+    "farmer_medium-light_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffc\u200d\ud83c\udf73": [
+    "cook_medium-light_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffc\u200d\ud83c\udf7c": [
+    "person_feeding_baby_medium-light_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffc\u200d\ud83c\udf84": [
+    "mx_claus_medium-light_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffc\u200d\ud83c\udf93": [
+    "student_medium-light_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffc\u200d\ud83c\udfa4": [
+    "singer_medium-light_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffc\u200d\ud83c\udfa8": [
+    "artist_medium-light_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffc\u200d\ud83c\udfeb": [
+    "teacher_medium-light_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffc\u200d\ud83c\udfed": [
+    "factory_worker_medium-light_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffc\u200d\ud83d\udcbb": [
+    "technologist_medium-light_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffc\u200d\ud83d\udcbc": [
+    "office_worker_medium-light_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffc\u200d\ud83d\udd27": [
+    "mechanic_medium-light_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffc\u200d\ud83d\udd2c": [
+    "scientist_medium-light_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffc\u200d\ud83d\ude80": [
+    "astronaut_medium-light_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffc\u200d\ud83d\ude92": [
+    "firefighter_medium-light_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffc\u200d\ud83e\udd1d\u200d\ud83e\uddd1\ud83c\udffb": [
+    "people_holding_hands_medium-light_skin_tone_light_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffc\u200d\ud83e\udd1d\u200d\ud83e\uddd1\ud83c\udffc": [
+    "people_holding_hands_medium-light_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffc\u200d\ud83e\udd1d\u200d\ud83e\uddd1\ud83c\udffd": [
+    "people_holding_hands_medium-light_skin_tone_medium_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffc\u200d\ud83e\udd1d\u200d\ud83e\uddd1\ud83c\udffe": [
+    "people_holding_hands_medium-light_skin_tone_medium-dark_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffc\u200d\ud83e\udd1d\u200d\ud83e\uddd1\ud83c\udfff": [
+    "people_holding_hands_medium-light_skin_tone_dark_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffc\u200d\ud83e\uddaf": [
+    "person_with_white_cane_medium-light_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffc\u200d\ud83e\uddaf\u200d\u27a1": [
+    "person_with_white_cane_facing_right_medium-light_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffc\u200d\ud83e\uddaf\u200d\u27a1\ufe0f": [
+    "person_with_white_cane_facing_right_medium-light_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffc\u200d\ud83e\uddb0": [
+    "person_medium-light_skin_tone_red_hair"
+  ],
+  "\ud83e\uddd1\ud83c\udffc\u200d\ud83e\uddb1": [
+    "person_medium-light_skin_tone_curly_hair"
+  ],
+  "\ud83e\uddd1\ud83c\udffc\u200d\ud83e\uddb2": [
+    "person_medium-light_skin_tone_bald"
+  ],
+  "\ud83e\uddd1\ud83c\udffc\u200d\ud83e\uddb3": [
+    "person_medium-light_skin_tone_white_hair"
+  ],
+  "\ud83e\uddd1\ud83c\udffc\u200d\ud83e\uddbc": [
+    "person_in_motorized_wheelchair_medium-light_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffc\u200d\ud83e\uddbc\u200d\u27a1": [
+    "person_in_motorized_wheelchair_facing_right_medium-light_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffc\u200d\ud83e\uddbc\u200d\u27a1\ufe0f": [
+    "person_in_motorized_wheelchair_facing_right_medium-light_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffc\u200d\ud83e\uddbd": [
+    "person_in_manual_wheelchair_medium-light_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffc\u200d\ud83e\uddbd\u200d\u27a1": [
+    "person_in_manual_wheelchair_facing_right_medium-light_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffc\u200d\ud83e\uddbd\u200d\u27a1\ufe0f": [
+    "person_in_manual_wheelchair_facing_right_medium-light_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffd": [
+    "person_medium_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffd\u200d\u2695": [
+    "health_worker_medium_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffd\u200d\u2695\ufe0f": [
+    "health_worker_medium_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffd\u200d\u2696": [
+    "judge_medium_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffd\u200d\u2696\ufe0f": [
+    "judge_medium_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffd\u200d\u2708": [
+    "pilot_medium_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffd\u200d\u2708\ufe0f": [
+    "pilot_medium_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffd\u200d\u2764\u200d\ud83d\udc8b\u200d\ud83e\uddd1\ud83c\udffb": [
+    "kiss_person_person_medium_skin_tone_light_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffd\u200d\u2764\u200d\ud83d\udc8b\u200d\ud83e\uddd1\ud83c\udffc": [
+    "kiss_person_person_medium_skin_tone_medium-light_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffd\u200d\u2764\u200d\ud83d\udc8b\u200d\ud83e\uddd1\ud83c\udffe": [
+    "kiss_person_person_medium_skin_tone_medium-dark_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffd\u200d\u2764\u200d\ud83d\udc8b\u200d\ud83e\uddd1\ud83c\udfff": [
+    "kiss_person_person_medium_skin_tone_dark_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffd\u200d\u2764\u200d\ud83e\uddd1\ud83c\udffb": [
+    "couple_with_heart_person_person_medium_skin_tone_light_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffd\u200d\u2764\u200d\ud83e\uddd1\ud83c\udffc": [
+    "couple_with_heart_person_person_medium_skin_tone_medium-light_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffd\u200d\u2764\u200d\ud83e\uddd1\ud83c\udffe": [
+    "couple_with_heart_person_person_medium_skin_tone_medium-dark_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffd\u200d\u2764\u200d\ud83e\uddd1\ud83c\udfff": [
+    "couple_with_heart_person_person_medium_skin_tone_dark_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffd\u200d\u2764\ufe0f\u200d\ud83d\udc8b\u200d\ud83e\uddd1\ud83c\udffb": [
+    "kiss_person_person_medium_skin_tone_light_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffd\u200d\u2764\ufe0f\u200d\ud83d\udc8b\u200d\ud83e\uddd1\ud83c\udffc": [
+    "kiss_person_person_medium_skin_tone_medium-light_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffd\u200d\u2764\ufe0f\u200d\ud83d\udc8b\u200d\ud83e\uddd1\ud83c\udffe": [
+    "kiss_person_person_medium_skin_tone_medium-dark_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffd\u200d\u2764\ufe0f\u200d\ud83d\udc8b\u200d\ud83e\uddd1\ud83c\udfff": [
+    "kiss_person_person_medium_skin_tone_dark_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffd\u200d\u2764\ufe0f\u200d\ud83e\uddd1\ud83c\udffb": [
+    "couple_with_heart_person_person_medium_skin_tone_light_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffd\u200d\u2764\ufe0f\u200d\ud83e\uddd1\ud83c\udffc": [
+    "couple_with_heart_person_person_medium_skin_tone_medium-light_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffd\u200d\u2764\ufe0f\u200d\ud83e\uddd1\ud83c\udffe": [
+    "couple_with_heart_person_person_medium_skin_tone_medium-dark_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffd\u200d\u2764\ufe0f\u200d\ud83e\uddd1\ud83c\udfff": [
+    "couple_with_heart_person_person_medium_skin_tone_dark_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffd\u200d\ud83c\udf3e": [
+    "farmer_medium_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffd\u200d\ud83c\udf73": [
+    "cook_medium_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffd\u200d\ud83c\udf7c": [
+    "person_feeding_baby_medium_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffd\u200d\ud83c\udf84": [
+    "mx_claus_medium_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffd\u200d\ud83c\udf93": [
+    "student_medium_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffd\u200d\ud83c\udfa4": [
+    "singer_medium_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffd\u200d\ud83c\udfa8": [
+    "artist_medium_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffd\u200d\ud83c\udfeb": [
+    "teacher_medium_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffd\u200d\ud83c\udfed": [
+    "factory_worker_medium_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffd\u200d\ud83d\udcbb": [
+    "technologist_medium_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffd\u200d\ud83d\udcbc": [
+    "office_worker_medium_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffd\u200d\ud83d\udd27": [
+    "mechanic_medium_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffd\u200d\ud83d\udd2c": [
+    "scientist_medium_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffd\u200d\ud83d\ude80": [
+    "astronaut_medium_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffd\u200d\ud83d\ude92": [
+    "firefighter_medium_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffd\u200d\ud83e\udd1d\u200d\ud83e\uddd1\ud83c\udffb": [
+    "people_holding_hands_medium_skin_tone_light_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffd\u200d\ud83e\udd1d\u200d\ud83e\uddd1\ud83c\udffc": [
+    "people_holding_hands_medium_skin_tone_medium-light_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffd\u200d\ud83e\udd1d\u200d\ud83e\uddd1\ud83c\udffd": [
+    "people_holding_hands_medium_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffd\u200d\ud83e\udd1d\u200d\ud83e\uddd1\ud83c\udffe": [
+    "people_holding_hands_medium_skin_tone_medium-dark_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffd\u200d\ud83e\udd1d\u200d\ud83e\uddd1\ud83c\udfff": [
+    "people_holding_hands_medium_skin_tone_dark_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffd\u200d\ud83e\uddaf": [
+    "person_with_white_cane_medium_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffd\u200d\ud83e\uddaf\u200d\u27a1": [
+    "person_with_white_cane_facing_right_medium_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffd\u200d\ud83e\uddaf\u200d\u27a1\ufe0f": [
+    "person_with_white_cane_facing_right_medium_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffd\u200d\ud83e\uddb0": [
+    "person_medium_skin_tone_red_hair"
+  ],
+  "\ud83e\uddd1\ud83c\udffd\u200d\ud83e\uddb1": [
+    "person_medium_skin_tone_curly_hair"
+  ],
+  "\ud83e\uddd1\ud83c\udffd\u200d\ud83e\uddb2": [
+    "person_medium_skin_tone_bald"
+  ],
+  "\ud83e\uddd1\ud83c\udffd\u200d\ud83e\uddb3": [
+    "person_medium_skin_tone_white_hair"
+  ],
+  "\ud83e\uddd1\ud83c\udffd\u200d\ud83e\uddbc": [
+    "person_in_motorized_wheelchair_medium_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffd\u200d\ud83e\uddbc\u200d\u27a1": [
+    "person_in_motorized_wheelchair_facing_right_medium_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffd\u200d\ud83e\uddbc\u200d\u27a1\ufe0f": [
+    "person_in_motorized_wheelchair_facing_right_medium_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffd\u200d\ud83e\uddbd": [
+    "person_in_manual_wheelchair_medium_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffd\u200d\ud83e\uddbd\u200d\u27a1": [
+    "person_in_manual_wheelchair_facing_right_medium_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffd\u200d\ud83e\uddbd\u200d\u27a1\ufe0f": [
+    "person_in_manual_wheelchair_facing_right_medium_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffe": [
+    "person_medium-dark_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffe\u200d\u2695": [
+    "health_worker_medium-dark_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffe\u200d\u2695\ufe0f": [
+    "health_worker_medium-dark_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffe\u200d\u2696": [
+    "judge_medium-dark_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffe\u200d\u2696\ufe0f": [
+    "judge_medium-dark_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffe\u200d\u2708": [
+    "pilot_medium-dark_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffe\u200d\u2708\ufe0f": [
+    "pilot_medium-dark_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffe\u200d\u2764\u200d\ud83d\udc8b\u200d\ud83e\uddd1\ud83c\udffb": [
+    "kiss_person_person_medium-dark_skin_tone_light_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffe\u200d\u2764\u200d\ud83d\udc8b\u200d\ud83e\uddd1\ud83c\udffc": [
+    "kiss_person_person_medium-dark_skin_tone_medium-light_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffe\u200d\u2764\u200d\ud83d\udc8b\u200d\ud83e\uddd1\ud83c\udffd": [
+    "kiss_person_person_medium-dark_skin_tone_medium_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffe\u200d\u2764\u200d\ud83d\udc8b\u200d\ud83e\uddd1\ud83c\udfff": [
+    "kiss_person_person_medium-dark_skin_tone_dark_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffe\u200d\u2764\u200d\ud83e\uddd1\ud83c\udffb": [
+    "couple_with_heart_person_person_medium-dark_skin_tone_light_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffe\u200d\u2764\u200d\ud83e\uddd1\ud83c\udffc": [
+    "couple_with_heart_person_person_medium-dark_skin_tone_medium-light_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffe\u200d\u2764\u200d\ud83e\uddd1\ud83c\udffd": [
+    "couple_with_heart_person_person_medium-dark_skin_tone_medium_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffe\u200d\u2764\u200d\ud83e\uddd1\ud83c\udfff": [
+    "couple_with_heart_person_person_medium-dark_skin_tone_dark_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffe\u200d\u2764\ufe0f\u200d\ud83d\udc8b\u200d\ud83e\uddd1\ud83c\udffb": [
+    "kiss_person_person_medium-dark_skin_tone_light_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffe\u200d\u2764\ufe0f\u200d\ud83d\udc8b\u200d\ud83e\uddd1\ud83c\udffc": [
+    "kiss_person_person_medium-dark_skin_tone_medium-light_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffe\u200d\u2764\ufe0f\u200d\ud83d\udc8b\u200d\ud83e\uddd1\ud83c\udffd": [
+    "kiss_person_person_medium-dark_skin_tone_medium_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffe\u200d\u2764\ufe0f\u200d\ud83d\udc8b\u200d\ud83e\uddd1\ud83c\udfff": [
+    "kiss_person_person_medium-dark_skin_tone_dark_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffe\u200d\u2764\ufe0f\u200d\ud83e\uddd1\ud83c\udffb": [
+    "couple_with_heart_person_person_medium-dark_skin_tone_light_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffe\u200d\u2764\ufe0f\u200d\ud83e\uddd1\ud83c\udffc": [
+    "couple_with_heart_person_person_medium-dark_skin_tone_medium-light_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffe\u200d\u2764\ufe0f\u200d\ud83e\uddd1\ud83c\udffd": [
+    "couple_with_heart_person_person_medium-dark_skin_tone_medium_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffe\u200d\u2764\ufe0f\u200d\ud83e\uddd1\ud83c\udfff": [
+    "couple_with_heart_person_person_medium-dark_skin_tone_dark_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffe\u200d\ud83c\udf3e": [
+    "farmer_medium-dark_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffe\u200d\ud83c\udf73": [
+    "cook_medium-dark_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffe\u200d\ud83c\udf7c": [
+    "person_feeding_baby_medium-dark_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffe\u200d\ud83c\udf84": [
+    "mx_claus_medium-dark_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffe\u200d\ud83c\udf93": [
+    "student_medium-dark_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffe\u200d\ud83c\udfa4": [
+    "singer_medium-dark_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffe\u200d\ud83c\udfa8": [
+    "artist_medium-dark_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffe\u200d\ud83c\udfeb": [
+    "teacher_medium-dark_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffe\u200d\ud83c\udfed": [
+    "factory_worker_medium-dark_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffe\u200d\ud83d\udcbb": [
+    "technologist_medium-dark_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffe\u200d\ud83d\udcbc": [
+    "office_worker_medium-dark_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffe\u200d\ud83d\udd27": [
+    "mechanic_medium-dark_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffe\u200d\ud83d\udd2c": [
+    "scientist_medium-dark_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffe\u200d\ud83d\ude80": [
+    "astronaut_medium-dark_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffe\u200d\ud83d\ude92": [
+    "firefighter_medium-dark_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffe\u200d\ud83e\udd1d\u200d\ud83e\uddd1\ud83c\udffb": [
+    "people_holding_hands_medium-dark_skin_tone_light_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffe\u200d\ud83e\udd1d\u200d\ud83e\uddd1\ud83c\udffc": [
+    "people_holding_hands_medium-dark_skin_tone_medium-light_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffe\u200d\ud83e\udd1d\u200d\ud83e\uddd1\ud83c\udffd": [
+    "people_holding_hands_medium-dark_skin_tone_medium_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffe\u200d\ud83e\udd1d\u200d\ud83e\uddd1\ud83c\udffe": [
+    "people_holding_hands_medium-dark_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffe\u200d\ud83e\udd1d\u200d\ud83e\uddd1\ud83c\udfff": [
+    "people_holding_hands_medium-dark_skin_tone_dark_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffe\u200d\ud83e\uddaf": [
+    "person_with_white_cane_medium-dark_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffe\u200d\ud83e\uddaf\u200d\u27a1": [
+    "person_with_white_cane_facing_right_medium-dark_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffe\u200d\ud83e\uddaf\u200d\u27a1\ufe0f": [
+    "person_with_white_cane_facing_right_medium-dark_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffe\u200d\ud83e\uddb0": [
+    "person_medium-dark_skin_tone_red_hair"
+  ],
+  "\ud83e\uddd1\ud83c\udffe\u200d\ud83e\uddb1": [
+    "person_medium-dark_skin_tone_curly_hair"
+  ],
+  "\ud83e\uddd1\ud83c\udffe\u200d\ud83e\uddb2": [
+    "person_medium-dark_skin_tone_bald"
+  ],
+  "\ud83e\uddd1\ud83c\udffe\u200d\ud83e\uddb3": [
+    "person_medium-dark_skin_tone_white_hair"
+  ],
+  "\ud83e\uddd1\ud83c\udffe\u200d\ud83e\uddbc": [
+    "person_in_motorized_wheelchair_medium-dark_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffe\u200d\ud83e\uddbc\u200d\u27a1": [
+    "person_in_motorized_wheelchair_facing_right_medium-dark_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffe\u200d\ud83e\uddbc\u200d\u27a1\ufe0f": [
+    "person_in_motorized_wheelchair_facing_right_medium-dark_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffe\u200d\ud83e\uddbd": [
+    "person_in_manual_wheelchair_medium-dark_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffe\u200d\ud83e\uddbd\u200d\u27a1": [
+    "person_in_manual_wheelchair_facing_right_medium-dark_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udffe\u200d\ud83e\uddbd\u200d\u27a1\ufe0f": [
+    "person_in_manual_wheelchair_facing_right_medium-dark_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udfff": [
+    "person_dark_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udfff\u200d\u2695": [
+    "health_worker_dark_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udfff\u200d\u2695\ufe0f": [
+    "health_worker_dark_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udfff\u200d\u2696": [
+    "judge_dark_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udfff\u200d\u2696\ufe0f": [
+    "judge_dark_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udfff\u200d\u2708": [
+    "pilot_dark_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udfff\u200d\u2708\ufe0f": [
+    "pilot_dark_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udfff\u200d\u2764\u200d\ud83d\udc8b\u200d\ud83e\uddd1\ud83c\udffb": [
+    "kiss_person_person_dark_skin_tone_light_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udfff\u200d\u2764\u200d\ud83d\udc8b\u200d\ud83e\uddd1\ud83c\udffc": [
+    "kiss_person_person_dark_skin_tone_medium-light_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udfff\u200d\u2764\u200d\ud83d\udc8b\u200d\ud83e\uddd1\ud83c\udffd": [
+    "kiss_person_person_dark_skin_tone_medium_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udfff\u200d\u2764\u200d\ud83d\udc8b\u200d\ud83e\uddd1\ud83c\udffe": [
+    "kiss_person_person_dark_skin_tone_medium-dark_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udfff\u200d\u2764\u200d\ud83e\uddd1\ud83c\udffb": [
+    "couple_with_heart_person_person_dark_skin_tone_light_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udfff\u200d\u2764\u200d\ud83e\uddd1\ud83c\udffc": [
+    "couple_with_heart_person_person_dark_skin_tone_medium-light_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udfff\u200d\u2764\u200d\ud83e\uddd1\ud83c\udffd": [
+    "couple_with_heart_person_person_dark_skin_tone_medium_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udfff\u200d\u2764\u200d\ud83e\uddd1\ud83c\udffe": [
+    "couple_with_heart_person_person_dark_skin_tone_medium-dark_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udfff\u200d\u2764\ufe0f\u200d\ud83d\udc8b\u200d\ud83e\uddd1\ud83c\udffb": [
+    "kiss_person_person_dark_skin_tone_light_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udfff\u200d\u2764\ufe0f\u200d\ud83d\udc8b\u200d\ud83e\uddd1\ud83c\udffc": [
+    "kiss_person_person_dark_skin_tone_medium-light_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udfff\u200d\u2764\ufe0f\u200d\ud83d\udc8b\u200d\ud83e\uddd1\ud83c\udffd": [
+    "kiss_person_person_dark_skin_tone_medium_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udfff\u200d\u2764\ufe0f\u200d\ud83d\udc8b\u200d\ud83e\uddd1\ud83c\udffe": [
+    "kiss_person_person_dark_skin_tone_medium-dark_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udfff\u200d\u2764\ufe0f\u200d\ud83e\uddd1\ud83c\udffb": [
+    "couple_with_heart_person_person_dark_skin_tone_light_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udfff\u200d\u2764\ufe0f\u200d\ud83e\uddd1\ud83c\udffc": [
+    "couple_with_heart_person_person_dark_skin_tone_medium-light_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udfff\u200d\u2764\ufe0f\u200d\ud83e\uddd1\ud83c\udffd": [
+    "couple_with_heart_person_person_dark_skin_tone_medium_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udfff\u200d\u2764\ufe0f\u200d\ud83e\uddd1\ud83c\udffe": [
+    "couple_with_heart_person_person_dark_skin_tone_medium-dark_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udfff\u200d\ud83c\udf3e": [
+    "farmer_dark_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udfff\u200d\ud83c\udf73": [
+    "cook_dark_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udfff\u200d\ud83c\udf7c": [
+    "person_feeding_baby_dark_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udfff\u200d\ud83c\udf84": [
+    "mx_claus_dark_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udfff\u200d\ud83c\udf93": [
+    "student_dark_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udfff\u200d\ud83c\udfa4": [
+    "singer_dark_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udfff\u200d\ud83c\udfa8": [
+    "artist_dark_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udfff\u200d\ud83c\udfeb": [
+    "teacher_dark_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udfff\u200d\ud83c\udfed": [
+    "factory_worker_dark_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udfff\u200d\ud83d\udcbb": [
+    "technologist_dark_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udfff\u200d\ud83d\udcbc": [
+    "office_worker_dark_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udfff\u200d\ud83d\udd27": [
+    "mechanic_dark_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udfff\u200d\ud83d\udd2c": [
+    "scientist_dark_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udfff\u200d\ud83d\ude80": [
+    "astronaut_dark_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udfff\u200d\ud83d\ude92": [
+    "firefighter_dark_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udfff\u200d\ud83e\udd1d\u200d\ud83e\uddd1\ud83c\udffb": [
+    "people_holding_hands_dark_skin_tone_light_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udfff\u200d\ud83e\udd1d\u200d\ud83e\uddd1\ud83c\udffc": [
+    "people_holding_hands_dark_skin_tone_medium-light_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udfff\u200d\ud83e\udd1d\u200d\ud83e\uddd1\ud83c\udffd": [
+    "people_holding_hands_dark_skin_tone_medium_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udfff\u200d\ud83e\udd1d\u200d\ud83e\uddd1\ud83c\udffe": [
+    "people_holding_hands_dark_skin_tone_medium-dark_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udfff\u200d\ud83e\udd1d\u200d\ud83e\uddd1\ud83c\udfff": [
+    "people_holding_hands_dark_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udfff\u200d\ud83e\uddaf": [
+    "person_with_white_cane_dark_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udfff\u200d\ud83e\uddaf\u200d\u27a1": [
+    "person_with_white_cane_facing_right_dark_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udfff\u200d\ud83e\uddaf\u200d\u27a1\ufe0f": [
+    "person_with_white_cane_facing_right_dark_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udfff\u200d\ud83e\uddb0": [
+    "person_dark_skin_tone_red_hair"
+  ],
+  "\ud83e\uddd1\ud83c\udfff\u200d\ud83e\uddb1": [
+    "person_dark_skin_tone_curly_hair"
+  ],
+  "\ud83e\uddd1\ud83c\udfff\u200d\ud83e\uddb2": [
+    "person_dark_skin_tone_bald"
+  ],
+  "\ud83e\uddd1\ud83c\udfff\u200d\ud83e\uddb3": [
+    "person_dark_skin_tone_white_hair"
+  ],
+  "\ud83e\uddd1\ud83c\udfff\u200d\ud83e\uddbc": [
+    "person_in_motorized_wheelchair_dark_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udfff\u200d\ud83e\uddbc\u200d\u27a1": [
+    "person_in_motorized_wheelchair_facing_right_dark_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udfff\u200d\ud83e\uddbc\u200d\u27a1\ufe0f": [
+    "person_in_motorized_wheelchair_facing_right_dark_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udfff\u200d\ud83e\uddbd": [
+    "person_in_manual_wheelchair_dark_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udfff\u200d\ud83e\uddbd\u200d\u27a1": [
+    "person_in_manual_wheelchair_facing_right_dark_skin_tone"
+  ],
+  "\ud83e\uddd1\ud83c\udfff\u200d\ud83e\uddbd\u200d\u27a1\ufe0f": [
+    "person_in_manual_wheelchair_facing_right_dark_skin_tone"
+  ],
+  "\ud83e\uddd2": [
+    "child"
+  ],
+  "\ud83e\uddd2\ud83c\udffb": [
+    "child_light_skin_tone"
+  ],
+  "\ud83e\uddd2\ud83c\udffc": [
+    "child_medium-light_skin_tone"
+  ],
+  "\ud83e\uddd2\ud83c\udffd": [
+    "child_medium_skin_tone"
+  ],
+  "\ud83e\uddd2\ud83c\udffe": [
+    "child_medium-dark_skin_tone"
+  ],
+  "\ud83e\uddd2\ud83c\udfff": [
+    "child_dark_skin_tone"
+  ],
+  "\ud83e\uddd3": [
+    "older_person",
+    "older_adult"
+  ],
+  "\ud83e\uddd3\ud83c\udffb": [
+    "older_person_light_skin_tone"
+  ],
+  "\ud83e\uddd3\ud83c\udffc": [
+    "older_person_medium-light_skin_tone"
+  ],
+  "\ud83e\uddd3\ud83c\udffd": [
+    "older_person_medium_skin_tone"
+  ],
+  "\ud83e\uddd3\ud83c\udffe": [
+    "older_person_medium-dark_skin_tone"
+  ],
+  "\ud83e\uddd3\ud83c\udfff": [
+    "older_person_dark_skin_tone"
+  ],
+  "\ud83e\uddd4": [
+    "person_beard",
+    "bearded_person"
+  ],
+  "\ud83e\uddd4\u200d\u2640": [
+    "woman_beard"
+  ],
+  "\ud83e\uddd4\u200d\u2640\ufe0f": [
+    "woman_beard"
+  ],
+  "\ud83e\uddd4\u200d\u2642": [
+    "man_beard"
+  ],
+  "\ud83e\uddd4\u200d\u2642\ufe0f": [
+    "man_beard"
+  ],
+  "\ud83e\uddd4\ud83c\udffb": [
+    "person_light_skin_tone_beard"
+  ],
+  "\ud83e\uddd4\ud83c\udffb\u200d\u2640": [
+    "woman_light_skin_tone_beard"
+  ],
+  "\ud83e\uddd4\ud83c\udffb\u200d\u2640\ufe0f": [
+    "woman_light_skin_tone_beard"
+  ],
+  "\ud83e\uddd4\ud83c\udffb\u200d\u2642": [
+    "man_light_skin_tone_beard"
+  ],
+  "\ud83e\uddd4\ud83c\udffb\u200d\u2642\ufe0f": [
+    "man_light_skin_tone_beard"
+  ],
+  "\ud83e\uddd4\ud83c\udffc": [
+    "person_medium-light_skin_tone_beard"
+  ],
+  "\ud83e\uddd4\ud83c\udffc\u200d\u2640": [
+    "woman_medium-light_skin_tone_beard"
+  ],
+  "\ud83e\uddd4\ud83c\udffc\u200d\u2640\ufe0f": [
+    "woman_medium-light_skin_tone_beard"
+  ],
+  "\ud83e\uddd4\ud83c\udffc\u200d\u2642": [
+    "man_medium-light_skin_tone_beard"
+  ],
+  "\ud83e\uddd4\ud83c\udffc\u200d\u2642\ufe0f": [
+    "man_medium-light_skin_tone_beard"
+  ],
+  "\ud83e\uddd4\ud83c\udffd": [
+    "person_medium_skin_tone_beard"
+  ],
+  "\ud83e\uddd4\ud83c\udffd\u200d\u2640": [
+    "woman_medium_skin_tone_beard"
+  ],
+  "\ud83e\uddd4\ud83c\udffd\u200d\u2640\ufe0f": [
+    "woman_medium_skin_tone_beard"
+  ],
+  "\ud83e\uddd4\ud83c\udffd\u200d\u2642": [
+    "man_medium_skin_tone_beard"
+  ],
+  "\ud83e\uddd4\ud83c\udffd\u200d\u2642\ufe0f": [
+    "man_medium_skin_tone_beard"
+  ],
+  "\ud83e\uddd4\ud83c\udffe": [
+    "person_medium-dark_skin_tone_beard"
+  ],
+  "\ud83e\uddd4\ud83c\udffe\u200d\u2640": [
+    "woman_medium-dark_skin_tone_beard"
+  ],
+  "\ud83e\uddd4\ud83c\udffe\u200d\u2640\ufe0f": [
+    "woman_medium-dark_skin_tone_beard"
+  ],
+  "\ud83e\uddd4\ud83c\udffe\u200d\u2642": [
+    "man_medium-dark_skin_tone_beard"
+  ],
+  "\ud83e\uddd4\ud83c\udffe\u200d\u2642\ufe0f": [
+    "man_medium-dark_skin_tone_beard"
+  ],
+  "\ud83e\uddd4\ud83c\udfff": [
+    "person_dark_skin_tone_beard"
+  ],
+  "\ud83e\uddd4\ud83c\udfff\u200d\u2640": [
+    "woman_dark_skin_tone_beard"
+  ],
+  "\ud83e\uddd4\ud83c\udfff\u200d\u2640\ufe0f": [
+    "woman_dark_skin_tone_beard"
+  ],
+  "\ud83e\uddd4\ud83c\udfff\u200d\u2642": [
+    "man_dark_skin_tone_beard"
+  ],
+  "\ud83e\uddd4\ud83c\udfff\u200d\u2642\ufe0f": [
+    "man_dark_skin_tone_beard"
+  ],
+  "\ud83e\uddd5": [
+    "woman_with_headscarf"
+  ],
+  "\ud83e\uddd5\ud83c\udffb": [
+    "woman_with_headscarf_light_skin_tone"
+  ],
+  "\ud83e\uddd5\ud83c\udffc": [
+    "woman_with_headscarf_medium-light_skin_tone"
+  ],
+  "\ud83e\uddd5\ud83c\udffd": [
+    "woman_with_headscarf_medium_skin_tone"
+  ],
+  "\ud83e\uddd5\ud83c\udffe": [
+    "woman_with_headscarf_medium-dark_skin_tone"
+  ],
+  "\ud83e\uddd5\ud83c\udfff": [
+    "woman_with_headscarf_dark_skin_tone"
+  ],
+  "\ud83e\uddd6": [
+    "person_in_steamy_room",
+    "sauna_person"
+  ],
+  "\ud83e\uddd6\u200d\u2640": [
+    "woman_in_steamy_room",
+    "sauna_woman"
+  ],
+  "\ud83e\uddd6\u200d\u2640\ufe0f": [
+    "woman_in_steamy_room",
+    "sauna_woman"
+  ],
+  "\ud83e\uddd6\u200d\u2642": [
+    "man_in_steamy_room",
+    "sauna_man"
+  ],
+  "\ud83e\uddd6\u200d\u2642\ufe0f": [
+    "man_in_steamy_room",
+    "sauna_man"
+  ],
+  "\ud83e\uddd6\ud83c\udffb": [
+    "person_in_steamy_room_light_skin_tone"
+  ],
+  "\ud83e\uddd6\ud83c\udffb\u200d\u2640": [
+    "woman_in_steamy_room_light_skin_tone"
+  ],
+  "\ud83e\uddd6\ud83c\udffb\u200d\u2640\ufe0f": [
+    "woman_in_steamy_room_light_skin_tone"
+  ],
+  "\ud83e\uddd6\ud83c\udffb\u200d\u2642": [
+    "man_in_steamy_room_light_skin_tone"
+  ],
+  "\ud83e\uddd6\ud83c\udffb\u200d\u2642\ufe0f": [
+    "man_in_steamy_room_light_skin_tone"
+  ],
+  "\ud83e\uddd6\ud83c\udffc": [
+    "person_in_steamy_room_medium-light_skin_tone"
+  ],
+  "\ud83e\uddd6\ud83c\udffc\u200d\u2640": [
+    "woman_in_steamy_room_medium-light_skin_tone"
+  ],
+  "\ud83e\uddd6\ud83c\udffc\u200d\u2640\ufe0f": [
+    "woman_in_steamy_room_medium-light_skin_tone"
+  ],
+  "\ud83e\uddd6\ud83c\udffc\u200d\u2642": [
+    "man_in_steamy_room_medium-light_skin_tone"
+  ],
+  "\ud83e\uddd6\ud83c\udffc\u200d\u2642\ufe0f": [
+    "man_in_steamy_room_medium-light_skin_tone"
+  ],
+  "\ud83e\uddd6\ud83c\udffd": [
+    "person_in_steamy_room_medium_skin_tone"
+  ],
+  "\ud83e\uddd6\ud83c\udffd\u200d\u2640": [
+    "woman_in_steamy_room_medium_skin_tone"
+  ],
+  "\ud83e\uddd6\ud83c\udffd\u200d\u2640\ufe0f": [
+    "woman_in_steamy_room_medium_skin_tone"
+  ],
+  "\ud83e\uddd6\ud83c\udffd\u200d\u2642": [
+    "man_in_steamy_room_medium_skin_tone"
+  ],
+  "\ud83e\uddd6\ud83c\udffd\u200d\u2642\ufe0f": [
+    "man_in_steamy_room_medium_skin_tone"
+  ],
+  "\ud83e\uddd6\ud83c\udffe": [
+    "person_in_steamy_room_medium-dark_skin_tone"
+  ],
+  "\ud83e\uddd6\ud83c\udffe\u200d\u2640": [
+    "woman_in_steamy_room_medium-dark_skin_tone"
+  ],
+  "\ud83e\uddd6\ud83c\udffe\u200d\u2640\ufe0f": [
+    "woman_in_steamy_room_medium-dark_skin_tone"
+  ],
+  "\ud83e\uddd6\ud83c\udffe\u200d\u2642": [
+    "man_in_steamy_room_medium-dark_skin_tone"
+  ],
+  "\ud83e\uddd6\ud83c\udffe\u200d\u2642\ufe0f": [
+    "man_in_steamy_room_medium-dark_skin_tone"
+  ],
+  "\ud83e\uddd6\ud83c\udfff": [
+    "person_in_steamy_room_dark_skin_tone"
+  ],
+  "\ud83e\uddd6\ud83c\udfff\u200d\u2640": [
+    "woman_in_steamy_room_dark_skin_tone"
+  ],
+  "\ud83e\uddd6\ud83c\udfff\u200d\u2640\ufe0f": [
+    "woman_in_steamy_room_dark_skin_tone"
+  ],
+  "\ud83e\uddd6\ud83c\udfff\u200d\u2642": [
+    "man_in_steamy_room_dark_skin_tone"
+  ],
+  "\ud83e\uddd6\ud83c\udfff\u200d\u2642\ufe0f": [
+    "man_in_steamy_room_dark_skin_tone"
+  ],
+  "\ud83e\uddd7": [
+    "person_climbing",
+    "climbing"
+  ],
+  "\ud83e\uddd7\u200d\u2640": [
+    "woman_climbing",
+    "climbing_woman"
+  ],
+  "\ud83e\uddd7\u200d\u2640\ufe0f": [
+    "woman_climbing",
+    "climbing_woman"
+  ],
+  "\ud83e\uddd7\u200d\u2642": [
+    "man_climbing",
+    "climbing_man"
+  ],
+  "\ud83e\uddd7\u200d\u2642\ufe0f": [
+    "man_climbing",
+    "climbing_man"
+  ],
+  "\ud83e\uddd7\ud83c\udffb": [
+    "person_climbing_light_skin_tone"
+  ],
+  "\ud83e\uddd7\ud83c\udffb\u200d\u2640": [
+    "woman_climbing_light_skin_tone"
+  ],
+  "\ud83e\uddd7\ud83c\udffb\u200d\u2640\ufe0f": [
+    "woman_climbing_light_skin_tone"
+  ],
+  "\ud83e\uddd7\ud83c\udffb\u200d\u2642": [
+    "man_climbing_light_skin_tone"
+  ],
+  "\ud83e\uddd7\ud83c\udffb\u200d\u2642\ufe0f": [
+    "man_climbing_light_skin_tone"
+  ],
+  "\ud83e\uddd7\ud83c\udffc": [
+    "person_climbing_medium-light_skin_tone"
+  ],
+  "\ud83e\uddd7\ud83c\udffc\u200d\u2640": [
+    "woman_climbing_medium-light_skin_tone"
+  ],
+  "\ud83e\uddd7\ud83c\udffc\u200d\u2640\ufe0f": [
+    "woman_climbing_medium-light_skin_tone"
+  ],
+  "\ud83e\uddd7\ud83c\udffc\u200d\u2642": [
+    "man_climbing_medium-light_skin_tone"
+  ],
+  "\ud83e\uddd7\ud83c\udffc\u200d\u2642\ufe0f": [
+    "man_climbing_medium-light_skin_tone"
+  ],
+  "\ud83e\uddd7\ud83c\udffd": [
+    "person_climbing_medium_skin_tone"
+  ],
+  "\ud83e\uddd7\ud83c\udffd\u200d\u2640": [
+    "woman_climbing_medium_skin_tone"
+  ],
+  "\ud83e\uddd7\ud83c\udffd\u200d\u2640\ufe0f": [
+    "woman_climbing_medium_skin_tone"
+  ],
+  "\ud83e\uddd7\ud83c\udffd\u200d\u2642": [
+    "man_climbing_medium_skin_tone"
+  ],
+  "\ud83e\uddd7\ud83c\udffd\u200d\u2642\ufe0f": [
+    "man_climbing_medium_skin_tone"
+  ],
+  "\ud83e\uddd7\ud83c\udffe": [
+    "person_climbing_medium-dark_skin_tone"
+  ],
+  "\ud83e\uddd7\ud83c\udffe\u200d\u2640": [
+    "woman_climbing_medium-dark_skin_tone"
+  ],
+  "\ud83e\uddd7\ud83c\udffe\u200d\u2640\ufe0f": [
+    "woman_climbing_medium-dark_skin_tone"
+  ],
+  "\ud83e\uddd7\ud83c\udffe\u200d\u2642": [
+    "man_climbing_medium-dark_skin_tone"
+  ],
+  "\ud83e\uddd7\ud83c\udffe\u200d\u2642\ufe0f": [
+    "man_climbing_medium-dark_skin_tone"
+  ],
+  "\ud83e\uddd7\ud83c\udfff": [
+    "person_climbing_dark_skin_tone"
+  ],
+  "\ud83e\uddd7\ud83c\udfff\u200d\u2640": [
+    "woman_climbing_dark_skin_tone"
+  ],
+  "\ud83e\uddd7\ud83c\udfff\u200d\u2640\ufe0f": [
+    "woman_climbing_dark_skin_tone"
+  ],
+  "\ud83e\uddd7\ud83c\udfff\u200d\u2642": [
+    "man_climbing_dark_skin_tone"
+  ],
+  "\ud83e\uddd7\ud83c\udfff\u200d\u2642\ufe0f": [
+    "man_climbing_dark_skin_tone"
+  ],
+  "\ud83e\uddd8": [
+    "person_in_lotus_position",
+    "lotus_position"
+  ],
+  "\ud83e\uddd8\u200d\u2640": [
+    "woman_in_lotus_position",
+    "lotus_position_woman"
+  ],
+  "\ud83e\uddd8\u200d\u2640\ufe0f": [
+    "woman_in_lotus_position",
+    "lotus_position_woman"
+  ],
+  "\ud83e\uddd8\u200d\u2642": [
+    "man_in_lotus_position",
+    "lotus_position_man"
+  ],
+  "\ud83e\uddd8\u200d\u2642\ufe0f": [
+    "man_in_lotus_position",
+    "lotus_position_man"
+  ],
+  "\ud83e\uddd8\ud83c\udffb": [
+    "person_in_lotus_position_light_skin_tone"
+  ],
+  "\ud83e\uddd8\ud83c\udffb\u200d\u2640": [
+    "woman_in_lotus_position_light_skin_tone"
+  ],
+  "\ud83e\uddd8\ud83c\udffb\u200d\u2640\ufe0f": [
+    "woman_in_lotus_position_light_skin_tone"
+  ],
+  "\ud83e\uddd8\ud83c\udffb\u200d\u2642": [
+    "man_in_lotus_position_light_skin_tone"
+  ],
+  "\ud83e\uddd8\ud83c\udffb\u200d\u2642\ufe0f": [
+    "man_in_lotus_position_light_skin_tone"
+  ],
+  "\ud83e\uddd8\ud83c\udffc": [
+    "person_in_lotus_position_medium-light_skin_tone"
+  ],
+  "\ud83e\uddd8\ud83c\udffc\u200d\u2640": [
+    "woman_in_lotus_position_medium-light_skin_tone"
+  ],
+  "\ud83e\uddd8\ud83c\udffc\u200d\u2640\ufe0f": [
+    "woman_in_lotus_position_medium-light_skin_tone"
+  ],
+  "\ud83e\uddd8\ud83c\udffc\u200d\u2642": [
+    "man_in_lotus_position_medium-light_skin_tone"
+  ],
+  "\ud83e\uddd8\ud83c\udffc\u200d\u2642\ufe0f": [
+    "man_in_lotus_position_medium-light_skin_tone"
+  ],
+  "\ud83e\uddd8\ud83c\udffd": [
+    "person_in_lotus_position_medium_skin_tone"
+  ],
+  "\ud83e\uddd8\ud83c\udffd\u200d\u2640": [
+    "woman_in_lotus_position_medium_skin_tone"
+  ],
+  "\ud83e\uddd8\ud83c\udffd\u200d\u2640\ufe0f": [
+    "woman_in_lotus_position_medium_skin_tone"
+  ],
+  "\ud83e\uddd8\ud83c\udffd\u200d\u2642": [
+    "man_in_lotus_position_medium_skin_tone"
+  ],
+  "\ud83e\uddd8\ud83c\udffd\u200d\u2642\ufe0f": [
+    "man_in_lotus_position_medium_skin_tone"
+  ],
+  "\ud83e\uddd8\ud83c\udffe": [
+    "person_in_lotus_position_medium-dark_skin_tone"
+  ],
+  "\ud83e\uddd8\ud83c\udffe\u200d\u2640": [
+    "woman_in_lotus_position_medium-dark_skin_tone"
+  ],
+  "\ud83e\uddd8\ud83c\udffe\u200d\u2640\ufe0f": [
+    "woman_in_lotus_position_medium-dark_skin_tone"
+  ],
+  "\ud83e\uddd8\ud83c\udffe\u200d\u2642": [
+    "man_in_lotus_position_medium-dark_skin_tone"
+  ],
+  "\ud83e\uddd8\ud83c\udffe\u200d\u2642\ufe0f": [
+    "man_in_lotus_position_medium-dark_skin_tone"
+  ],
+  "\ud83e\uddd8\ud83c\udfff": [
+    "person_in_lotus_position_dark_skin_tone"
+  ],
+  "\ud83e\uddd8\ud83c\udfff\u200d\u2640": [
+    "woman_in_lotus_position_dark_skin_tone"
+  ],
+  "\ud83e\uddd8\ud83c\udfff\u200d\u2640\ufe0f": [
+    "woman_in_lotus_position_dark_skin_tone"
+  ],
+  "\ud83e\uddd8\ud83c\udfff\u200d\u2642": [
+    "man_in_lotus_position_dark_skin_tone"
+  ],
+  "\ud83e\uddd8\ud83c\udfff\u200d\u2642\ufe0f": [
+    "man_in_lotus_position_dark_skin_tone"
+  ],
+  "\ud83e\uddd9": [
+    "mage"
+  ],
+  "\ud83e\uddd9\u200d\u2640": [
+    "woman_mage",
+    "mage_woman"
+  ],
+  "\ud83e\uddd9\u200d\u2640\ufe0f": [
+    "woman_mage",
+    "mage_woman"
+  ],
+  "\ud83e\uddd9\u200d\u2642": [
+    "man_mage",
+    "mage_man"
+  ],
+  "\ud83e\uddd9\u200d\u2642\ufe0f": [
+    "man_mage",
+    "mage_man"
+  ],
+  "\ud83e\uddd9\ud83c\udffb": [
+    "mage_light_skin_tone"
+  ],
+  "\ud83e\uddd9\ud83c\udffb\u200d\u2640": [
+    "woman_mage_light_skin_tone"
+  ],
+  "\ud83e\uddd9\ud83c\udffb\u200d\u2640\ufe0f": [
+    "woman_mage_light_skin_tone"
+  ],
+  "\ud83e\uddd9\ud83c\udffb\u200d\u2642": [
+    "man_mage_light_skin_tone"
+  ],
+  "\ud83e\uddd9\ud83c\udffb\u200d\u2642\ufe0f": [
+    "man_mage_light_skin_tone"
+  ],
+  "\ud83e\uddd9\ud83c\udffc": [
+    "mage_medium-light_skin_tone"
+  ],
+  "\ud83e\uddd9\ud83c\udffc\u200d\u2640": [
+    "woman_mage_medium-light_skin_tone"
+  ],
+  "\ud83e\uddd9\ud83c\udffc\u200d\u2640\ufe0f": [
+    "woman_mage_medium-light_skin_tone"
+  ],
+  "\ud83e\uddd9\ud83c\udffc\u200d\u2642": [
+    "man_mage_medium-light_skin_tone"
+  ],
+  "\ud83e\uddd9\ud83c\udffc\u200d\u2642\ufe0f": [
+    "man_mage_medium-light_skin_tone"
+  ],
+  "\ud83e\uddd9\ud83c\udffd": [
+    "mage_medium_skin_tone"
+  ],
+  "\ud83e\uddd9\ud83c\udffd\u200d\u2640": [
+    "woman_mage_medium_skin_tone"
+  ],
+  "\ud83e\uddd9\ud83c\udffd\u200d\u2640\ufe0f": [
+    "woman_mage_medium_skin_tone"
+  ],
+  "\ud83e\uddd9\ud83c\udffd\u200d\u2642": [
+    "man_mage_medium_skin_tone"
+  ],
+  "\ud83e\uddd9\ud83c\udffd\u200d\u2642\ufe0f": [
+    "man_mage_medium_skin_tone"
+  ],
+  "\ud83e\uddd9\ud83c\udffe": [
+    "mage_medium-dark_skin_tone"
+  ],
+  "\ud83e\uddd9\ud83c\udffe\u200d\u2640": [
+    "woman_mage_medium-dark_skin_tone"
+  ],
+  "\ud83e\uddd9\ud83c\udffe\u200d\u2640\ufe0f": [
+    "woman_mage_medium-dark_skin_tone"
+  ],
+  "\ud83e\uddd9\ud83c\udffe\u200d\u2642": [
+    "man_mage_medium-dark_skin_tone"
+  ],
+  "\ud83e\uddd9\ud83c\udffe\u200d\u2642\ufe0f": [
+    "man_mage_medium-dark_skin_tone"
+  ],
+  "\ud83e\uddd9\ud83c\udfff": [
+    "mage_dark_skin_tone"
+  ],
+  "\ud83e\uddd9\ud83c\udfff\u200d\u2640": [
+    "woman_mage_dark_skin_tone"
+  ],
+  "\ud83e\uddd9\ud83c\udfff\u200d\u2640\ufe0f": [
+    "woman_mage_dark_skin_tone"
+  ],
+  "\ud83e\uddd9\ud83c\udfff\u200d\u2642": [
+    "man_mage_dark_skin_tone"
+  ],
+  "\ud83e\uddd9\ud83c\udfff\u200d\u2642\ufe0f": [
+    "man_mage_dark_skin_tone"
+  ],
+  "\ud83e\uddda": [
+    "fairy"
+  ],
+  "\ud83e\uddda\u200d\u2640": [
+    "woman_fairy",
+    "fairy_woman"
+  ],
+  "\ud83e\uddda\u200d\u2640\ufe0f": [
+    "woman_fairy",
+    "fairy_woman"
+  ],
+  "\ud83e\uddda\u200d\u2642": [
+    "man_fairy",
+    "fairy_man"
+  ],
+  "\ud83e\uddda\u200d\u2642\ufe0f": [
+    "man_fairy",
+    "fairy_man"
+  ],
+  "\ud83e\uddda\ud83c\udffb": [
+    "fairy_light_skin_tone"
+  ],
+  "\ud83e\uddda\ud83c\udffb\u200d\u2640": [
+    "woman_fairy_light_skin_tone"
+  ],
+  "\ud83e\uddda\ud83c\udffb\u200d\u2640\ufe0f": [
+    "woman_fairy_light_skin_tone"
+  ],
+  "\ud83e\uddda\ud83c\udffb\u200d\u2642": [
+    "man_fairy_light_skin_tone"
+  ],
+  "\ud83e\uddda\ud83c\udffb\u200d\u2642\ufe0f": [
+    "man_fairy_light_skin_tone"
+  ],
+  "\ud83e\uddda\ud83c\udffc": [
+    "fairy_medium-light_skin_tone"
+  ],
+  "\ud83e\uddda\ud83c\udffc\u200d\u2640": [
+    "woman_fairy_medium-light_skin_tone"
+  ],
+  "\ud83e\uddda\ud83c\udffc\u200d\u2640\ufe0f": [
+    "woman_fairy_medium-light_skin_tone"
+  ],
+  "\ud83e\uddda\ud83c\udffc\u200d\u2642": [
+    "man_fairy_medium-light_skin_tone"
+  ],
+  "\ud83e\uddda\ud83c\udffc\u200d\u2642\ufe0f": [
+    "man_fairy_medium-light_skin_tone"
+  ],
+  "\ud83e\uddda\ud83c\udffd": [
+    "fairy_medium_skin_tone"
+  ],
+  "\ud83e\uddda\ud83c\udffd\u200d\u2640": [
+    "woman_fairy_medium_skin_tone"
+  ],
+  "\ud83e\uddda\ud83c\udffd\u200d\u2640\ufe0f": [
+    "woman_fairy_medium_skin_tone"
+  ],
+  "\ud83e\uddda\ud83c\udffd\u200d\u2642": [
+    "man_fairy_medium_skin_tone"
+  ],
+  "\ud83e\uddda\ud83c\udffd\u200d\u2642\ufe0f": [
+    "man_fairy_medium_skin_tone"
+  ],
+  "\ud83e\uddda\ud83c\udffe": [
+    "fairy_medium-dark_skin_tone"
+  ],
+  "\ud83e\uddda\ud83c\udffe\u200d\u2640": [
+    "woman_fairy_medium-dark_skin_tone"
+  ],
+  "\ud83e\uddda\ud83c\udffe\u200d\u2640\ufe0f": [
+    "woman_fairy_medium-dark_skin_tone"
+  ],
+  "\ud83e\uddda\ud83c\udffe\u200d\u2642": [
+    "man_fairy_medium-dark_skin_tone"
+  ],
+  "\ud83e\uddda\ud83c\udffe\u200d\u2642\ufe0f": [
+    "man_fairy_medium-dark_skin_tone"
+  ],
+  "\ud83e\uddda\ud83c\udfff": [
+    "fairy_dark_skin_tone"
+  ],
+  "\ud83e\uddda\ud83c\udfff\u200d\u2640": [
+    "woman_fairy_dark_skin_tone"
+  ],
+  "\ud83e\uddda\ud83c\udfff\u200d\u2640\ufe0f": [
+    "woman_fairy_dark_skin_tone"
+  ],
+  "\ud83e\uddda\ud83c\udfff\u200d\u2642": [
+    "man_fairy_dark_skin_tone"
+  ],
+  "\ud83e\uddda\ud83c\udfff\u200d\u2642\ufe0f": [
+    "man_fairy_dark_skin_tone"
+  ],
+  "\ud83e\udddb": [
+    "vampire"
+  ],
+  "\ud83e\udddb\u200d\u2640": [
+    "woman_vampire",
+    "vampire_woman"
+  ],
+  "\ud83e\udddb\u200d\u2640\ufe0f": [
+    "woman_vampire",
+    "vampire_woman"
+  ],
+  "\ud83e\udddb\u200d\u2642": [
+    "man_vampire",
+    "vampire_man"
+  ],
+  "\ud83e\udddb\u200d\u2642\ufe0f": [
+    "man_vampire",
+    "vampire_man"
+  ],
+  "\ud83e\udddb\ud83c\udffb": [
+    "vampire_light_skin_tone"
+  ],
+  "\ud83e\udddb\ud83c\udffb\u200d\u2640": [
+    "woman_vampire_light_skin_tone"
+  ],
+  "\ud83e\udddb\ud83c\udffb\u200d\u2640\ufe0f": [
+    "woman_vampire_light_skin_tone"
+  ],
+  "\ud83e\udddb\ud83c\udffb\u200d\u2642": [
+    "man_vampire_light_skin_tone"
+  ],
+  "\ud83e\udddb\ud83c\udffb\u200d\u2642\ufe0f": [
+    "man_vampire_light_skin_tone"
+  ],
+  "\ud83e\udddb\ud83c\udffc": [
+    "vampire_medium-light_skin_tone"
+  ],
+  "\ud83e\udddb\ud83c\udffc\u200d\u2640": [
+    "woman_vampire_medium-light_skin_tone"
+  ],
+  "\ud83e\udddb\ud83c\udffc\u200d\u2640\ufe0f": [
+    "woman_vampire_medium-light_skin_tone"
+  ],
+  "\ud83e\udddb\ud83c\udffc\u200d\u2642": [
+    "man_vampire_medium-light_skin_tone"
+  ],
+  "\ud83e\udddb\ud83c\udffc\u200d\u2642\ufe0f": [
+    "man_vampire_medium-light_skin_tone"
+  ],
+  "\ud83e\udddb\ud83c\udffd": [
+    "vampire_medium_skin_tone"
+  ],
+  "\ud83e\udddb\ud83c\udffd\u200d\u2640": [
+    "woman_vampire_medium_skin_tone"
+  ],
+  "\ud83e\udddb\ud83c\udffd\u200d\u2640\ufe0f": [
+    "woman_vampire_medium_skin_tone"
+  ],
+  "\ud83e\udddb\ud83c\udffd\u200d\u2642": [
+    "man_vampire_medium_skin_tone"
+  ],
+  "\ud83e\udddb\ud83c\udffd\u200d\u2642\ufe0f": [
+    "man_vampire_medium_skin_tone"
+  ],
+  "\ud83e\udddb\ud83c\udffe": [
+    "vampire_medium-dark_skin_tone"
+  ],
+  "\ud83e\udddb\ud83c\udffe\u200d\u2640": [
+    "woman_vampire_medium-dark_skin_tone"
+  ],
+  "\ud83e\udddb\ud83c\udffe\u200d\u2640\ufe0f": [
+    "woman_vampire_medium-dark_skin_tone"
+  ],
+  "\ud83e\udddb\ud83c\udffe\u200d\u2642": [
+    "man_vampire_medium-dark_skin_tone"
+  ],
+  "\ud83e\udddb\ud83c\udffe\u200d\u2642\ufe0f": [
+    "man_vampire_medium-dark_skin_tone"
+  ],
+  "\ud83e\udddb\ud83c\udfff": [
+    "vampire_dark_skin_tone"
+  ],
+  "\ud83e\udddb\ud83c\udfff\u200d\u2640": [
+    "woman_vampire_dark_skin_tone"
+  ],
+  "\ud83e\udddb\ud83c\udfff\u200d\u2640\ufe0f": [
+    "woman_vampire_dark_skin_tone"
+  ],
+  "\ud83e\udddb\ud83c\udfff\u200d\u2642": [
+    "man_vampire_dark_skin_tone"
+  ],
+  "\ud83e\udddb\ud83c\udfff\u200d\u2642\ufe0f": [
+    "man_vampire_dark_skin_tone"
+  ],
+  "\ud83e\udddc": [
+    "merperson"
+  ],
+  "\ud83e\udddc\u200d\u2640": [
+    "mermaid"
+  ],
+  "\ud83e\udddc\u200d\u2640\ufe0f": [
+    "mermaid"
+  ],
+  "\ud83e\udddc\u200d\u2642": [
+    "merman"
+  ],
+  "\ud83e\udddc\u200d\u2642\ufe0f": [
+    "merman"
+  ],
+  "\ud83e\udddc\ud83c\udffb": [
+    "merperson_light_skin_tone"
+  ],
+  "\ud83e\udddc\ud83c\udffb\u200d\u2640": [
+    "mermaid_light_skin_tone"
+  ],
+  "\ud83e\udddc\ud83c\udffb\u200d\u2640\ufe0f": [
+    "mermaid_light_skin_tone"
+  ],
+  "\ud83e\udddc\ud83c\udffb\u200d\u2642": [
+    "merman_light_skin_tone"
+  ],
+  "\ud83e\udddc\ud83c\udffb\u200d\u2642\ufe0f": [
+    "merman_light_skin_tone"
+  ],
+  "\ud83e\udddc\ud83c\udffc": [
+    "merperson_medium-light_skin_tone"
+  ],
+  "\ud83e\udddc\ud83c\udffc\u200d\u2640": [
+    "mermaid_medium-light_skin_tone"
+  ],
+  "\ud83e\udddc\ud83c\udffc\u200d\u2640\ufe0f": [
+    "mermaid_medium-light_skin_tone"
+  ],
+  "\ud83e\udddc\ud83c\udffc\u200d\u2642": [
+    "merman_medium-light_skin_tone"
+  ],
+  "\ud83e\udddc\ud83c\udffc\u200d\u2642\ufe0f": [
+    "merman_medium-light_skin_tone"
+  ],
+  "\ud83e\udddc\ud83c\udffd": [
+    "merperson_medium_skin_tone"
+  ],
+  "\ud83e\udddc\ud83c\udffd\u200d\u2640": [
+    "mermaid_medium_skin_tone"
+  ],
+  "\ud83e\udddc\ud83c\udffd\u200d\u2640\ufe0f": [
+    "mermaid_medium_skin_tone"
+  ],
+  "\ud83e\udddc\ud83c\udffd\u200d\u2642": [
+    "merman_medium_skin_tone"
+  ],
+  "\ud83e\udddc\ud83c\udffd\u200d\u2642\ufe0f": [
+    "merman_medium_skin_tone"
+  ],
+  "\ud83e\udddc\ud83c\udffe": [
+    "merperson_medium-dark_skin_tone"
+  ],
+  "\ud83e\udddc\ud83c\udffe\u200d\u2640": [
+    "mermaid_medium-dark_skin_tone"
+  ],
+  "\ud83e\udddc\ud83c\udffe\u200d\u2640\ufe0f": [
+    "mermaid_medium-dark_skin_tone"
+  ],
+  "\ud83e\udddc\ud83c\udffe\u200d\u2642": [
+    "merman_medium-dark_skin_tone"
+  ],
+  "\ud83e\udddc\ud83c\udffe\u200d\u2642\ufe0f": [
+    "merman_medium-dark_skin_tone"
+  ],
+  "\ud83e\udddc\ud83c\udfff": [
+    "merperson_dark_skin_tone"
+  ],
+  "\ud83e\udddc\ud83c\udfff\u200d\u2640": [
+    "mermaid_dark_skin_tone"
+  ],
+  "\ud83e\udddc\ud83c\udfff\u200d\u2640\ufe0f": [
+    "mermaid_dark_skin_tone"
+  ],
+  "\ud83e\udddc\ud83c\udfff\u200d\u2642": [
+    "merman_dark_skin_tone"
+  ],
+  "\ud83e\udddc\ud83c\udfff\u200d\u2642\ufe0f": [
+    "merman_dark_skin_tone"
+  ],
+  "\ud83e\udddd": [
+    "elf"
+  ],
+  "\ud83e\udddd\u200d\u2640": [
+    "woman_elf",
+    "elf_woman"
+  ],
+  "\ud83e\udddd\u200d\u2640\ufe0f": [
+    "woman_elf",
+    "elf_woman"
+  ],
+  "\ud83e\udddd\u200d\u2642": [
+    "man_elf",
+    "elf_man"
+  ],
+  "\ud83e\udddd\u200d\u2642\ufe0f": [
+    "man_elf",
+    "elf_man"
+  ],
+  "\ud83e\udddd\ud83c\udffb": [
+    "elf_light_skin_tone"
+  ],
+  "\ud83e\udddd\ud83c\udffb\u200d\u2640": [
+    "woman_elf_light_skin_tone"
+  ],
+  "\ud83e\udddd\ud83c\udffb\u200d\u2640\ufe0f": [
+    "woman_elf_light_skin_tone"
+  ],
+  "\ud83e\udddd\ud83c\udffb\u200d\u2642": [
+    "man_elf_light_skin_tone"
+  ],
+  "\ud83e\udddd\ud83c\udffb\u200d\u2642\ufe0f": [
+    "man_elf_light_skin_tone"
+  ],
+  "\ud83e\udddd\ud83c\udffc": [
+    "elf_medium-light_skin_tone"
+  ],
+  "\ud83e\udddd\ud83c\udffc\u200d\u2640": [
+    "woman_elf_medium-light_skin_tone"
+  ],
+  "\ud83e\udddd\ud83c\udffc\u200d\u2640\ufe0f": [
+    "woman_elf_medium-light_skin_tone"
+  ],
+  "\ud83e\udddd\ud83c\udffc\u200d\u2642": [
+    "man_elf_medium-light_skin_tone"
+  ],
+  "\ud83e\udddd\ud83c\udffc\u200d\u2642\ufe0f": [
+    "man_elf_medium-light_skin_tone"
+  ],
+  "\ud83e\udddd\ud83c\udffd": [
+    "elf_medium_skin_tone"
+  ],
+  "\ud83e\udddd\ud83c\udffd\u200d\u2640": [
+    "woman_elf_medium_skin_tone"
+  ],
+  "\ud83e\udddd\ud83c\udffd\u200d\u2640\ufe0f": [
+    "woman_elf_medium_skin_tone"
+  ],
+  "\ud83e\udddd\ud83c\udffd\u200d\u2642": [
+    "man_elf_medium_skin_tone"
+  ],
+  "\ud83e\udddd\ud83c\udffd\u200d\u2642\ufe0f": [
+    "man_elf_medium_skin_tone"
+  ],
+  "\ud83e\udddd\ud83c\udffe": [
+    "elf_medium-dark_skin_tone"
+  ],
+  "\ud83e\udddd\ud83c\udffe\u200d\u2640": [
+    "woman_elf_medium-dark_skin_tone"
+  ],
+  "\ud83e\udddd\ud83c\udffe\u200d\u2640\ufe0f": [
+    "woman_elf_medium-dark_skin_tone"
+  ],
+  "\ud83e\udddd\ud83c\udffe\u200d\u2642": [
+    "man_elf_medium-dark_skin_tone"
+  ],
+  "\ud83e\udddd\ud83c\udffe\u200d\u2642\ufe0f": [
+    "man_elf_medium-dark_skin_tone"
+  ],
+  "\ud83e\udddd\ud83c\udfff": [
+    "elf_dark_skin_tone"
+  ],
+  "\ud83e\udddd\ud83c\udfff\u200d\u2640": [
+    "woman_elf_dark_skin_tone"
+  ],
+  "\ud83e\udddd\ud83c\udfff\u200d\u2640\ufe0f": [
+    "woman_elf_dark_skin_tone"
+  ],
+  "\ud83e\udddd\ud83c\udfff\u200d\u2642": [
+    "man_elf_dark_skin_tone"
+  ],
+  "\ud83e\udddd\ud83c\udfff\u200d\u2642\ufe0f": [
+    "man_elf_dark_skin_tone"
+  ],
+  "\ud83e\uddde": [
+    "genie"
+  ],
+  "\ud83e\uddde\u200d\u2640": [
+    "woman_genie",
+    "genie_woman"
+  ],
+  "\ud83e\uddde\u200d\u2640\ufe0f": [
+    "woman_genie",
+    "genie_woman"
+  ],
+  "\ud83e\uddde\u200d\u2642": [
+    "man_genie",
+    "genie_man"
+  ],
+  "\ud83e\uddde\u200d\u2642\ufe0f": [
+    "man_genie",
+    "genie_man"
+  ],
+  "\ud83e\udddf": [
+    "zombie"
+  ],
+  "\ud83e\udddf\u200d\u2640": [
+    "woman_zombie",
+    "zombie_woman"
+  ],
+  "\ud83e\udddf\u200d\u2640\ufe0f": [
+    "woman_zombie",
+    "zombie_woman"
+  ],
+  "\ud83e\udddf\u200d\u2642": [
+    "man_zombie",
+    "zombie_man"
+  ],
+  "\ud83e\udddf\u200d\u2642\ufe0f": [
+    "man_zombie",
+    "zombie_man"
+  ],
+  "\ud83e\udde0": [
+    "brain"
+  ],
+  "\ud83e\udde1": [
+    "orange_heart"
+  ],
+  "\ud83e\udde2": [
+    "billed_cap"
+  ],
+  "\ud83e\udde3": [
+    "scarf"
+  ],
+  "\ud83e\udde4": [
+    "gloves"
+  ],
+  "\ud83e\udde5": [
+    "coat"
+  ],
+  "\ud83e\udde6": [
+    "socks"
+  ],
+  "\ud83e\udde7": [
+    "red_envelope"
+  ],
+  "\ud83e\udde8": [
+    "firecracker"
+  ],
+  "\ud83e\udde9": [
+    "puzzle_piece",
+    "jigsaw"
+  ],
+  "\ud83e\uddea": [
+    "test_tube"
+  ],
+  "\ud83e\uddeb": [
+    "petri_dish"
+  ],
+  "\ud83e\uddec": [
+    "dna"
+  ],
+  "\ud83e\udded": [
+    "compass"
+  ],
+  "\ud83e\uddee": [
+    "abacus"
+  ],
+  "\ud83e\uddef": [
+    "fire_extinguisher"
+  ],
+  "\ud83e\uddf0": [
+    "toolbox"
+  ],
+  "\ud83e\uddf1": [
+    "brick",
+    "bricks"
+  ],
+  "\ud83e\uddf2": [
+    "magnet"
+  ],
+  "\ud83e\uddf3": [
+    "luggage"
+  ],
+  "\ud83e\uddf4": [
+    "lotion_bottle"
+  ],
+  "\ud83e\uddf5": [
+    "thread"
+  ],
+  "\ud83e\uddf6": [
+    "yarn"
+  ],
+  "\ud83e\uddf7": [
+    "safety_pin"
+  ],
+  "\ud83e\uddf8": [
+    "teddy_bear"
+  ],
+  "\ud83e\uddf9": [
+    "broom"
+  ],
+  "\ud83e\uddfa": [
+    "basket"
+  ],
+  "\ud83e\uddfb": [
+    "roll_of_paper"
+  ],
+  "\ud83e\uddfc": [
+    "soap"
+  ],
+  "\ud83e\uddfd": [
+    "sponge"
+  ],
+  "\ud83e\uddfe": [
+    "receipt"
+  ],
+  "\ud83e\uddff": [
+    "nazar_amulet"
+  ],
+  "\ud83e\ude70": [
+    "ballet_shoes"
+  ],
+  "\ud83e\ude71": [
+    "one-piece_swimsuit",
+    "one_piece_swimsuit"
+  ],
+  "\ud83e\ude72": [
+    "briefs",
+    "swim_brief"
+  ],
+  "\ud83e\ude73": [
+    "shorts"
+  ],
+  "\ud83e\ude74": [
+    "thong_sandal"
+  ],
+  "\ud83e\ude75": [
+    "light_blue_heart"
+  ],
+  "\ud83e\ude76": [
+    "grey_heart"
+  ],
+  "\ud83e\ude77": [
+    "pink_heart"
+  ],
+  "\ud83e\ude78": [
+    "drop_of_blood"
+  ],
+  "\ud83e\ude79": [
+    "adhesive_bandage"
+  ],
+  "\ud83e\ude7a": [
+    "stethoscope"
+  ],
+  "\ud83e\ude7b": [
+    "x-ray",
+    "x_ray"
+  ],
+  "\ud83e\ude7c": [
+    "crutch"
+  ],
+  "\ud83e\ude80": [
+    "yo-yo",
+    "yo_yo"
+  ],
+  "\ud83e\ude81": [
+    "kite"
+  ],
+  "\ud83e\ude82": [
+    "parachute"
+  ],
+  "\ud83e\ude83": [
+    "boomerang"
+  ],
+  "\ud83e\ude84": [
+    "magic_wand"
+  ],
+  "\ud83e\ude85": [
+    "pi\u00f1ata",
+    "pinata"
+  ],
+  "\ud83e\ude86": [
+    "nesting_dolls"
+  ],
+  "\ud83e\ude87": [
+    "maracas"
+  ],
+  "\ud83e\ude88": [
+    "flute"
+  ],
+  "\ud83e\ude90": [
+    "ringed_planet"
+  ],
+  "\ud83e\ude91": [
+    "chair"
+  ],
+  "\ud83e\ude92": [
+    "razor"
+  ],
+  "\ud83e\ude93": [
+    "axe"
+  ],
+  "\ud83e\ude94": [
+    "diya_lamp"
+  ],
+  "\ud83e\ude95": [
+    "banjo"
+  ],
+  "\ud83e\ude96": [
+    "military_helmet"
+  ],
+  "\ud83e\ude97": [
+    "accordion"
+  ],
+  "\ud83e\ude98": [
+    "long_drum"
+  ],
+  "\ud83e\ude99": [
+    "coin"
+  ],
+  "\ud83e\ude9a": [
+    "carpentry_saw"
+  ],
+  "\ud83e\ude9b": [
+    "screwdriver"
+  ],
+  "\ud83e\ude9c": [
+    "ladder"
+  ],
+  "\ud83e\ude9d": [
+    "hook"
+  ],
+  "\ud83e\ude9e": [
+    "mirror"
+  ],
+  "\ud83e\ude9f": [
+    "window"
+  ],
+  "\ud83e\udea0": [
+    "plunger"
+  ],
+  "\ud83e\udea1": [
+    "sewing_needle"
+  ],
+  "\ud83e\udea2": [
+    "knot"
+  ],
+  "\ud83e\udea3": [
+    "bucket"
+  ],
+  "\ud83e\udea4": [
+    "mouse_trap"
+  ],
+  "\ud83e\udea5": [
+    "toothbrush"
+  ],
+  "\ud83e\udea6": [
+    "headstone"
+  ],
+  "\ud83e\udea7": [
+    "placard"
+  ],
+  "\ud83e\udea8": [
+    "rock"
+  ],
+  "\ud83e\udea9": [
+    "mirror_ball"
+  ],
+  "\ud83e\udeaa": [
+    "identification_card"
+  ],
+  "\ud83e\udeab": [
+    "low_battery"
+  ],
+  "\ud83e\udeac": [
+    "hamsa"
+  ],
+  "\ud83e\udead": [
+    "folding_hand_fan"
+  ],
+  "\ud83e\udeae": [
+    "hair_pick"
+  ],
+  "\ud83e\udeaf": [
+    "khanda"
+  ],
+  "\ud83e\udeb0": [
+    "fly"
+  ],
+  "\ud83e\udeb1": [
+    "worm"
+  ],
+  "\ud83e\udeb2": [
+    "beetle"
+  ],
+  "\ud83e\udeb3": [
+    "cockroach"
+  ],
+  "\ud83e\udeb4": [
+    "potted_plant"
+  ],
+  "\ud83e\udeb5": [
+    "wood"
+  ],
+  "\ud83e\udeb6": [
+    "feather"
+  ],
+  "\ud83e\udeb7": [
+    "lotus"
+  ],
+  "\ud83e\udeb8": [
+    "coral"
+  ],
+  "\ud83e\udeb9": [
+    "empty_nest"
+  ],
+  "\ud83e\udeba": [
+    "nest_with_eggs"
+  ],
+  "\ud83e\udebb": [
+    "hyacinth"
+  ],
+  "\ud83e\udebc": [
+    "jellyfish"
+  ],
+  "\ud83e\udebd": [
+    "wing"
+  ],
+  "\ud83e\udebf": [
+    "goose"
+  ],
+  "\ud83e\udec0": [
+    "anatomical_heart"
+  ],
+  "\ud83e\udec1": [
+    "lungs"
+  ],
+  "\ud83e\udec2": [
+    "people_hugging"
+  ],
+  "\ud83e\udec3": [
+    "pregnant_man"
+  ],
+  "\ud83e\udec3\ud83c\udffb": [
+    "pregnant_man_light_skin_tone"
+  ],
+  "\ud83e\udec3\ud83c\udffc": [
+    "pregnant_man_medium-light_skin_tone"
+  ],
+  "\ud83e\udec3\ud83c\udffd": [
+    "pregnant_man_medium_skin_tone"
+  ],
+  "\ud83e\udec3\ud83c\udffe": [
+    "pregnant_man_medium-dark_skin_tone"
+  ],
+  "\ud83e\udec3\ud83c\udfff": [
+    "pregnant_man_dark_skin_tone"
+  ],
+  "\ud83e\udec4": [
+    "pregnant_person"
+  ],
+  "\ud83e\udec4\ud83c\udffb": [
+    "pregnant_person_light_skin_tone"
+  ],
+  "\ud83e\udec4\ud83c\udffc": [
+    "pregnant_person_medium-light_skin_tone"
+  ],
+  "\ud83e\udec4\ud83c\udffd": [
+    "pregnant_person_medium_skin_tone"
+  ],
+  "\ud83e\udec4\ud83c\udffe": [
+    "pregnant_person_medium-dark_skin_tone"
+  ],
+  "\ud83e\udec4\ud83c\udfff": [
+    "pregnant_person_dark_skin_tone"
+  ],
+  "\ud83e\udec5": [
+    "person_with_crown"
+  ],
+  "\ud83e\udec5\ud83c\udffb": [
+    "person_with_crown_light_skin_tone"
+  ],
+  "\ud83e\udec5\ud83c\udffc": [
+    "person_with_crown_medium-light_skin_tone"
+  ],
+  "\ud83e\udec5\ud83c\udffd": [
+    "person_with_crown_medium_skin_tone"
+  ],
+  "\ud83e\udec5\ud83c\udffe": [
+    "person_with_crown_medium-dark_skin_tone"
+  ],
+  "\ud83e\udec5\ud83c\udfff": [
+    "person_with_crown_dark_skin_tone"
+  ],
+  "\ud83e\udece": [
+    "moose"
+  ],
+  "\ud83e\udecf": [
+    "donkey"
+  ],
+  "\ud83e\uded0": [
+    "blueberries"
+  ],
+  "\ud83e\uded1": [
+    "bell_pepper"
+  ],
+  "\ud83e\uded2": [
+    "olive"
+  ],
+  "\ud83e\uded3": [
+    "flatbread"
+  ],
+  "\ud83e\uded4": [
+    "tamale"
+  ],
+  "\ud83e\uded5": [
+    "fondue"
+  ],
+  "\ud83e\uded6": [
+    "teapot"
+  ],
+  "\ud83e\uded7": [
+    "pouring_liquid"
+  ],
+  "\ud83e\uded8": [
+    "beans"
+  ],
+  "\ud83e\uded9": [
+    "jar"
+  ],
+  "\ud83e\udeda": [
+    "ginger_root"
+  ],
+  "\ud83e\udedb": [
+    "pea_pod"
+  ],
+  "\ud83e\udee0": [
+    "melting_face"
+  ],
+  "\ud83e\udee1": [
+    "saluting_face"
+  ],
+  "\ud83e\udee2": [
+    "face_with_open_eyes_and_hand_over_mouth"
+  ],
+  "\ud83e\udee3": [
+    "face_with_peeking_eye"
+  ],
+  "\ud83e\udee4": [
+    "face_with_diagonal_mouth"
+  ],
+  "\ud83e\udee5": [
+    "dotted_line_face"
+  ],
+  "\ud83e\udee6": [
+    "biting_lip"
+  ],
+  "\ud83e\udee7": [
+    "bubbles"
+  ],
+  "\ud83e\udee8": [
+    "shaking_face"
+  ],
+  "\ud83e\udef0": [
+    "hand_with_index_finger_and_thumb_crossed"
+  ],
+  "\ud83e\udef0\ud83c\udffb": [
+    "hand_with_index_finger_and_thumb_crossed_light_skin_tone"
+  ],
+  "\ud83e\udef0\ud83c\udffc": [
+    "hand_with_index_finger_and_thumb_crossed_medium-light_skin_tone"
+  ],
+  "\ud83e\udef0\ud83c\udffd": [
+    "hand_with_index_finger_and_thumb_crossed_medium_skin_tone"
+  ],
+  "\ud83e\udef0\ud83c\udffe": [
+    "hand_with_index_finger_and_thumb_crossed_medium-dark_skin_tone"
+  ],
+  "\ud83e\udef0\ud83c\udfff": [
+    "hand_with_index_finger_and_thumb_crossed_dark_skin_tone"
+  ],
+  "\ud83e\udef1": [
+    "rightwards_hand"
+  ],
+  "\ud83e\udef1\ud83c\udffb": [
+    "rightwards_hand_light_skin_tone"
+  ],
+  "\ud83e\udef1\ud83c\udffb\u200d\ud83e\udef2\ud83c\udffc": [
+    "handshake_light_skin_tone_medium-light_skin_tone"
+  ],
+  "\ud83e\udef1\ud83c\udffb\u200d\ud83e\udef2\ud83c\udffd": [
+    "handshake_light_skin_tone_medium_skin_tone"
+  ],
+  "\ud83e\udef1\ud83c\udffb\u200d\ud83e\udef2\ud83c\udffe": [
+    "handshake_light_skin_tone_medium-dark_skin_tone"
+  ],
+  "\ud83e\udef1\ud83c\udffb\u200d\ud83e\udef2\ud83c\udfff": [
+    "handshake_light_skin_tone_dark_skin_tone"
+  ],
+  "\ud83e\udef1\ud83c\udffc": [
+    "rightwards_hand_medium-light_skin_tone"
+  ],
+  "\ud83e\udef1\ud83c\udffc\u200d\ud83e\udef2\ud83c\udffb": [
+    "handshake_medium-light_skin_tone_light_skin_tone"
+  ],
+  "\ud83e\udef1\ud83c\udffc\u200d\ud83e\udef2\ud83c\udffd": [
+    "handshake_medium-light_skin_tone_medium_skin_tone"
+  ],
+  "\ud83e\udef1\ud83c\udffc\u200d\ud83e\udef2\ud83c\udffe": [
+    "handshake_medium-light_skin_tone_medium-dark_skin_tone"
+  ],
+  "\ud83e\udef1\ud83c\udffc\u200d\ud83e\udef2\ud83c\udfff": [
+    "handshake_medium-light_skin_tone_dark_skin_tone"
+  ],
+  "\ud83e\udef1\ud83c\udffd": [
+    "rightwards_hand_medium_skin_tone"
+  ],
+  "\ud83e\udef1\ud83c\udffd\u200d\ud83e\udef2\ud83c\udffb": [
+    "handshake_medium_skin_tone_light_skin_tone"
+  ],
+  "\ud83e\udef1\ud83c\udffd\u200d\ud83e\udef2\ud83c\udffc": [
+    "handshake_medium_skin_tone_medium-light_skin_tone"
+  ],
+  "\ud83e\udef1\ud83c\udffd\u200d\ud83e\udef2\ud83c\udffe": [
+    "handshake_medium_skin_tone_medium-dark_skin_tone"
+  ],
+  "\ud83e\udef1\ud83c\udffd\u200d\ud83e\udef2\ud83c\udfff": [
+    "handshake_medium_skin_tone_dark_skin_tone"
+  ],
+  "\ud83e\udef1\ud83c\udffe": [
+    "rightwards_hand_medium-dark_skin_tone"
+  ],
+  "\ud83e\udef1\ud83c\udffe\u200d\ud83e\udef2\ud83c\udffb": [
+    "handshake_medium-dark_skin_tone_light_skin_tone"
+  ],
+  "\ud83e\udef1\ud83c\udffe\u200d\ud83e\udef2\ud83c\udffc": [
+    "handshake_medium-dark_skin_tone_medium-light_skin_tone"
+  ],
+  "\ud83e\udef1\ud83c\udffe\u200d\ud83e\udef2\ud83c\udffd": [
+    "handshake_medium-dark_skin_tone_medium_skin_tone"
+  ],
+  "\ud83e\udef1\ud83c\udffe\u200d\ud83e\udef2\ud83c\udfff": [
+    "handshake_medium-dark_skin_tone_dark_skin_tone"
+  ],
+  "\ud83e\udef1\ud83c\udfff": [
+    "rightwards_hand_dark_skin_tone"
+  ],
+  "\ud83e\udef1\ud83c\udfff\u200d\ud83e\udef2\ud83c\udffb": [
+    "handshake_dark_skin_tone_light_skin_tone"
+  ],
+  "\ud83e\udef1\ud83c\udfff\u200d\ud83e\udef2\ud83c\udffc": [
+    "handshake_dark_skin_tone_medium-light_skin_tone"
+  ],
+  "\ud83e\udef1\ud83c\udfff\u200d\ud83e\udef2\ud83c\udffd": [
+    "handshake_dark_skin_tone_medium_skin_tone"
+  ],
+  "\ud83e\udef1\ud83c\udfff\u200d\ud83e\udef2\ud83c\udffe": [
+    "handshake_dark_skin_tone_medium-dark_skin_tone"
+  ],
+  "\ud83e\udef2": [
+    "leftwards_hand"
+  ],
+  "\ud83e\udef2\ud83c\udffb": [
+    "leftwards_hand_light_skin_tone"
+  ],
+  "\ud83e\udef2\ud83c\udffc": [
+    "leftwards_hand_medium-light_skin_tone"
+  ],
+  "\ud83e\udef2\ud83c\udffd": [
+    "leftwards_hand_medium_skin_tone"
+  ],
+  "\ud83e\udef2\ud83c\udffe": [
+    "leftwards_hand_medium-dark_skin_tone"
+  ],
+  "\ud83e\udef2\ud83c\udfff": [
+    "leftwards_hand_dark_skin_tone"
+  ],
+  "\ud83e\udef3": [
+    "palm_down_hand"
+  ],
+  "\ud83e\udef3\ud83c\udffb": [
+    "palm_down_hand_light_skin_tone"
+  ],
+  "\ud83e\udef3\ud83c\udffc": [
+    "palm_down_hand_medium-light_skin_tone"
+  ],
+  "\ud83e\udef3\ud83c\udffd": [
+    "palm_down_hand_medium_skin_tone"
+  ],
+  "\ud83e\udef3\ud83c\udffe": [
+    "palm_down_hand_medium-dark_skin_tone"
+  ],
+  "\ud83e\udef3\ud83c\udfff": [
+    "palm_down_hand_dark_skin_tone"
+  ],
+  "\ud83e\udef4": [
+    "palm_up_hand"
+  ],
+  "\ud83e\udef4\ud83c\udffb": [
+    "palm_up_hand_light_skin_tone"
+  ],
+  "\ud83e\udef4\ud83c\udffc": [
+    "palm_up_hand_medium-light_skin_tone"
+  ],
+  "\ud83e\udef4\ud83c\udffd": [
+    "palm_up_hand_medium_skin_tone"
+  ],
+  "\ud83e\udef4\ud83c\udffe": [
+    "palm_up_hand_medium-dark_skin_tone"
+  ],
+  "\ud83e\udef4\ud83c\udfff": [
+    "palm_up_hand_dark_skin_tone"
+  ],
+  "\ud83e\udef5": [
+    "index_pointing_at_the_viewer"
+  ],
+  "\ud83e\udef5\ud83c\udffb": [
+    "index_pointing_at_the_viewer_light_skin_tone"
+  ],
+  "\ud83e\udef5\ud83c\udffc": [
+    "index_pointing_at_the_viewer_medium-light_skin_tone"
+  ],
+  "\ud83e\udef5\ud83c\udffd": [
+    "index_pointing_at_the_viewer_medium_skin_tone"
+  ],
+  "\ud83e\udef5\ud83c\udffe": [
+    "index_pointing_at_the_viewer_medium-dark_skin_tone"
+  ],
+  "\ud83e\udef5\ud83c\udfff": [
+    "index_pointing_at_the_viewer_dark_skin_tone"
+  ],
+  "\ud83e\udef6": [
+    "heart_hands"
+  ],
+  "\ud83e\udef6\ud83c\udffb": [
+    "heart_hands_light_skin_tone"
+  ],
+  "\ud83e\udef6\ud83c\udffc": [
+    "heart_hands_medium-light_skin_tone"
+  ],
+  "\ud83e\udef6\ud83c\udffd": [
+    "heart_hands_medium_skin_tone"
+  ],
+  "\ud83e\udef6\ud83c\udffe": [
+    "heart_hands_medium-dark_skin_tone"
+  ],
+  "\ud83e\udef6\ud83c\udfff": [
+    "heart_hands_dark_skin_tone"
+  ],
+  "\ud83e\udef7": [
+    "leftwards_pushing_hand"
+  ],
+  "\ud83e\udef7\ud83c\udffb": [
+    "leftwards_pushing_hand_light_skin_tone"
+  ],
+  "\ud83e\udef7\ud83c\udffc": [
+    "leftwards_pushing_hand_medium-light_skin_tone"
+  ],
+  "\ud83e\udef7\ud83c\udffd": [
+    "leftwards_pushing_hand_medium_skin_tone"
+  ],
+  "\ud83e\udef7\ud83c\udffe": [
+    "leftwards_pushing_hand_medium-dark_skin_tone"
+  ],
+  "\ud83e\udef7\ud83c\udfff": [
+    "leftwards_pushing_hand_dark_skin_tone"
+  ],
+  "\ud83e\udef8": [
+    "rightwards_pushing_hand"
+  ],
+  "\ud83e\udef8\ud83c\udffb": [
+    "rightwards_pushing_hand_light_skin_tone"
+  ],
+  "\ud83e\udef8\ud83c\udffc": [
+    "rightwards_pushing_hand_medium-light_skin_tone"
+  ],
+  "\ud83e\udef8\ud83c\udffd": [
+    "rightwards_pushing_hand_medium_skin_tone"
+  ],
+  "\ud83e\udef8\ud83c\udffe": [
+    "rightwards_pushing_hand_medium-dark_skin_tone"
+  ],
+  "\ud83e\udef8\ud83c\udfff": [
+    "rightwards_pushing_hand_dark_skin_tone"
+  ]
 }

--- a/addons/emojis-for-godot/emojis/gen_json.py
+++ b/addons/emojis-for-godot/emojis/gen_json.py
@@ -7,12 +7,10 @@ and apply as much formatting as possible so the codes can be dropped into the
 emoji registry file.
 """
 
-import sys
-import os
+import sys, os
+import re, bs4
 import unicodedata
-import re
 import requests
-import bs4
 import xml.etree.ElementTree as ET
 import logging
 import emoji as emoji_pkg
@@ -455,11 +453,15 @@ if __name__ == "__main__":
 		if any("flag_for_" in a for a in aliases):
 			# Put the :flag_for_COUNTRY: alias as the first entry so that it gets picked by demojize()
 			# This ensures compatibility because in the past there was only the :flag_for_COUNTRY: alias
-			aliases = [a for a in aliases if "flag_for_" in a] + [a for a in aliases if "flag_for_" not in a]
+			aliases = [a for a in aliases if "flag_for_" in a]
+			aliases += [a for a in aliases if "flag_for_" not in a]
 
-		# Print dict of dicts
-		alias = ''
-		emojis_data[emj] = v["en"].lower()
+		# emoji to dict
+		emojis_data[emj] = [v["en"].lower()]
+		
+		for a in aliases:
+			emojis_data[emj].append(a)
+	
 		if v["status"] == "fully_qualified":
 			f += 1
 		elif v["status"] == "component":

--- a/addons/emojis-for-godot/emojis/requirements.txt
+++ b/addons/emojis-for-godot/emojis/requirements.txt
@@ -1,0 +1,3 @@
+emoji>=2.8.0
+requests>=2.31.0
+beautifulsoup4>=4.12.2

--- a/project.godot
+++ b/project.godot
@@ -12,8 +12,9 @@ config_version=5
 
 config/name="Emojis For Godot"
 config/description="No Description"
+config/tags=PackedStringArray("addon", "rakugo")
 run/main_scene="res://addons/emojis-for-godot/examples/Examples.tscn"
-config/features=PackedStringArray("4.1")
+config/features=PackedStringArray("4.2")
 config/icon="res://addons/emojis-for-godot/icon.png"
 
 [autoload]


### PR DESCRIPTION
Makes Short aliases works again so you can write `:sunglasses:` to get :sunglasses:,
instead of `:face_with_sunglasses:` to get :sunglasses:.
It also make some other emojis available back again.